### PR TITLE
Disable travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: rust
-cache:
-    directories:
-        - $HOME/.cargo
 rust:
     - 1.7.0
     - stable


### PR DESCRIPTION
This was causing consistent build failures, so the cache is now disabled.