### PR TITLE
Adding #[length]

### DIFF
--- a/pnet_macros/src/lib.rs
+++ b/pnet_macros/src/lib.rs
@@ -88,12 +88,25 @@
 //!  * \#[length_fn = "function_name"]
 //!
 //!    This attribute is used to enable variable length fields. To specify a variable length field,
-//!    it should have the type `Vec<T>`. It must have the `#[length_fn]` attribute, which specifies
-//!    a function name to calculate the length of the field. The signature for the length function
-//!    should be `fn {function_name}<'a>(example_packet: &ExamplePacket<'a>) -> usize`,
-//!    substituting `&ExamplePacket<'a>` for the appropriately named packet type for your
-//!    structure. You may access whichever fields are required to calculate the length of the
-//!    field. The returned value should be a number of bytes that the field uses.
+//!    it should have the type `Vec<T>`. It must have the `#[length_fn]` (or #[length]) attribute,
+//!    which specifies a function name to calculate the length of the field. The signature for the
+//!    length function should be
+//!    `fn {function_name}<'a>(example_packet: &ExamplePacket<'a>) -> usize`, substituting
+//!    `&ExamplePacket<'a>` for the appropriately named packet type for your structure. You may
+//!    access whichever fields are required to calculate the length of the field. The returned
+//!    value should be a number of bytes that the field uses.
+//!
+//!    The type contained in the vector may either be one of the primitive types specified in
+//!    `pnet_macros::types`, or another structure marked with #[packet], for example
+//!    `Vec<Example>`.
+//!
+//!  * \#[length = "arithmetic expression"]
+//!
+//!    This attribute is used to enable variable length fields. To specify a variable length field,
+//!    it should have the type `Vec<T>`. It must have the `#[length]` (or #[length_fn]) attribute,
+//!    which specifies an arithmetic expression to calculate the length of the field. Only field
+//!    names, constants, integers, basic arithmetic expressions (+ - * / %) and parentheses are
+//!    in the expression. An example would be `#[length = "field_name + CONSTANT - 4]`.
 //!
 //!    The type contained in the vector may either be one of the primitive types specified in
 //!    `pnet_macros::types`, or another structure marked with #[packet], for example

--- a/pnet_macros/tests/compile-fail/length_expr.rs
+++ b/pnet_macros/tests/compile-fail/length_expr.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: Only field names, integers, basic arithmetic expressions (+ - * / %) and parentheses are allowed in the "length" attribute
+// error-pattern: Only field names, constants, integers, basic arithmetic expressions (+ - * / %) and parentheses are allowed in the "length" attribute
 
 #![feature(custom_attribute, plugin)]
 #![plugin(pnet_macros)]

--- a/pnet_macros/tests/compile-fail/length_expr.rs
+++ b/pnet_macros/tests/compile-fail/length_expr.rs
@@ -6,6 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// error-pattern: Only field names, integers and basic arithmetic expressions (+ - * / %) are allowed in the "length" attribute
+
 #![feature(custom_attribute, plugin)]
 #![plugin(pnet_macros)]
 
@@ -14,7 +16,8 @@ extern crate pnet;
 #[packet]
 pub struct PacketWithPayload {
     banana: u8,
-    var_length: Vec<u8>, //~ ERROR: variable length field must have #[length = ""] or #[length_fn = ""] attribute
+    #[length = "banana + 7.5"]
+    var_length: Vec<u8>,
     #[payload]
     payload: Vec<u8>
 }

--- a/pnet_macros/tests/compile-fail/length_expr_key.rs
+++ b/pnet_macros/tests/compile-fail/length_expr_key.rs
@@ -1,0 +1,25 @@
+// Copyright (c) 2015 Robert Clipsham <robert@octarineparrot.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern: error: Field name must be a member of the struct and not the field itself
+
+#![feature(custom_attribute, plugin)]
+#![plugin(pnet_macros)]
+
+extern crate pnet;
+
+#[packet]
+pub struct PacketWithPayload {
+    banana: u8,
+    #[length = "tomato"]
+    var_length: Vec<u8>,
+    #[payload]
+    payload: Vec<u8>
+}
+
+fn main() {}

--- a/pnet_macros/tests/compile-fail/length_expr_parentheses.rs
+++ b/pnet_macros/tests/compile-fail/length_expr_parentheses.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: Only field names, integers, basic arithmetic expressions (+ - * / %) and parentheses are allowed in the "length" attribute
+// error-pattern: error: this file contains an un-closed delimiter
 
 #![feature(custom_attribute, plugin)]
 #![plugin(pnet_macros)]
@@ -16,7 +16,7 @@ extern crate pnet;
 #[packet]
 pub struct PacketWithPayload {
     banana: u8,
-    #[length = "banana + 7.5"]
+    #[length = "banana * (7 + 3"]
     var_length: Vec<u8>,
     #[payload]
     payload: Vec<u8>

--- a/pnet_macros/tests/run-pass/length_expr.rs
+++ b/pnet_macros/tests/run-pass/length_expr.rs
@@ -6,15 +6,23 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(custom_attribute, plugin)]
+#![feature(core, collections, custom_attribute, plugin)]
 #![plugin(pnet_macros)]
 
 extern crate pnet;
 
 #[packet]
-pub struct PacketWithPayload {
+pub struct Key {
     banana: u8,
-    var_length: Vec<u8>, //~ ERROR: variable length field must have #[length = ""] or #[length_fn = ""] attribute
+    #[length = "banana"]
+    #[payload]
+    payload: Vec<u8>
+}
+
+#[packet]
+pub struct AnotherKey {
+    banana: u8,
+    #[length = "banana + 7"]
     #[payload]
     payload: Vec<u8>
 }


### PR DESCRIPTION
This commits add an alternative way to provide the length of a variable sized field. Instead of providing a function, an arithmetic expression like `#[length] = "field_name - 4"` is specified.

The advantage of this approach is that no custom functions are needed although it's probably still powerful enough for most cases.

In the future this expression can be used determine the size of the source struct even for variable sized fields.