### PR TITLE
removing a uselesss println

### DIFF
--- a/src/packet/ipv4.rs.in
+++ b/src/packet/ipv4.rs.in
@@ -107,7 +107,6 @@ pub struct Ipv4OptionNumber(pub u8);
 impl Ipv4OptionNumber {
     /// Create a new Ipv4OptionNumber
     pub fn new(value: u8) -> Ipv4OptionNumber {
-        println!("{:?}", Ipv4OptionNumbers::EOL);
         Ipv4OptionNumber(value)
     }
 }


### PR DESCRIPTION
I forget to remove a useless println from the ipv4.rs file.