### PR TITLE
Split internal per target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 target/
 Cargo.lock
-Packet.lib
+*.lib

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 Cargo.lock
+Packet.lib

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -11,15 +11,18 @@ extern crate libc;
 use std::io;
 use std::mem;
 
-pub use self::native::{addr_to_sockaddr, close, retry, sockaddr_to_addr};
+pub use self::native::{addr_to_sockaddr, sockaddr_to_addr};
+
+#[cfg(windows)]mod windows;
+#[cfg(not(windows))]mod posix;
+
+#[cfg(windows)]
+pub use self::windows::*;
+#[cfg(not(windows))]
+pub use self::posix::*;
 
 mod native;
 
-#[cfg(windows)] pub type CSocket = libc::SOCKET;
-#[cfg(windows)] pub type BufLen = i32;
-
-#[cfg(not(windows))] pub type CSocket = libc::c_int;
-#[cfg(not(windows))] pub type BufLen = libc::size_t;
 
 // Any file descriptor on unix, only sockets on Windows.
 pub struct FileDesc {

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -13,13 +13,16 @@ use std::mem;
 
 pub use self::native::{addr_to_sockaddr, sockaddr_to_addr};
 
-#[cfg(windows)]mod windows;
-#[cfg(not(windows))]mod posix;
+
+#[cfg(unix)]
+mod unix;
+#[cfg(unix)]
+pub use self::unix::*;
 
 #[cfg(windows)]
+mod windows;
+#[cfg(windows)]
 pub use self::windows::*;
-#[cfg(not(windows))]
-pub use self::posix::*;
 
 mod native;
 

--- a/src/internal/native.rs
+++ b/src/internal/native.rs
@@ -17,8 +17,6 @@ use std::mem;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
 
-
-
 ///
 /// sockaddr and misc bindings
 ///

--- a/src/internal/native.rs
+++ b/src/internal/native.rs
@@ -16,48 +16,8 @@ use std::io;
 use std::mem;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
-use internal::CSocket;
 
-#[cfg(windows)]
-pub unsafe fn close(sock: CSocket) {
-    let _ = libc::closesocket(sock);
-}
-#[cfg(unix)]
-pub unsafe fn close(sock: CSocket) {
-    let _ = libc::close(sock);
-}
 
-fn errno() -> i32 {
-    io::Error::last_os_error().raw_os_error().unwrap()
-}
-
-#[cfg(windows)]
-#[inline]
-pub fn retry<F>(f: &mut F) -> libc::c_int
-    where F: FnMut() -> libc::c_int
-{
-    loop {
-        let minus1 = -1;
-        let ret = f();
-        if ret != minus1 || errno() as isize != libc::WSAEINTR as isize {
-            return ret;
-        }
-    }
-}
-
-#[cfg(unix)]
-#[inline]
-pub fn retry<F>(f: &mut F) -> libc::ssize_t
-    where F: FnMut() -> libc::ssize_t
-{
-    loop {
-        let minus1 = -1;
-        let ret = f();
-        if ret != minus1 || errno() as isize != libc::EINTR as isize {
-            return ret;
-        }
-    }
-}
 
 ///
 /// sockaddr and misc bindings
@@ -91,9 +51,14 @@ pub fn addr_to_sockaddr(addr: SocketAddr, storage: &mut libc::sockaddr_storage) 
                 let ip_addr = sa.ip();
                 let segments = ip_addr.segments();
                 let inaddr = libc::in6_addr {
-                    s6_addr: [htons(segments[0]), htons(segments[1]), htons(segments[2]),
-                              htons(segments[3]), htons(segments[4]), htons(segments[5]),
-                              htons(segments[6]), htons(segments[7])],
+                    s6_addr: [htons(segments[0]),
+                              htons(segments[1]),
+                              htons(segments[2]),
+                              htons(segments[3]),
+                              htons(segments[4]),
+                              htons(segments[5]),
+                              htons(segments[6]),
+                              htons(segments[7])],
                 };
                 let storage = storage as *mut _ as *mut libc::sockaddr_in6;
                 (*storage).sin6_family = libc::AF_INET6 as libc::sa_family_t;

--- a/src/internal/posix.rs
+++ b/src/internal/posix.rs
@@ -1,0 +1,30 @@
+extern crate libc;
+
+use std::io;
+
+#[cfg(not(windows))] pub type CSocket = libc::c_int;
+#[cfg(not(windows))] pub type BufLen = libc::size_t;
+
+
+fn errno() -> i32 {
+    io::Error::last_os_error().raw_os_error().unwrap()
+}
+
+#[cfg(unix)]
+pub unsafe fn close(sock: CSocket) {
+    let _ = libc::close(sock);
+}
+
+#[cfg(unix)]
+#[inline]
+pub fn retry<F>(f: &mut F) -> libc::ssize_t
+    where F: FnMut() -> libc::ssize_t
+{
+    loop {
+        let minus1 = -1;
+        let ret = f();
+        if ret != minus1 || errno() as isize != libc::EINTR as isize {
+            return ret;
+        }
+    }
+}

--- a/src/internal/unix.rs
+++ b/src/internal/unix.rs
@@ -2,20 +2,18 @@ extern crate libc;
 
 use std::io;
 
-#[cfg(not(windows))] pub type CSocket = libc::c_int;
-#[cfg(not(windows))] pub type BufLen = libc::size_t;
+pub type CSocket = libc::c_int;
+pub type BufLen = libc::size_t;
 
 
 fn errno() -> i32 {
     io::Error::last_os_error().raw_os_error().unwrap()
 }
 
-#[cfg(unix)]
 pub unsafe fn close(sock: CSocket) {
     let _ = libc::close(sock);
 }
 
-#[cfg(unix)]
 #[inline]
 pub fn retry<F>(f: &mut F) -> libc::ssize_t
     where F: FnMut() -> libc::ssize_t

--- a/src/internal/windows.rs
+++ b/src/internal/windows.rs
@@ -1,0 +1,30 @@
+extern crate libc;
+
+use std::io;
+
+#[cfg(windows)] pub type CSocket = libc::SOCKET;
+#[cfg(windows)] pub type BufLen = i32;
+
+
+fn errno() -> i32 {
+    io::Error::last_os_error().raw_os_error().unwrap()
+}
+
+#[cfg(windows)]
+pub unsafe fn close(sock: CSocket) {
+    let _ = libc::closesocket(sock);
+}
+
+#[cfg(windows)]
+#[inline]
+pub fn retry<F>(f: &mut F) -> libc::c_int
+    where F: FnMut() -> libc::c_int
+{
+    loop {
+        let minus1 = -1;
+        let ret = f();
+        if ret != minus1 || errno() as isize != libc::WSAEINTR as isize {
+            return ret;
+        }
+    }
+}

--- a/src/internal/windows.rs
+++ b/src/internal/windows.rs
@@ -2,20 +2,18 @@ extern crate libc;
 
 use std::io;
 
-#[cfg(windows)] pub type CSocket = libc::SOCKET;
-#[cfg(windows)] pub type BufLen = i32;
+pub type CSocket = libc::SOCKET;
+pub type BufLen = i32;
 
 
 fn errno() -> i32 {
     io::Error::last_os_error().raw_os_error().unwrap()
 }
 
-#[cfg(windows)]
 pub unsafe fn close(sock: CSocket) {
     let _ = libc::closesocket(sock);
 }
 
-#[cfg(windows)]
 #[inline]
 pub fn retry<F>(f: &mut F) -> libc::c_int
     where F: FnMut() -> libc::c_int


### PR DESCRIPTION
Split the 'internal' module to unix and windows sub-modules.