### PR TITLE
Add missing documentation.

### DIFF
--- a/pnet_macros/src/lib.rs
+++ b/pnet_macros/src/lib.rs
@@ -137,7 +137,7 @@
 //!        which must return a tuple of the primitive types specified in the parameters to the
 //!        `#[construct_with(...)]` attribute, and in the `new` method.
 
-#![warn(missing_docs)]
+#![deny(missing_docs)]
 
 #![feature(append, fmt_radix, plugin_registrar, quote, rustc_private)]
 

--- a/src/packet/ethernet.rs
+++ b/src/packet/ethernet.rs
@@ -60,10 +60,15 @@ fn ethernet_header_test() {
 pub mod EtherTypes {
     use packet::ethernet::EtherType;
 
+    /// Internet Protocol version 4 (IPv4) [RFC7042]
     pub const Ipv4: EtherType      = EtherType(0x0800);
+    /// Address Resolution Protocol (ARP) [RFC7042]
     pub const Arp: EtherType       = EtherType(0x0806);
+    /// Wake on Lan
     pub const WakeOnLan: EtherType = EtherType(0x0842);
+    /// Reverse Address Resolution Protocol (RARP) [RFC903]
     pub const Rarp: EtherType      = EtherType(0x8035);
+    /// Internet Protocol version 6 (IPv6) [RFC7042]
     pub const Ipv6: EtherType      = EtherType(0x86DD);
 }
 


### PR DESCRIPTION
This adds in some documentation which Rust has recently started complaining about being missing. It's odd that it wasn't caught already.

Also switched from warn -> deny for missing documentation in pnet_macros, since it is completely documented.