### PR TITLE
Require a minimum length for packets.

### DIFF
--- a/benches/rs_sender.rs
+++ b/benches/rs_sender.rs
@@ -30,7 +30,7 @@ static UDP_HEADER_LEN: usize = 8;
 static TEST_DATA_LEN: usize = 5;
 
 pub fn build_ipv4_header(packet: &mut [u8]) -> MutableIpv4Packet {
-    let mut ip_header = MutableIpv4Packet::new(packet);
+    let mut ip_header = MutableIpv4Packet::new(packet).unwrap();
 
     let total_len = (IPV4_HEADER_LEN + UDP_HEADER_LEN + TEST_DATA_LEN) as u16;
 
@@ -49,7 +49,7 @@ pub fn build_ipv4_header(packet: &mut [u8]) -> MutableIpv4Packet {
 }
 
 pub fn build_udp_header(packet: &mut [u8]) -> MutableUdpPacket {
-    let mut udp_header = MutableUdpPacket::new(packet);
+    let mut udp_header = MutableUdpPacket::new(packet).unwrap();
 
     udp_header.set_source(1234); // Arbitary port number
     udp_header.set_destination(1234);
@@ -95,7 +95,7 @@ fn main() {
     };
 
     let mut buffer = [0u8; 64];
-    let mut mut_ethernet_header = MutableEthernetPacket::new(&mut buffer[..]);
+    let mut mut_ethernet_header = MutableEthernetPacket::new(&mut buffer[..]).unwrap();
     {
         mut_ethernet_header.set_destination(destination);
         mut_ethernet_header.set_source(interface.mac_address());
@@ -103,7 +103,7 @@ fn main() {
         build_udp4_packet(mut_ethernet_header.payload_mut(), "rmesg");
     }
 
-    let ethernet_header = EthernetPacket::new(mut_ethernet_header.packet());
+    let ethernet_header = EthernetPacket::new(mut_ethernet_header.packet()).unwrap();
 
     loop {
         tx.send_to(&ethernet_header, None);

--- a/examples/transport_echo_server.rs
+++ b/examples/transport_echo_server.rs
@@ -36,7 +36,7 @@ fn main() {
             Ok((packet, addr)) => {
                 // Allocate enough space for a new packet
                 let mut vec: Vec<u8> = repeat(0u8).take(packet.packet().len()).collect();
-                let mut new_packet = MutableUdpPacket::new(&mut vec[..]);
+                let mut new_packet = MutableUdpPacket::new(&mut vec[..]).unwrap();
 
                 // Create a clone of the original packet
                 new_packet.clone_from(&packet);

--- a/pnet_macros/src/decorator.rs
+++ b/pnet_macros/src/decorator.rs
@@ -621,7 +621,7 @@ fn handle_vector_field(cx: &mut GenContext,
                                     let mut current_offset = {co};
                                     let len = {packet_length};
                                     for val in vals.into_iter() {{
-                                        let mut packet = Mutable{inner_ty_str}Packet::new(&mut self.packet[current_offset..]);
+                                        let mut packet = Mutable{inner_ty_str}Packet::new(&mut self.packet[current_offset..]).unwrap();
                                         packet.populate(val);
                                         current_offset += packet.packet_size();
                                         assert!(current_offset <= len);
@@ -727,12 +727,15 @@ fn generate_packet_impl(cx: &mut GenContext, packet: &Packet, mutable: bool, nam
     };
 
     cx.push_item_from_string(format!("impl<'a> {name}<'a> {{
-        /// Constructs a new {name}
+        /// Constructs a new {name}. If the provided buffer is less than the minimum required
+        /// packet size, this will return None.
         #[inline]
-        pub fn new<'p>(packet: &'p {mut} [u8]) -> {name}<'p> {{
-            // TODO This should ensure the provided buffer is at least a minimum size so we can avoid
-            //      bounds checking in accessors/mutators
-            {name} {{ packet: packet }}
+        pub fn new<'p>(packet: &'p {mut} [u8]) -> Option<{name}<'p>> {{
+            if packet.len() >= {name}::minimum_packet_size() {{
+                Some({name} {{ packet: packet }})
+            }} else {{
+                None
+            }}
         }}
 
         /// Maps from a {name} to a {imm_name}
@@ -843,7 +846,7 @@ fn generate_iterables(cx: &mut GenContext, packet: &Packet) {
         fn next(&mut self) -> Option<{name}Packet<'a>> {{
             use pnet::packet::PacketSize;
             if self.buf.len() > 0 {{
-                let ret = {name}Packet::new(self.buf);
+                let ret = {name}Packet::new(self.buf).unwrap();
                 self.buf = &self.buf[ret.packet_size()..];
 
                 return Some(ret);

--- a/src/datalink/bpf.rs
+++ b/src/datalink/bpf.rs
@@ -179,7 +179,7 @@ impl DataLinkSenderImpl {
                     }
                 }
                 {
-                    let eh = MutableEthernetPacket::new(&mut chunk[self.header_size..]);
+                    let eh = MutableEthernetPacket::new(&mut chunk[self.header_size..]).unwrap();
                     func(eh);
                 }
                 match unsafe { libc::write(self.fd.fd,
@@ -253,7 +253,7 @@ impl<'a> DataLinkChannelIteratorImpl<'a> {
             }
         }
         let (start, len) = self.packets.pop_front().unwrap();
-        Ok(EthernetPacket::new(&self.pc.read_buffer[start .. start + len]))
+        Ok(EthernetPacket::new(&self.pc.read_buffer[start .. start + len]).unwrap())
     }
 }
 

--- a/src/datalink/linux.rs
+++ b/src/datalink/linux.rs
@@ -59,7 +59,7 @@ impl DataLinkSenderImpl {
             for chunk in mut_slice.as_mut_slice()[.. min]
                                   .chunks_mut(packet_size) {
                 {
-                    let eh = MutableEthernetPacket::new(chunk);
+                    let eh = MutableEthernetPacket::new(chunk).unwrap();
                     func(eh);
                 }
                 let send_addr = (&self.send_addr as *const libc::sockaddr_ll)
@@ -173,7 +173,7 @@ impl<'a> DataLinkChannelIteratorImpl<'a> {
         let mut caddr: libc::sockaddr_storage = unsafe { mem::zeroed() };
         let res = internal::recv_from(self.pc.socket.fd, self.pc.read_buffer.as_mut_slice(), &mut caddr);
         match res {
-            Ok(len) => Ok(EthernetPacket::new(&self.pc.read_buffer.as_slice()[0 .. len])),
+            Ok(len) => Ok(EthernetPacket::new(&self.pc.read_buffer.as_slice()[0 .. len]).unwrap()),
             Err(e) => Err(e),
         }
     }

--- a/src/packet/ethernet.rs
+++ b/src/packet/ethernet.rs
@@ -29,7 +29,7 @@ pub struct Ethernet {
 fn ethernet_header_test() {
     let mut packet = [0u8; 14];
     {
-        let mut ethernet_header = MutableEthernetPacket::new(&mut packet[..]);
+        let mut ethernet_header = MutableEthernetPacket::new(&mut packet[..]).unwrap();
 
         let source = MacAddr(0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc);
         ethernet_header.set_source(source);

--- a/src/packet/ipv4.rs
+++ b/src/packet/ipv4.rs
@@ -64,7 +64,7 @@ fn ipv4_options_length<'a>(ipv4: &Ipv4Packet<'a>) -> usize {
 #[test]
 fn ipv4_options_length_test() {
     let mut packet = [0u8; 20];
-    let mut ip_header = MutableIpv4Packet::new(&mut packet[..]);
+    let mut ip_header = MutableIpv4Packet::new(&mut packet[..]).unwrap();
     ip_header.set_header_length(5);
     assert_eq!(ipv4_options_length(&ip_header.to_immutable()), 0);
 }
@@ -86,7 +86,7 @@ fn ipv4_packet_test() {
 
     let mut packet = [0u8; 20];
     {
-        let mut ip_header = MutableIpv4Packet::new(&mut packet[..]);
+        let mut ip_header = MutableIpv4Packet::new(&mut packet[..]).unwrap();
         ip_header.set_version(4);
         assert_eq!(ip_header.get_version(), 4);
 

--- a/src/packet/ipv6.rs
+++ b/src/packet/ipv6.rs
@@ -37,7 +37,7 @@ fn ipv6_header_test() {
     use packet::ip::IpNextHeaderProtocols;
     let mut packet = [0u8; 40];
     {
-        let mut ip_header = MutableIpv6Packet::new(&mut packet[..]);
+        let mut ip_header = MutableIpv6Packet::new(&mut packet[..]).unwrap();
         ip_header.set_version(6);
         assert_eq!(ip_header.get_version(), 6);
 

--- a/src/packet/udp.rs
+++ b/src/packet/udp.rs
@@ -88,7 +88,7 @@ fn udp_header_ipv4_test() {
     let ipv4_destination = Ipv4Addr::new(192, 168, 0, 199);
     let next_level_protocol = IpNextHeaderProtocols::Udp;
     {
-        let mut ip_header = MutableIpv4Packet::new(&mut packet[..]);
+        let mut ip_header = MutableIpv4Packet::new(&mut packet[..]).unwrap();
         ip_header.set_next_level_protocol(next_level_protocol);
         ip_header.set_source(ipv4_source);
         ip_header.set_destination(ipv4_destination);
@@ -101,7 +101,7 @@ fn udp_header_ipv4_test() {
     packet[20 + 8 + 3] = 't' as u8;
 
     {
-        let mut udp_header = MutableUdpPacket::new(&mut packet[20..]);
+        let mut udp_header = MutableUdpPacket::new(&mut packet[20..]).unwrap();
         udp_header.set_source(12345);
         assert_eq!(udp_header.get_source(), 12345);
 
@@ -200,7 +200,7 @@ fn udp_header_ipv6_test() {
     let ipv6_source = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1);
     let ipv6_destination = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1);
     {
-        let mut ip_header = MutableIpv6Packet::new(&mut packet[..]);
+        let mut ip_header = MutableIpv6Packet::new(&mut packet[..]).unwrap();
         ip_header.set_next_header(next_header);
         ip_header.set_source(ipv6_source);
         ip_header.set_destination(ipv6_destination);
@@ -213,7 +213,7 @@ fn udp_header_ipv6_test() {
     packet[40 + 8 + 3] = 't' as u8;
 
     {
-        let mut udp_header = MutableUdpPacket::new(&mut packet[40..]);
+        let mut udp_header = MutableUdpPacket::new(&mut packet[40..]).unwrap();
         udp_header.set_source(12345);
         assert_eq!(udp_header.get_source(), 12345);
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -152,7 +152,7 @@ impl TransportSender {
             let mut mut_slice: Vec<u8> = repeat(0u8).take(packet.packet().len()).collect();
             mut_slice.as_mut_slice().clone_from_slice(packet.packet());
 
-            let mut new_packet = MutableIpv4Packet::new(&mut mut_slice[..]);
+            let mut new_packet = MutableIpv4Packet::new(&mut mut_slice[..]).unwrap();
             let length = new_packet.get_total_length().to_be();
             new_packet.set_total_length(length);
             let offset = new_packet.get_fragment_offset().to_be();
@@ -194,7 +194,7 @@ macro_rules! transport_channel_iterator {
 
                 let offset = match self.tr.channel_type {
                     Layer4(Ipv4(_)) => {
-                        let ip_header = Ipv4Packet::new(&self.tr.buffer[..]);
+                        let ip_header = Ipv4Packet::new(&self.tr.buffer[..]).unwrap();
 
                         ip_header.get_header_length() as usize * 4usize
                     },
@@ -207,7 +207,7 @@ macro_rules! transport_channel_iterator {
                 };
                 return match res {
                     Ok(len) => {
-                        let packet = $ty::new(&self.tr.buffer[offset..len]);
+                        let packet = $ty::new(&self.tr.buffer[offset..len]).unwrap();
                         let addr = internal::sockaddr_to_addr(
                                         &caddr,
                                         mem::size_of::<libc::sockaddr_storage>()
@@ -222,7 +222,7 @@ macro_rules! transport_channel_iterator {
                     use packet::ipv4::MutableIpv4Packet;
 
                     let buflen = buffer.len();
-                    let mut new_packet = MutableIpv4Packet::new(buffer);
+                    let mut new_packet = MutableIpv4Packet::new(buffer).unwrap();
 
                     let length = u16::from_be(new_packet.get_total_length());
                     new_packet.set_total_length(length);


### PR DESCRIPTION
Constructing a new packet will now return an Option, which will be None if the
provided buffer is not sufficiently large.