### PR TITLE
use libc::size_t instead of u64

### DIFF
--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -19,7 +19,7 @@ mod native;
 #[cfg(windows)] pub type BufLen = i32;
 
 #[cfg(not(windows))] pub type CSocket = libc::c_int;
-#[cfg(not(windows))] pub type BufLen = u64;
+#[cfg(not(windows))] pub type BufLen = libc::size_t;
 
 // Any file descriptor on unix, only sockets on Windows.
 pub struct FileDesc {


### PR DESCRIPTION
This will fix compilation errors on 32bit non-windows platforms.