### PR TITLE
Add function to determine the packet_size from a struct

### DIFF
--- a/pnet_macros/tests/compile-fail/no_packet_size.rs
+++ b/pnet_macros/tests/compile-fail/no_packet_size.rs
@@ -1,0 +1,29 @@
+// Copyright (c) 2015 Robert Clipsham <robert@octarineparrot.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern: error: no associated item named `packet_size` found for type `NoPacketSizeFn` in the current scope
+
+#![feature(custom_attribute, plugin)]
+#![plugin(pnet_macros)]
+
+extern crate pnet;
+
+#[packet]
+pub struct NoPacketSizeFn {
+    banana: u8,
+    #[payload]
+    payload: Vec<u8>
+}
+
+fn main() {
+    let no_packet_size_fn = NoPacketSizeFn {
+        banana: 7,
+        payload: vec![1, 2, 3, 4]
+    };
+    let packet_size = NoPacketSizeFn::packet_size(&no_packet_size_fn);
+}

--- a/pnet_macros/tests/run-pass/packet_size.rs
+++ b/pnet_macros/tests/run-pass/packet_size.rs
@@ -1,0 +1,45 @@
+// Copyright (c) 2015 Robert Clipsham <robert@octarineparrot.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(core, collections, custom_attribute, plugin)]
+#![plugin(pnet_macros)]
+
+extern crate pnet;
+
+#[packet]
+pub struct Key {
+    banana: u8,
+    #[length = "banana"]
+    #[payload]
+    payload: Vec<u8>
+}
+
+#[packet]
+pub struct AnotherKey {
+    banana: u8,
+    #[length = "banana + 7"]
+    #[payload]
+    payload: Vec<u8>
+}
+
+fn main() {
+    let key_payload = vec![1, 2, 3, 4];
+    let key = Key {
+        banana: key_payload.len() as u8,
+        payload: key_payload
+    };
+    assert_eq!(KeyPacket::packet_size(&key), 5);
+
+
+    let another_key_payload = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    let another_key = AnotherKey {
+        banana: (another_key_payload.len() - 7) as u8,
+        payload: another_key_payload
+    };
+    assert_eq!(AnotherKeyPacket::packet_size(&another_key), 11);
+}


### PR DESCRIPTION
There's a new `packet_size` function that is implemented for the
packets in case the size of a packet can be determined from the
struct. This is the case when the sizes of all variable sized fields
are defined by a length expression (as opposed to a length function).

This makes it possible to create a new packet from a struct without
knowing its size up front. Example:

    #[packet]
    pub struct Simple {
        sz: u8,
        #[length = "sz"]
        #[payload]
        payload: Vec<u8>
    }

    let payload = vec![1, 2, 3, 4];
    let simple = Simple {
        sz: payload.len() as u8,
        payload: payload
    };

    let mut packet = vec![0; SimplePacket::packet_size(&simple)];
    MutableDcpOpenPacket::new(&mut packet[..]).unwrap().populate(simple);