### PR TITLE
remove clippy needless_lifetimes attribute

### DIFF
--- a/src/datalink/bpf.rs
+++ b/src/datalink/bpf.rs
@@ -237,8 +237,6 @@ pub struct DataLinkReceiverImpl {
 }
 
 impl DataLinkReceiver for DataLinkReceiverImpl {
-    // FIXME See https://github.com/Manishearth/rust-clippy/issues/417
-    #[cfg_attr(feature = "clippy", allow(needless_lifetimes))]
     fn iter<'a>(&'a mut self) -> Box<DataLinkChannelIterator + 'a> {
         let buflen = self.read_buffer.len();
         Box::new(DataLinkChannelIteratorImpl {

--- a/src/datalink/linux.rs
+++ b/src/datalink/linux.rs
@@ -170,8 +170,6 @@ pub struct DataLinkReceiverImpl {
 
 impl DataLinkReceiver for DataLinkReceiverImpl {
     // FIXME Layer 3
-    // FIXME See https://github.com/Manishearth/rust-clippy/issues/417
-    #[cfg_attr(feature = "clippy", allow(needless_lifetimes))]
     fn iter<'a>(&'a mut self) -> Box<DataLinkChannelIterator + 'a> {
         Box::new(DataLinkChannelIteratorImpl { pc: self })
     }

--- a/src/datalink/mod.rs
+++ b/src/datalink/mod.rs
@@ -106,8 +106,6 @@ pub trait DataLinkReceiver : Send {
     ///
     /// This will likely be removed once other layer two types are supported.
     #[inline]
-    // FIXME See https://github.com/Manishearth/rust-clippy/issues/417
-    #[cfg_attr(feature = "clippy", allow(needless_lifetimes))]
     fn iter<'a>(&'a mut self) -> Box<DataLinkChannelIterator + 'a>;
 }
 

--- a/src/datalink/winpcap.rs
+++ b/src/datalink/winpcap.rs
@@ -204,8 +204,6 @@ pub struct DataLinkReceiverImpl {
 }
 
 impl DataLinkReceiver for DataLinkReceiverImpl {
-    // FIXME See https://github.com/Manishearth/rust-clippy/issues/417
-    #[cfg_attr(feature = "clippy", allow(needless_lifetimes))]
     fn iter<'a>(&'a mut self) -> Box<DataLinkChannelIterator + 'a> {
         let buflen = unsafe { (*self.packet.packet).Length } as usize;
         Box::new(DataLinkChannelIteratorImpl {


### PR DESCRIPTION
https://github.com/Manishearth/rust-clippy/issues/417 is now solved, so
this attribute is not required anymore.