### PR TITLE
Fix issue #112.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "pnet"
-version = "0.1.1"
+version = "0.2.0"
 authors = [ "Robert Clipsham <robert@octarineparrot.com>" ]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"

--- a/pnet_macros/Cargo.toml
+++ b/pnet_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "pnet_macros"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Robert Clipsham <robert@octarineparrot.com>"]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"

--- a/pnet_macros/tests/run-pass/mqtt.rs
+++ b/pnet_macros/tests/run-pass/mqtt.rs
@@ -1,0 +1,30 @@
+// Copyright (c) 2015 Robert Clipsham <robert@octarineparrot.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(custom_attribute, plugin, slice_bytes, vec_push_all)]
+#![plugin(pnet_macros)]
+
+extern crate pnet;
+extern crate pnet_macros;
+
+use pnet_macros::types::*;
+
+#[packet]
+pub struct Mqtt {
+    source: u16be,
+    destination: u16be,
+    #[length_fn="mqtt_options_length"]
+    options: Vec<u8>,
+    t: u8,
+    #[payload]
+    payload: Vec<u8>
+}
+
+fn mqtt_options_length(_: &MqttPacket) -> usize { 0 }
+
+fn main(){}


### PR DESCRIPTION
The primary issue was that accessors and mutators could attempt to borrow
mutably and immutably at the same time if there was a length method specified.
This hadn't been caught previously due to no code having fields after a
variable length field.