### PR TITLE
update to libc 0.2.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ optional = true
 version = ">=0.0"
 
 [dependencies.libc]
-version = "=0.1.12"
+version = "0.2.*"
 
 [dependencies.syntex]
 version = "=0.26.0"


### PR DESCRIPTION
I want my crate only depends on one libc version (and the only reverse dependency for libc 0.1.x is pnet) so I update it. I'm not sure I did this right. The code is "stolen" from nix-rust crate (https://github.com/carllerche/nix-rust/blob/master/src/sys/socket/addr.rs#L275-L331). Please comment.