### PR TITLE
ARP

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -31,6 +31,7 @@ mod macros {
         "ipv6.rs",
         "udp.rs",
         "tcp.rs",
+        "arp.rs"
     ];
 
     pub fn expand() {

--- a/examples/packetdump.rs
+++ b/examples/packetdump.rs
@@ -20,6 +20,7 @@ use pnet::packet::ipv4::Ipv4Packet;
 use pnet::packet::ipv6::Ipv6Packet;
 use pnet::packet::udp::UdpPacket;
 use pnet::packet::tcp::TcpPacket;
+use pnet::packet::arp::ArpPacket;
 
 use pnet::datalink;
 
@@ -89,12 +90,18 @@ fn handle_ipv6_packet(interface_name: &str, ethernet: &EthernetPacket) {
 }
 
 fn handle_arp_packet(interface_name: &str, ethernet: &EthernetPacket) {
-    println!("[{}]: ARP packet: {} > {}; length: {}",
-            interface_name,
-            ethernet.get_source(),
-            ethernet.get_destination(),
-            ethernet.packet().len())
-
+    let header = ArpPacket::new(ethernet.payload());
+	if let Some(header) = header {
+        println!("[{}]: ARP packet: {}({}) > {}({}); operation: {:?}",
+                interface_name,
+                ethernet.get_source(),
+                header.get_sender_proto_addr(),
+                ethernet.get_destination(),
+                header.get_target_proto_addr(),
+                header.get_operation());
+    } else {
+        println!("[{}]: Malformed ARP Packet", interface_name);
+    }
 }
 
 fn handle_packet(interface_name: &str, ethernet: &EthernetPacket) {

--- a/src/packet/arp.rs
+++ b/src/packet/arp.rs
@@ -1,0 +1,15 @@
+// Copyright (c) 2015 Robert Clipsham <robert@octarineparrot.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! TCP packet abstraction
+
+#[cfg(feature = "with-syntex")]
+include!(concat!(env!("OUT_DIR"), "/arp.rs"));
+
+#[cfg(not(feature = "with-syntex"))]
+include!("arp.rs.in");

--- a/src/packet/arp.rs.in
+++ b/src/packet/arp.rs.in
@@ -1,0 +1,105 @@
+// Copyright (c) 2014, 2015 Robert Clipsham <robert@octarineparrot.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use packet::Packet;
+use packet::PacketSize;
+use packet::PrimitiveValues;
+use packet::ethernet::EtherType;
+use util::MacAddr;
+
+use pnet_macros_support::types::*;
+
+use std::net::{Ipv4Addr};
+
+/// Represents ARP operation
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ArpOperation(pub u16);
+
+impl ArpOperation {
+    /// Create a new ArpOperation
+    pub fn new(value: u16) -> Self {
+        ArpOperation(value)
+    }
+}
+
+impl PrimitiveValues for ArpOperation {
+    type T = (u16,);
+    fn to_primitive_values(&self) -> (u16,) {
+        (self.0,)
+    }
+}
+
+/// ARP protocol operations
+#[allow(non_snake_case)]
+#[allow(non_upper_case_globals)]
+pub mod ArpOperations {
+    use super::ArpOperation;
+
+    /// ARP request
+    pub const Request: ArpOperation = ArpOperation(1);
+
+    /// ARP reply
+    pub const Reply: ArpOperation = ArpOperation(2);
+}
+
+/// Represents ARP hardware types
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ArpHardwareType(pub u16);
+
+impl ArpHardwareType {
+    /// Create a new ArpHardwareType
+    pub fn new(value: u16) -> Self {
+        ArpHardwareType(value)
+    }
+}
+
+impl PrimitiveValues for ArpHardwareType {
+    type T = (u16,);
+    fn to_primitive_values(&self) -> (u16,) {
+        (self.0,)
+    }
+}
+
+/// ARP protocol hardware types
+#[allow(non_snake_case)]
+#[allow(non_upper_case_globals)]
+pub mod ArpHardwareTypes {
+    use super::ArpHardwareType;
+
+    /// Ethernet
+    pub const Ethernet: ArpHardwareType = ArpHardwareType(1);
+}
+
+/// Represents an ARP Packet
+#[packet]
+#[allow(non_snake_case)]
+pub struct Arp {
+    #[construct_with(u16)]
+    hardware_type: ArpHardwareType,
+    #[construct_with(u16)]
+    protocol_type: EtherType,
+    // We completely ignore hw_addr_len and
+    // proto_addr_len and use values for
+    // Ipv4 on top of Ethernet as it's the
+    // most common use case
+    hw_addr_len: u8,
+    proto_addr_len: u8,
+    #[construct_with(u16)]
+    operation: ArpOperation,
+    #[construct_with(u8, u8, u8, u8, u8, u8)]
+    sender_hw_addr: MacAddr,
+    #[construct_with(u8, u8, u8, u8)]
+    sender_proto_addr: Ipv4Addr,
+    #[construct_with(u8, u8, u8, u8, u8, u8)]
+    target_hw_addr: MacAddr,
+    #[construct_with(u8, u8, u8, u8)]
+    target_proto_addr: Ipv4Addr,
+    #[payload]
+    #[length = "0"]
+    payload: Vec<u8>,
+}

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -96,3 +96,4 @@ pub mod ipv4;
 pub mod ipv6;
 pub mod udp;
 pub mod tcp;
+pub mod arp;


### PR DESCRIPTION
Here's an ARP packet impl with 2 caveats:

1) libpnet_macros won't let me define a packet without payload, so I put in a hack.

2) I used Ipv4Addr and MacAddr types. This is not actually correct per specification (RFC defines lengths for these fields (hw_addr_len, proto_addr_len)), but this definition covers like 99% of use cases and is damn convenient. 

What do you think?