### PR TITLE
support Vec<u{16,24,32,..}> in packets

### DIFF
--- a/pnet_macros/src/decorator.rs
+++ b/pnet_macros/src/decorator.rs
@@ -1173,6 +1173,37 @@ fn generate_accessor_op_str(name: &str,
     op_strings
 }
 
+#[test]
+fn test_generate_accessor_op_str() {
+
+    {
+        let ops = operations(0, 24).unwrap();
+        let result = generate_accessor_op_str("test", "u24be", &ops);
+        let expected = "let b0 = ((test[co + 0] as u24be) << 16) as u24be;\n\
+                    let b1 = ((test[co + 1] as u24be) << 8) as u24be;\n\
+                    let b2 = ((test[co + 2] as u24be)) as u24be;\n\n\
+                    b0 | b1 | b2\n";
+
+        assert_eq!(result, expected);
+    }
+
+    {
+        let ops = operations(0, 16).unwrap();
+        let result = generate_accessor_op_str("test", "u16be", &ops);
+        let expected = "let b0 = ((test[co + 0] as u16be) << 8) as u16be;\n\
+                    let b1 = ((test[co + 1] as u16be)) as u16be;\n\n\
+                    b0 | b1\n";
+        assert_eq!(result, expected);
+    }
+
+    {
+        let ops = operations(0, 8).unwrap();
+        let result = generate_accessor_op_str("test", "u8", &ops);
+        let expected = "(test[co] as u8)";
+        assert_eq!(result, expected);
+    }
+}
+
 /// Given the name of a field, and a set of operations required to get the value of that field,
 /// return the Rust code required to get the field.
 fn generate_accessor_str(name: &str,

--- a/pnet_macros/src/decorator.rs
+++ b/pnet_macros/src/decorator.rs
@@ -537,7 +537,7 @@ fn handle_vec_primitive(cx: &mut GenContext,
                                         let end = current_offset + {packet_length};
 
                                         let packet = &_self.packet[current_offset..end];
-                                        let mut vec : Vec<{inner_ty_str}> = Vec::with_capacity(packet.len());
+                                        let mut vec: Vec<{inner_ty_str}> = Vec::with_capacity(packet.len());
                                         let mut co = 0;
                                         for _ in 0..vec.capacity() {{
                                             vec.push({{
@@ -545,7 +545,6 @@ fn handle_vec_primitive(cx: &mut GenContext,
                                             }});
                                             co += {size};
                                         }}
-                                        //vec.extend_from_slice(packet);
                                         vec
                                     }}
                                     ",

--- a/pnet_macros/tests/run-pass/variable_length_fields.rs
+++ b/pnet_macros/tests/run-pass/variable_length_fields.rs
@@ -10,6 +10,9 @@
 #![plugin(pnet_macros_plugin)]
 
 extern crate pnet;
+extern crate pnet_macros_support;
+
+use pnet_macros_support::types::*;
 
 #[packet]
 pub struct PacketWithPayload {
@@ -20,8 +23,34 @@ pub struct PacketWithPayload {
     payload: Vec<u8>
 }
 
+#[packet]
+pub struct PacketWithU16 {
+    length: u8,
+    #[length = "length"]
+    data: Vec<u16be>,
+    #[payload]
+    payload: Vec<u8>
+}
+
 fn length_fn(_: &PacketWithPayloadPacket) -> usize {
     unimplemented!()
 }
 
-fn main() {}
+fn main() {
+
+    // Test if we can add data to the u16be
+    let mut packet = [0u8; 7];
+    {
+        let mut p = MutablePacketWithU16Packet::new(&mut packet[..]).unwrap();
+        p.set_length(6);
+        p.set_data(&vec![0x0001, 0x1223, 0x3ff4]);
+    }
+
+    let ref_packet = [0x06, /* length */
+                      0x00, 0x01,
+                      0x12, 0x23,
+                      0x3f, 0xf4];
+
+    assert_eq!(&ref_packet[..], &packet[..]);
+
+}


### PR DESCRIPTION
Currently, `Vec<T>` is only allowed in a #[packet] struct if `T` is u8 or another #[packet] struct.

This adds support for when `T` is a byte-aligned big-endian primitive (e.g. u16be, u24be, u32be, u40be, u48be, u56be, and u64be). This is useful if you have an array of 2-byte values in a packet header (such as in TLS cipher suites, or elliptic curves).

The GRE packet definition would also benefit from this, as it is currently using a #[packet] definition U16BE and U32BE, which carry extra weight with unused payloads, and prevent those fields from having easily-defined constants (since you can't instantiate the payload Vec<u8> at compile time).