### PR TITLE
Make simple types hashable

### DIFF
--- a/src/packet/ethernet.rs.in
+++ b/src/packet/ethernet.rs.in
@@ -71,7 +71,7 @@ pub mod EtherTypes {
 }
 
 /// Represents the Ethernet ethertype field.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EtherType(pub u16);
 
 impl EtherType {

--- a/src/packet/ip.rs
+++ b/src/packet/ip.rs
@@ -465,7 +465,7 @@ pub mod IpNextHeaderProtocols {
 
 /// Represents an IPv4 next level protocol, or an IPv6 next header protocol,
 /// see `IpNextHeaderProtocols` for a list of values.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IpNextHeaderProtocol(pub u8);
 
 impl IpNextHeaderProtocol {

--- a/src/packet/ipv4.rs.in
+++ b/src/packet/ipv4.rs.in
@@ -100,8 +100,8 @@ pub mod Ipv4OptionNumbers {
     pub const EXP: Ipv4OptionNumber = Ipv4OptionNumber(30);
 }
 
-/// Represents an IPv4 option 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+/// Represents an IPv4 option
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Ipv4OptionNumber(pub u8);
 
 impl Ipv4OptionNumber {

--- a/src/util.rs
+++ b/src/util.rs
@@ -132,7 +132,7 @@ pub enum IpAddr {
     /// An IPv4 Address
     V4(Ipv4Addr),
     /// An IPv6 Address
-    V6(Ipv6Addr)
+    V6(Ipv6Addr),
 }
 
 impl FromStr for IpAddr {
@@ -147,7 +147,7 @@ impl FromStr for IpAddr {
                     Ok(res) => Ok(IpAddr::V6(res)),
                     Err(_) => Err(()),
                 }
-            },
+            }
         }
     }
 }
@@ -313,8 +313,9 @@ fn get_network_interfaces_impl() -> Vec<NetworkInterface> {
             _ => new.mac,
         };
         match (&mut old.ips, &new.ips) {
-            (&mut Some(ref mut old_ips), &Some(ref new_ips)) =>
-                old_ips.extend_from_slice(&new_ips[..]),
+            (&mut Some(ref mut old_ips), &Some(ref new_ips)) => {
+                old_ips.extend_from_slice(&new_ips[..])
+            }
             (&mut ref mut old_ips @ None, &Some(ref new_ips)) => *old_ips = Some(new_ips.clone()),
             _ => {}
         };

--- a/src/util.rs
+++ b/src/util.rs
@@ -24,7 +24,7 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 use internal;
 
 /// A MAC address
-#[derive(PartialEq, Eq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy, Hash)]
 pub struct MacAddr(pub u8, pub u8, pub u8, pub u8, pub u8, pub u8);
 
 impl MacAddr {
@@ -127,7 +127,7 @@ fn mac_addr_from_str() {
 }
 
 /// Represents either an Ipv4Addr or an Ipv6Addr
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub enum IpAddr {
     /// An IPv4 Address
     V4(Ipv4Addr),
@@ -168,7 +168,7 @@ impl fmt::Display for IpAddr {
 }
 
 /// Represents a network interface and its associated addresses
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub struct NetworkInterface {
     /// The name of the interface
     pub name: String,


### PR DESCRIPTION
I needed to store EtherType as a key in a HashMap, then I realized that a lot of these quite simple types could make use of being hashable.

@mrmonday 