### PR TITLE
Error when struct/enum isn't public

### DIFF
--- a/pnet_macros/src/decorator.rs
+++ b/pnet_macros/src/decorator.rs
@@ -213,6 +213,10 @@ fn make_packet(ecx: &mut ExtCtxt, span: Span, name: String, sd: &ast::StructDef)
 fn make_packets(ecx: &mut ExtCtxt, span: Span, item: &ast::Item) -> Option<Vec<Packet>> {
     match item.node {
         ast::ItemEnum(ref ed, ref _gs) => {
+            if item.vis != ast::Visibility::Public {
+                ecx.span_err(item.span, "#[packet] enums must be public");
+                return None;
+            }
             let mut vec = vec![];
             for ref variant in &ed.variants {
                 if let ast::StructVariantKind(ref sd) = variant.node.kind {
@@ -231,6 +235,10 @@ fn make_packets(ecx: &mut ExtCtxt, span: Span, item: &ast::Item) -> Option<Vec<P
             Some(vec)
         },
         ast::ItemStruct(ref sd, ref _gs) => {
+            if item.vis != ast::Visibility::Public {
+                ecx.span_err(item.span, "#[packet] structs must be public");
+                return None;
+            }
             let name = item.ident.as_str().to_string();
             if let Some(packet) = make_packet(ecx, span, name, sd) {
                 Some(vec![packet])

--- a/pnet_macros/tests/compile-fail/multiple_payload.rs
+++ b/pnet_macros/tests/compile-fail/multiple_payload.rs
@@ -12,7 +12,7 @@
 extern crate pnet;
 
 #[packet]
-struct PacketWithPayload {
+pub struct PacketWithPayload {
     #[length_fn = ""]
     #[payload]
     payload1: Vec<u8>,  //~ NOTE first payload defined here

--- a/pnet_macros/tests/compile-fail/must_be_pub.rs
+++ b/pnet_macros/tests/compile-fail/must_be_pub.rs
@@ -18,3 +18,4 @@ struct MustBePub { //~ ERROR #[packet] structs must be public
     payload: Vec<u8>
 }
 
+fn main() {}

--- a/pnet_macros/tests/compile-fail/variable_length_fields.rs
+++ b/pnet_macros/tests/compile-fail/variable_length_fields.rs
@@ -12,7 +12,7 @@
 extern crate pnet;
 
 #[packet]
-struct PacketWithPayload {
+pub struct PacketWithPayload {
     banana: u8,
     var_length: Vec<u8>, //~ ERROR: variable length field must have #[length_fn = ""] attribute
     #[payload]

--- a/pnet_macros/tests/compile-fail/variable_length_fields2.rs
+++ b/pnet_macros/tests/compile-fail/variable_length_fields2.rs
@@ -12,7 +12,7 @@
 extern crate pnet;
 
 #[packet]
-struct PacketWithPayload {
+pub struct PacketWithPayload {
     banana: u8,
     #[length_fn = "length_fn"]
     var_length: Vec<u8>, //~ ERROR: length_fn must be of type &PacketWithPayloadHeader -> usize


### PR DESCRIPTION
The should be an error when a struct that has an `#[packet]` attribute isn't
public. This is an implementation for the "must_be_pub" test.