### PR TITLE
Fix travis build.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ name = "pnet"
 default = ["clippy"]
 netmap = ["netmap_sys"]
 appveyor = []
+travis = []
 
 [dependencies.clippy]
 optional = true

--- a/build.sh
+++ b/build.sh
@@ -166,6 +166,7 @@ case "$1" in
         benchmarks
     ;;
     travis_script)
+        CARGO_FLAGS="$CARGO_FLAGS --features travis"
         travis_script
     ;;
     *)

--- a/pnet_macros/Cargo.toml
+++ b/pnet_macros/Cargo.toml
@@ -17,6 +17,7 @@ plugin = true
 
 [features]
 default = ["clippy"]
+travis = []
 
 [dev-dependencies]
 compiletest_rs = ">=0.0"

--- a/pnet_macros_support/Cargo.toml
+++ b/pnet_macros_support/Cargo.toml
@@ -13,3 +13,6 @@ keywords = ["networking", "bitfields", "packet", "protocol"]
 
 [lib]
 name = "pnet_macros_support"
+
+[features]
+travis = []

--- a/src/test.rs
+++ b/src/test.rs
@@ -223,8 +223,10 @@ fn layer4_ipv4() {
     layer4(IpAddr::V4(ipv4_source()), IPV4_HEADER_LEN as usize);
 }
 
+// travis does not currently support IPv6
 #[test]
-#[cfg(not(feature = "appveyor"))]
+#[cfg(all(not(feature = "appveyor"),
+          not(all(target_os = "linux", feature = "travis"))))]
 fn layer4_ipv6() {
     layer4(IpAddr::V6(ipv6_source()), IPV6_HEADER_LEN);
 }


### PR DESCRIPTION
Travis recently removed support for IPv6 networking, so, consequently, the IPv6
tests are failing.