### PR TITLE
Workaround rust-lang-nursery/libc#58.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "pnet"
-version = "0.4.0"
+version = "0.4.1"
 authors = [ "Robert Clipsham <robert@octarineparrot.com>" ]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"
@@ -33,6 +33,9 @@ version = ">=0.0"
 features = ["netmap_with_libs"]
 optional = true
 version = ">=0.0"
+
+[dependencies.libc]
+version = "=0.1.12"
 
 [dependencies.pnet_macros]
 path = "pnet_macros"

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To use `libpnet` in your project, add the following to your Cargo.toml:
 
 ```
 [dependencies.pnet]
-version = "0.4.0"
+version = "0.4.1"
 ```
 
 When developing, use the provided Makefile, which does weird things to make the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@
 #![allow(plugin_as_library)]
 
 // FIXME Remove this once the std lib has stabilised
-#![feature(custom_attribute, ip_addr, libc, plugin, slice_bytes,
+#![feature(custom_attribute, ip_addr, plugin, slice_bytes,
            slice_patterns, vec_push_all, lookup_host)]
 #![plugin(pnet_macros)]
 #![cfg_attr(test, feature(str_char))]


### PR DESCRIPTION
This fixes libpnet to an older version of libc, until this is fixed.

See also: rust-lang-nursery/libc#58.