### PR TITLE
Fixing bug in `get_network_interfaces_impl` interface merging.

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -246,6 +246,7 @@ fn get_network_interfaces_impl() -> Vec<NetworkInterface> {
         };
         match (&mut old.ips, &new.ips) {
             (&mut Some(ref mut old_ips), &Some(ref new_ips)) => old_ips.push_all(new_ips.as_slice()),
+            (&mut ref mut old_ips @ None, &Some(ref new_ips)) => *old_ips = Some(new_ips.clone()),
             _ => {}
         };
         old.flags = old.flags | new.flags;


### PR DESCRIPTION
If we found an interface, but it had no IPs, subsequent interfaces of
the same name with IPs would not be correctly merged into the interface
struct.

Work done by @lukeasrodgers.