### PR TITLE
Use traits to define DataLink*

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "pnet"
-version = "0.2.0"
+version = "0.3.0"
 authors = [ "Robert Clipsham <robert@octarineparrot.com>" ]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"


### PR DESCRIPTION
Using **Polymorphism** instead of **Encapsulation** is the key to use multiples backeds at the same time. Lets say that you need to open an datalink to a interface using bpf and an datalink on other interface using netmap, with this `trait` you can :)
Note1: I couldn't compile using netmap, so I didn't test using multiples backeds.
Note2: try to find a better solution to `default_datalink_channel` implementation