### PR TITLE
Fix issue #128.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ version = "=0.1.12"
 
 [dependencies.pnet_macros]
 path = "pnet_macros"
-version = ">=0.4"
+version = ">=0.5"
 
 [dependencies.pnet_macros_support]
 path = "pnet_macros"

--- a/pnet_macros/Cargo.toml
+++ b/pnet_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "pnet_macros"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Robert Clipsham <robert@octarineparrot.com>"]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"
@@ -23,7 +23,7 @@ compiletest_rs = ">=0.0"
 
 [dev-dependencies.pnet]
 path = ".."
-version = ">=0.3"
+version = ">=0.5"
 
 [dev-dependencies.pnet_macros_support]
 path = "../pnet_macros_support"

--- a/pnet_macros/tests/compile-fail/endianness_not_specified.rs
+++ b/pnet_macros/tests/compile-fail/endianness_not_specified.rs
@@ -6,25 +6,19 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(custom_attribute, plugin, slice_bytes, vec_push_all)]
+// error-pattern: endianness must be specified for types of size >= 8
+
+#![feature(custom_attribute, plugin)]
 #![plugin(pnet_macros)]
 
 extern crate pnet;
-extern crate pnet_macros_support;
-
-use pnet_macros_support::types::*;
 
 #[packet]
-pub struct WithVariableLengthField {
-    banana: u32be,
-    #[length = "3"]
-    var_length: Vec<u8>,
+pub struct PacketU16 {
+    banana: u16,
     #[payload]
     payload: Vec<u8>
 }
 
-fn main() {
-    let data = [1, 1, 1, 1, 2, 3, 4, 5, 6];
-    let packet = WithVariableLengthFieldPacket::new(&data[..]).unwrap();
-    assert_eq!(packet.get_var_length(), vec![2, 3, 4]);
-}
+fn main() {}
+

--- a/pnet_macros/tests/run-pass/min_packet_size.rs
+++ b/pnet_macros/tests/run-pass/min_packet_size.rs
@@ -24,7 +24,7 @@ pub struct ByteAligned {
 
 #[packet]
 pub struct ByteAlignedWithVariableLength {
-    banana: u16,
+    banana: u16be,
     #[length_fn = "length_fn1"]
     #[payload]
     payload: Vec<u8>
@@ -37,7 +37,7 @@ fn length_fn1(_: &ByteAlignedWithVariableLengthPacket) -> usize {
 
 #[packet]
 pub struct ByteAlignedWithVariableLengthAndPayload {
-    banana: u32,
+    banana: u32be,
     #[length_fn = "length_fn2"]
     var_length: Vec<u8>,
     #[payload]


### PR DESCRIPTION
Endianness must now be specified for fields in packets, if their size is
greater than eight.