### PR TITLE
Implemented VLAN tag parsing

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -32,7 +32,8 @@ mod macros {
         "icmp.rs",
         "udp.rs",
         "tcp.rs",
-        "arp.rs"
+        "arp.rs",
+        "vlan.rs"
     ];
 
     pub fn expand() {

--- a/src/packet/ethernet.rs.in
+++ b/src/packet/ethernet.rs.in
@@ -68,6 +68,8 @@ pub mod EtherTypes {
     pub const Rarp: EtherType = EtherType(0x8035);
     /// Internet Protocol version 6 (IPv6) [RFC7042]
     pub const Ipv6: EtherType = EtherType(0x86DD);
+    /// VLAN-tagged frame (IEEE 802.1Q)
+    pub const Vlan: EtherType = EtherType(0x8100);
 }
 
 /// Represents the Ethernet ethertype field.

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -98,3 +98,4 @@ pub mod udp;
 pub mod tcp;
 pub mod arp;
 pub mod icmp;
+pub mod vlan;

--- a/src/packet/vlan.rs
+++ b/src/packet/vlan.rs
@@ -1,0 +1,7 @@
+//! VLAN packet abstraction
+
+#[cfg(feature = "with-syntex")]
+include!(concat!(env!("OUT_DIR"), "/vlan.rs"));
+
+#[cfg(not(feature = "with-syntex"))]
+include!("vlan.rs.in");

--- a/src/packet/vlan.rs.in
+++ b/src/packet/vlan.rs.in
@@ -1,0 +1,91 @@
+use packet::{Packet, PrimitiveValues};
+use packet::ethernet::{EtherType, EtherTypes};
+use pnet_macros_support::types::*;
+
+/// Represents an IEEE 802.1p class of service
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ClassOfService(pub u3);
+
+impl ClassOfService {
+    /// Create a new ClassOfService
+    pub fn new(value: u3) -> ClassOfService {
+        ClassOfService(value)
+    }
+}
+
+impl PrimitiveValues for ClassOfService {
+    type T = (u3,);
+    fn to_primitive_values(&self) -> (u3,) {
+        (self.0,)
+    }
+}
+
+/// IEEE 802.1p classes of service as defined in
+/// https://en.wikipedia.org/wiki/IEEE_P802.1p
+#[allow(non_snake_case)]
+#[allow(non_upper_case_globals)]
+pub mod ClassesOfService {
+    use super::ClassOfService;
+
+    /// Background
+    pub const BK: ClassOfService = ClassOfService(1);
+
+    /// Best Effort
+    pub const BE: ClassOfService = ClassOfService(0);
+
+    /// Excellent Effort
+    pub const EE: ClassOfService = ClassOfService(2);
+
+    /// Critical Applications
+    pub const CA: ClassOfService = ClassOfService(3);
+
+    /// Video, < 100 ms latency
+    pub const VI: ClassOfService = ClassOfService(4);
+
+    /// Voice, < 10 ms latency
+    pub const VO: ClassOfService = ClassOfService(5);
+
+    /// Internetwork Control
+    pub const IC: ClassOfService = ClassOfService(6);
+
+    /// Network Control
+    pub const NC: ClassOfService = ClassOfService(7);
+}
+
+/// Represents a VLAN-tagged packet
+#[packet]
+pub struct Vlan {
+    #[construct_with(u3)]
+    priority_code_point: ClassOfService,
+    drop_eligible_indicator: u1,
+    vlan_identifier: u12be,
+    #[construct_with(u16be)]
+    ethertype: EtherType,
+    #[payload]
+    payload: Vec<u8>,
+}
+
+#[test]
+fn vlan_packet_test() {
+    let mut packet = [0u8; 4];
+    {
+        let mut vlan_header = MutableVlanPacket::new(&mut packet[..]).unwrap();
+        vlan_header.set_priority_code_point(ClassesOfService::BE);
+        assert_eq!(vlan_header.get_priority_code_point(), ClassesOfService::BE);
+
+        vlan_header.set_drop_eligible_indicator(0);
+        assert_eq!(vlan_header.get_drop_eligible_indicator(), 0);
+
+        vlan_header.set_ethertype(EtherTypes::Ipv4);
+        assert_eq!(vlan_header.get_ethertype(), EtherTypes::Ipv4);
+
+        vlan_header.set_vlan_identifier(0x100);
+        assert_eq!(vlan_header.get_vlan_identifier(), 0x100);
+    }
+
+    let ref_packet = [0x01,  // PCP, DEI, and first nibble of VID
+                      0x00,  // Remainder of VID
+                      0x08,  // First byte of ethertype
+                      0x00]; // Second byte of ethertype
+    assert_eq!(&ref_packet[..], &packet[..]);
+}


### PR DESCRIPTION
Implements a simple parser for 802.1Q tags, fixing https://github.com/libpnet/libpnet/issues/172.