### PR TITLE
Use std::net::IpAddr instead of own impl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache:
     directories:
         - $HOME/.cargo
 rust:
-    - 1.6.0
+    - 1.7.0
     - stable
     - beta
     - nightly
@@ -22,9 +22,9 @@ matrix:
   allow_failures:
     - rust: nightly
   exclude:
-    - rust: 1.6.0
+    - rust: 1.7.0
       env: PNET_FEATURES="travis nightly clippy" PNET_MACROS_FEATURES="travis clippy"
-    - rust: 1.6.0
+    - rust: 1.7.0
       env: PNET_FEATURES="travis nightly" PNET_MACROS_FEATURES="travis"
     - rust: stable
       env: PNET_FEATURES="travis nightly clippy" PNET_MACROS_FEATURES="travis clippy"

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ version = "0.7.4"
 ```
 
 `libpnet` should work on any Rust channel (stable, beta, or nightly), starting
-with Rust 1.6. When using a nightly version of Rust, you may wish to use pass
+with Rust 1.7. When using a nightly version of Rust, you may wish to use pass
 `--no-default-features --features nightly` to Cargo, to enable faster build
 times.
 
@@ -93,4 +93,3 @@ There are three requirements for building on Windows:
  * You must place `Packet.lib` from the [WinPcap Developers pack](https://www.winpcap.org/devel.htm)
    in a directory named `lib`, in the root of this repository. For the 64 bit toolchain it is in
    `WpdPack/Lib/x64/Packet.lib`, for the 32 bit toolchain, it is in `WpdPack/Lib/Packet.lib`.
-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,11 @@ environment:
   RUST_TEST_THREADS: 1
   matrix:
   - TARGET: x86_64-pc-windows-msvc
-    RUST_CHANNEL: 1.6.0
+    RUST_CHANNEL: 1.7.0
     WPD_LIB_PATH: "C:/dl/wpdpack/WpdPack/Lib/x64/Packet.lib"
     VCVARS: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\amd64\\vcvars64.bat"
   - TARGET: i686-pc-windows-msvc
-    RUST_CHANNEL: 1.6.0
+    RUST_CHANNEL: 1.7.0
     WPD_LIB_PATH: "C:/dl/wpdpack/WpdPack/Lib/Packet.lib"
     VCVARS: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\vcvars32.bat"
   - TARGET: x86_64-pc-windows-msvc

--- a/examples/packetdump.rs
+++ b/examples/packetdump.rs
@@ -11,18 +11,19 @@
 extern crate pnet;
 
 use std::env;
+use std::net::IpAddr;
 
-use pnet::packet::{Packet};
+use pnet::packet::Packet;
 use pnet::packet::ethernet::{EthernetPacket, EtherTypes};
 use pnet::packet::ip::{IpNextHeaderProtocol, IpNextHeaderProtocols};
-use pnet::packet::ipv4::{Ipv4Packet};
-use pnet::packet::ipv6::{Ipv6Packet};
-use pnet::packet::udp::{UdpPacket};
+use pnet::packet::ipv4::Ipv4Packet;
+use pnet::packet::ipv6::Ipv6Packet;
+use pnet::packet::udp::UdpPacket;
 
-use pnet::datalink::{datalink_channel};
-use pnet::datalink::DataLinkChannelType::{Layer2};
+use pnet::datalink::datalink_channel;
+use pnet::datalink::DataLinkChannelType::Layer2;
 
-use pnet::util::{IpAddr, NetworkInterface, get_network_interfaces};
+use pnet::util::{NetworkInterface, get_network_interfaces};
 
 fn handle_udp_packet(interface_name: &str, source: IpAddr, destination: IpAddr, packet: &[u8]) {
     let udp = UdpPacket::new(packet);

--- a/src/test.rs
+++ b/src/test.rs
@@ -8,7 +8,7 @@
 
 extern crate libc;
 
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::net::{Ipv4Addr, Ipv6Addr, IpAddr};
 use std::sync::mpsc::channel;
 use std::thread;
 use std::iter::Iterator;
@@ -24,7 +24,6 @@ use transport::{TransportChannelType, TransportProtocol, ipv4_packet_iter, trans
                 udp_packet_iter};
 use transport::TransportProtocol::{Ipv4, Ipv6};
 use util;
-use util::IpAddr;
 
 const IPV4_HEADER_LEN: usize = 20;
 const IPV6_HEADER_LEN: usize = 40;

--- a/src/util.rs
+++ b/src/util.rs
@@ -17,7 +17,7 @@ use std::fmt;
 use std::str::{FromStr, from_utf8_unchecked};
 use std::mem;
 use std::u8;
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::net::IpAddr;
 
 
 #[cfg(not(windows))]
@@ -124,47 +124,6 @@ fn mac_addr_from_str() {
                Err(ParseMacAddrErr::TooManyComponents));
     assert_eq!("xx:xx:xx:xx:xx:xx".parse::<MacAddr>(),
                Err(ParseMacAddrErr::InvalidComponent));
-}
-
-/// Represents either an Ipv4Addr or an Ipv6Addr
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
-pub enum IpAddr {
-    /// An IPv4 Address
-    V4(Ipv4Addr),
-    /// An IPv6 Address
-    V6(Ipv6Addr),
-}
-
-impl FromStr for IpAddr {
-    type Err = ();
-    fn from_str(s: &str) -> Result<IpAddr, ()> {
-        let ipv4: Result<Ipv4Addr, _> = FromStr::from_str(s);
-        let ipv6: Result<Ipv6Addr, _> = FromStr::from_str(s);
-        match ipv4 {
-            Ok(res) => Ok(IpAddr::V4(res)),
-            Err(_) => {
-                match ipv6 {
-                    Ok(res) => Ok(IpAddr::V6(res)),
-                    Err(_) => Err(()),
-                }
-            }
-        }
-    }
-}
-
-impl fmt::Debug for IpAddr {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(self, fmt)
-    }
-}
-
-impl fmt::Display for IpAddr {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            IpAddr::V4(ip_addr) => fmt::Display::fmt(&ip_addr, fmt),
-            IpAddr::V6(ip_addr) => fmt::Display::fmt(&ip_addr, fmt),
-        }
-    }
 }
 
 /// Represents a network interface and its associated addresses


### PR DESCRIPTION
Since `std::net::IpAddr` has been stabilized since rustc 1.7.0 we might want to use the std implementation instead. That enum has been around as unstable since 1.0.0, was deprecated in 1.6.0 and then brought back to stable in 1.7.0

@mrmonday 