### PR TITLE
Fixing bug in `get_network_interfaces_impl` interface merging.

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -228,10 +228,15 @@ fn get_network_interfaces_impl() -> Vec<NetworkInterface> {
             None => old.mac,
             _ => new.mac
         };
-        match (&mut old.ips, &new.ips) {
-            (&mut Some(ref mut old_ips), &Some(ref new_ips)) => old_ips.push_all(new_ips.as_slice()),
-            _ => {}
-        };
+        if match (&old.ips, &new.ips) { (&None, &Some(_)) => true, _ => false } {
+            old.ips = new.ips.clone();
+        }
+        else {
+            match (&mut old.ips, &new.ips) {
+                (&mut Some(ref mut old_ips), &Some(ref new_ips)) => old_ips.push_all(new_ips.as_slice()),
+                _ => {}
+            };
+        }
         old.flags = old.flags | new.flags;
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -228,15 +228,11 @@ fn get_network_interfaces_impl() -> Vec<NetworkInterface> {
             None => old.mac,
             _ => new.mac
         };
-        if match (&old.ips, &new.ips) { (&None, &Some(_)) => true, _ => false } {
-            old.ips = new.ips.clone();
-        }
-        else {
-            match (&mut old.ips, &new.ips) {
-                (&mut Some(ref mut old_ips), &Some(ref new_ips)) => old_ips.push_all(new_ips.as_slice()),
-                _ => {}
-            };
-        }
+        match (&mut old.ips, &new.ips) {
+            (&mut Some(ref mut old_ips), &Some(ref new_ips)) => old_ips.push_all(new_ips.as_slice()),
+            (&mut ref mut old_ips @ None, &Some(ref new_ips)) => *old_ips = Some(new_ips.clone()),
+            _ => {}
+        };
         old.flags = old.flags | new.flags;
     }
 


### PR DESCRIPTION
If we found an interface, but it had no IPs, subsequent interfaces of the same name with IPs would not be merged into the interface struct.

Adds a test for non-linux platforms, following the example of the `check_test_environment` test.

@mrmonday let me know if you'd like an additional test for alternate scenarios (e.g. in which no IP addresses should be found for a given interface). Not sure exactly how I'd implement that yet, might require some refactoring of `get_network_interfaces_impl` but I could give it a shot. Also not sure how this change will fare on non-OSX platforms.

Fixes #55