### PR TITLE
Use of `range` is no longer permitted, use `x..y` instead.

### DIFF
--- a/src/datalink/bpf.rs
+++ b/src/datalink/bpf.rs
@@ -40,7 +40,7 @@ pub fn datalink_channel(network_interface: &NetworkInterface,
     #[cfg(target_os = "macos")]
     fn get_fd() -> libc::c_int {
         // FIXME This is an arbitrary number of attempts
-        for i in range(0, 1_000is) {
+        for i in (0..1_000is) {
             let fd = unsafe {
                 let file_name = format!("/dev/bpf{}", i);
                 libc::open(CString::from_slice(file_name.as_bytes()).as_ptr(), libc::O_RDWR, 0)


### PR DESCRIPTION
libpnet doesn't work with latest rust (rustc 1.0.0-nightly (ecf8c64e1 2015-03-21) (built 2015-03-21)) due to `range` no longer being supported.

I'm getting test suite failures now (on OSX), but I believe they are unrelated to this change:

```rust
test old_packet::ethernet::ethernet_header_test ... ok
test old_packet::ipv4::ipv4_header_test ... ok
test old_packet::udp::udp_header_ipv4_test ... ok
test old_packet::ipv6::ipv6_header_test ... ok
test test::check_test_environment ... ok
test old_packet::udp::udp_header_ipv6_test ... ok
test util::mac_addr_from_str ... ok
test test::layer2 ... ok
thread '<unnamed>' panicked at 'assertion failed: `(left == right) && (right == left)` (left: `UdpHeader { source: 1234, destination: 1234, length: 12, checksum: 8668 }`, right: `UdpHeader { source: 1234, destination: 1234, length: 12, checksum: 8667 }`)', src/test.rs:150
test test::layer3_ipv4 ... ok
test test::layer4_ipv4 ... FAILED
test test::layer4_ipv6 ... ok

failures:

---- test::layer4_ipv4 stdout ----
	thread 'test::layer4_ipv4' panicked at 'child thread None panicked', /Users/rustbuild/src/rust-buildbot/slave/nightly-dist-rustc-mac/build/src/libstd/thread.rs:664



failures:
    test::layer4_ipv4

test result: FAILED. 10 passed; 1 failed; 0 ignored; 0 measured

thread '<main>' panicked at 'Some tests failed', /Users/rustbuild/src/rust-buildbot/slave/nightly-dist-rustc-mac/build/src/libtest/lib.rs:260
```