### PR TITLE
Fix issue #68 "Possible payload positioning issue".

### DIFF
--- a/src/packet/ipv4.rs
+++ b/src/packet/ipv4.rs
@@ -58,7 +58,15 @@ pub fn checksum<'a>(packet: &Ipv4Packet<'a>) -> u16be {
 }
 
 fn ipv4_options_length<'a>(ipv4: &Ipv4Packet<'a>) -> usize {
-    ipv4.get_header_length() as usize - 4
+    ipv4.get_header_length() as usize - 5
+}
+
+#[test]
+fn ipv4_options_length_test() {
+    let mut packet = [0u8; 20];
+    let mut ip_header = MutableIpv4Packet::new(&mut packet[..]);
+    ip_header.set_header_length(5);
+    assert_eq!(ipv4_options_length(&ip_header.to_immutable()), 0);
 }
 
 /// Represents the IPv4 Option field


### PR DESCRIPTION
IPv4 packets were incorrectly calculating the length of the IPv4 options field,
causing the set_payload() function to insert values 1 byte out of place. This
wasn't detected by tests previously since the .set_payload() function isn't
currently tested.