### PR TITLE
Fix packet range access

### DIFF
--- a/pnet_macros/src/decorator.rs
+++ b/pnet_macros/src/decorator.rs
@@ -503,12 +503,11 @@ fn handle_vec_primitive(cx: &mut GenContext,
                                     #[allow(trivial_numeric_casts)]
                                     pub fn get_{name}(&self) -> Vec<{inner_ty_str}> {{
                                         let current_offset = {co};
-                                        let len = {packet_length};
+                                        let end = current_offset + {packet_length};
 
-                                        let packet = &self.packet[current_offset..len];
+                                        let packet = &self.packet[current_offset..end];
                                         let mut vec = Vec::with_capacity(packet.len());
                                         vec.push_all(packet);
-
                                         vec
                                     }}
                                     ",

--- a/pnet_macros/tests/run-pass/get_variable_length_field.rs
+++ b/pnet_macros/tests/run-pass/get_variable_length_field.rs
@@ -1,0 +1,27 @@
+// Copyright (c) 2015 Robert Clipsham <robert@octarineparrot.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(custom_attribute, plugin, slice_bytes, vec_push_all)]
+#![plugin(pnet_macros)]
+
+extern crate pnet;
+
+#[packet]
+pub struct WithVariableLengthField {
+    banana: u32,
+    #[length = "3"]
+    var_length: Vec<u8>,
+    #[payload]
+    payload: Vec<u8>
+}
+
+fn main() {
+    let data = [1, 1, 1, 1, 2, 3, 4, 5, 6];
+    let packet = WithVariableLengthFieldPacket::new(&data[..]).unwrap();
+    assert_eq!(packet.get_var_length(), vec![2, 3, 4]);
+}


### PR DESCRIPTION
When getting a slice via a range, the end of the range is not the relative
offset from the start of the range, but the absolute position counted from
the start of the original array.