### PR TITLE
Re-enable clippy's explicit_counter_loop lint

### DIFF
--- a/src/datalink/bpf.rs
+++ b/src/datalink/bpf.rs
@@ -86,10 +86,8 @@ pub fn datalink_channel(network_interface: &NetworkInterface,
         return Err(io::Error::last_os_error());
     }
     let mut iface: bpf::ifreq = unsafe { mem::zeroed() };
-    let mut i = 0;
-    for c in network_interface.name.bytes() {
+    for (i, c) in network_interface.name.bytes().enumerate() {
         iface.ifr_name[i] = c as i8;
-        i += 1;
     }
 
     let buflen = read_buffer_size as libc::c_uint;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,8 +111,6 @@
 #![feature(custom_attribute, plugin)]
 #![plugin(pnet_macros)]
 #![cfg_attr(feature="clippy", plugin(clippy))]
-// See: https://github.com/Manishearth/rust-clippy/issues/373
-#![cfg_attr(feature="clippy", allow(explicit_counter_loop))]
 // We can't implement Iterator since we use streaming iterators
 #![cfg_attr(feature="clippy", allow(should_implement_trait))]
 


### PR DESCRIPTION
This lint was disabled due to https://github.com/Manishearth/rust-clippy/issues/373 , which has been fixed.