### PR TITLE
Bump the version number for libpnet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "pnet"
-version = "0.0.1"
+version = "0.1.0"
 authors = [ "Robert Clipsham <robert@octarineparrot.com>" ]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"

--- a/pnet_macros/Cargo.toml
+++ b/pnet_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "pnet_macros"
-version = "0.0.1"
+version = "0.1.0"
 authors = ["Robert Clipsham <robert@octarineparrot.com>"]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"


### PR DESCRIPTION
This should have been done long ago, since the version currently on crates.io
doesn't compile.