### PR TITLE
Tests failed when presented with iface name longer than 6 bytes

### DIFF
--- a/src/bindings/bpf.rs
+++ b/src/bindings/bpf.rs
@@ -83,7 +83,8 @@ pub struct ifreq {
 }
 
 // See /usr/include/net/if_dl.h
-// sdl_data does not match if_dl.h, since the size of 12 is a minimum. Will be unsafe when sdl_nlen > 40.
+// sdl_data does not match if_dl.h on OS X, since the size of 12 is a minimum. Will be unsafe
+// when sdl_nlen > 40.
 #[cfg(any(target_os = "freebsd", target_os = "macos"))]
 pub struct sockaddr_dl {
     pub sdl_len: libc::c_uchar,


### PR DESCRIPTION
Since sdl_data is variable length on OS X, and sdl_rcf and sdl_route aren't used in the library it seems sensible just to merge the structs for freebsd and os x here. Not sure if 46 is the correct maximum for sdl_data, however.
