### PR TITLE
Build static lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ authors = [ "Robert Clipsham <robert@octarineparrot.com>" ]
 [lib]
 
 name = "pnet"
-crate_type = [ "dylib" ]
+crate_type = [ "rlib", "dylib" ]


### PR DESCRIPTION
Currently only a dylib/.so is build and it is required to set LD_LIBRARY_PATH to run examples/play around.
