### PR TITLE
Remove Git dependency on netmap_sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ default = []
 netmap = ["netmap_sys"]
 
 [dependencies.netmap_sys]
-git = "https://github.com/libpnet/netmap_sys.git"
 features = ["netmap_with_libs"]
 optional = true
 


### PR DESCRIPTION
This hopefully will allow publishing the new version on crates.io.