### PR TITLE
Add dummy datalink backend for testing

### DIFF
--- a/benches/rs_receiver.rs
+++ b/benches/rs_receiver.rs
@@ -28,7 +28,7 @@ fn main() {
                               .unwrap();
 
     // Create a channel to receive on
-    let mut rx = match datalink::channel(&interface, &Default::default()) {
+    let mut rx = match datalink::channel(&interface, Default::default()) {
         Ok(Ethernet(_, rx)) => rx,
         Ok(_) => panic!("rs_sender: unhandled channel type"),
         Err(e) => panic!("rs_benchmark: unable to create channel: {}", e)

--- a/benches/rs_sender.rs
+++ b/benches/rs_sender.rs
@@ -87,7 +87,7 @@ fn main() {
                               .unwrap();
 
     // Create a channel to send on
-    let mut tx = match datalink::channel(interface, &Default::default()) {
+    let mut tx = match datalink::channel(interface, Default::default()) {
         Ok(Ethernet(tx, _)) => tx,
         Ok(_) => panic!("rs_sender: unhandled channel type"),
         Err(e) => panic!("rs_sender: unable to create channel: {}", e)

--- a/examples/packetdump.rs
+++ b/examples/packetdump.rs
@@ -165,7 +165,7 @@ fn main() {
                               .unwrap();
 
     // Create a channel to receive on
-    let (_, mut rx) = match datalink::channel(&interface, &Default::default()) {
+    let (_, mut rx) = match datalink::channel(&interface, Default::default()) {
         Ok(Ethernet(tx, rx)) => (tx, rx),
         Ok(_) => panic!("packetdump: unhandled channel type: {}"),
         Err(e) => panic!("packetdump: unable to create channel: {}", e),

--- a/src/datalink/bpf.rs
+++ b/src/datalink/bpf.rs
@@ -66,7 +66,7 @@ impl Default for Config {
 /// Create a datalink channel using the /dev/bpf device
 // NOTE buffer must be word aligned.
 #[inline]
-pub fn channel(network_interface: &NetworkInterface, config: &Config)
+pub fn channel(network_interface: &NetworkInterface, config: Config)
     -> io::Result<datalink::Channel> {
     #[cfg(target_os = "freebsd")]
     fn get_fd(_attempts: usize) -> libc::c_int {

--- a/src/datalink/dummy.rs
+++ b/src/datalink/dummy.rs
@@ -17,6 +17,7 @@ use std::time;
 use datalink::{self, EthernetDataLinkChannelIterator, EthernetDataLinkReceiver,
                EthernetDataLinkSender, NetworkInterface};
 use packet::ethernet::{EthernetPacket, MutableEthernetPacket};
+use packet::Packet;
 use util::MacAddr;
 
 /// Configuration for the dummy datalink backend
@@ -99,10 +100,12 @@ impl EthernetDataLinkSender for MockEthernetDataLinkSender {
     }
 
     fn send_to(&mut self,
-               _packet: &EthernetPacket,
+               packet: &EthernetPacket,
                _dst: Option<NetworkInterface>)
         -> Option<io::Result<()>> {
-        panic!("Not implemented in mock");
+        let buffer = packet.packet().to_vec();
+        self.out_packets.send(buffer).unwrap_or(());
+        Some(Ok(()))
     }
 }
 

--- a/src/datalink/dummy.rs
+++ b/src/datalink/dummy.rs
@@ -20,7 +20,8 @@ use packet::ethernet::{EthernetPacket, MutableEthernetPacket};
 use packet::Packet;
 use util::MacAddr;
 
-/// Configuration for the dummy datalink backend
+/// Configuration for the dummy datalink backend. Contains `std::sync::mpsc`
+/// channels that are used to communicate with the fake network.
 #[derive(Debug)]
 pub struct Config {
     /// The fake network will pull packets (or errors) form this `Receiver`
@@ -29,9 +30,9 @@ pub struct Config {
     in_packets_tx: Option<Sender<io::Result<Box<[u8]>>>>,
 
     /// All packets sent to this fake network will end up on this `Sender`
-    pub out_packets_tx: Sender<Vec<u8>>,
+    pub out_packets_tx: Sender<Box<[u8]>>,
 
-    out_packets_rx: Option<Receiver<Vec<u8>>>,
+    out_packets_rx: Option<Receiver<Box<[u8]>>>,
 }
 
 impl Config {
@@ -41,7 +42,7 @@ impl Config {
     }
 
     /// Get the `Receiver` handle where packets sent to the fake network can be read
-    pub fn read_handle(&mut self) -> Option<Receiver<Vec<u8>>> {
+    pub fn read_handle(&mut self) -> Option<Receiver<Box<[u8]>>> {
         self.out_packets_rx.take()
     }
 }
@@ -80,22 +81,27 @@ pub fn channel(_: &NetworkInterface, config: Config) -> io::Result<datalink::Cha
 
 
 struct MockEthernetDataLinkSender {
-    out_packets: Sender<Vec<u8>>,
+    out_packets: Sender<Box<[u8]>>,
 }
 
 impl EthernetDataLinkSender for MockEthernetDataLinkSender {
     fn build_and_send(&mut self,
-                      _num_packets: usize,
+                      num_packets: usize,
                       packet_size: usize,
                       func: &mut FnMut(MutableEthernetPacket))
         -> Option<io::Result<()>> {
-        let mut buffer = vec![0; packet_size];
-        {
-            let pkg = MutableEthernetPacket::new(&mut buffer[..]).unwrap();
-            func(pkg);
+        for _ in 0..num_packets {
+            let mut buffer = vec![0; packet_size];
+            {
+                let pkg = match MutableEthernetPacket::new(&mut buffer[..]) {
+                    Some(pkg) => pkg,
+                    None => return None,
+                };
+                func(pkg);
+            }
+            // Send the data to the queue. Don't care if it's closed
+            self.out_packets.send(buffer.into_boxed_slice()).unwrap_or(());
         }
-        // Send the data to the queue. Don't care if it's closed
-        self.out_packets.send(buffer).unwrap_or(());
         Some(Ok(()))
     }
 
@@ -104,7 +110,7 @@ impl EthernetDataLinkSender for MockEthernetDataLinkSender {
                _dst: Option<NetworkInterface>)
         -> Option<io::Result<()>> {
         let buffer = packet.packet().to_vec();
-        self.out_packets.send(buffer).unwrap_or(());
+        self.out_packets.send(buffer.into_boxed_slice()).unwrap_or(());
         Some(Ok(()))
     }
 }
@@ -154,7 +160,7 @@ impl<'a> EthernetDataLinkChannelIterator<'a> for MockEthernetDataLinkChannelIter
     }
 }
 
-/// Get three fake interfaces generated with `dummy_interface`
+/// Get three fake interfaces generated with `dummy_interface`.
 pub fn interfaces() -> Vec<NetworkInterface> {
     (0..3).map(|i| dummy_interface(i)).collect()
 }
@@ -170,5 +176,166 @@ pub fn dummy_interface(i: u8) -> NetworkInterface {
         mac: Some(MacAddr::new(1, 2, 3, 4, 5, i)),
         ips: None,
         flags: 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc::{self, Receiver, Sender, TryRecvError};
+    use std::io;
+    use std::thread::{sleep, spawn};
+    use std::time::Duration;
+
+    use packet::{MutablePacket, Packet};
+    use packet::ethernet::EthernetPacket;
+    use datalink::{EthernetDataLinkReceiver, EthernetDataLinkSender};
+    use datalink::Channel::Ethernet;
+
+    #[test]
+    fn send_too_small_packet_size() {
+        let (_, read_handle, mut tx, _) = create_net();
+        // Check that it fails to send with too small packet sizes
+        assert!(tx.build_and_send(1, 0, &mut |_| {}).is_none());
+    }
+
+    #[test]
+    fn send_nothing() {
+        let (_, read_handle, mut tx, _) = create_net();
+        // Check that sending zero packets yields zero packets
+        tx.build_and_send(0,
+                            20,
+                            &mut |_| {
+                                panic!("Should not be called");
+                            })
+            .unwrap()
+            .unwrap();
+        assert!(read_handle.try_recv().is_err());
+    }
+
+    #[test]
+    fn send_one_packet() {
+        let (_, read_handle, mut tx, _) = create_net();
+        // Check that sending one packet yields one packet
+        tx.build_and_send(1,
+                            20,
+                            &mut |mut pkg| {
+                                assert_eq!(pkg.packet().len(), 20);
+                                pkg.packet_mut()[0] = 9;
+                                pkg.packet_mut()[19] = 201;
+                            })
+            .unwrap()
+            .unwrap();
+        let pkg = read_handle.try_recv().expect("Expected one packet to be sent");
+        assert!(read_handle.try_recv().is_err());
+        assert_eq!(pkg.len(), 20);
+        assert_eq!(pkg[0], 9);
+        assert_eq!(pkg[19], 201);
+    }
+
+    #[test]
+    fn send_multiple_packets() {
+        let (_, read_handle, mut tx, _) = create_net();
+        // Check that sending multiple packets does the correct thing
+        let mut closure_counter = 0;
+        tx.build_and_send(3,
+                            20,
+                            &mut |mut pkg| {
+                                pkg.packet_mut()[0] = closure_counter;
+                                closure_counter += 1;
+                            })
+            .unwrap()
+            .unwrap();
+        for i in 0..3 {
+            let pkg = read_handle.try_recv().expect("Expected a packet");
+            assert_eq!(pkg[0], i);
+        }
+        assert!(read_handle.try_recv().is_err());
+    }
+
+    #[test]
+    fn send_to() {
+        let (_, read_handle, mut tx, _) = create_net();
+        let mut buffer = vec![0; 20];
+        buffer[1] = 34;
+        buffer[18] = 76;
+        let pkg = EthernetPacket::new(&buffer[..]).unwrap();
+
+        tx.send_to(&pkg, None).unwrap().unwrap();
+        let pkg = read_handle.try_recv().expect("Expected one packet to be sent");
+        assert!(read_handle.try_recv().is_err());
+        assert_eq!(pkg.len(), 20);
+        assert_eq!(pkg[1], 34);
+        assert_eq!(pkg[18], 76);
+    }
+
+    #[test]
+    fn read_nothing() {
+        let (inject_handle, _, _, mut rx) = create_net();
+        let (control_tx, control_rx) = mpsc::channel();
+        spawn(move || {
+            let mut rx_iter = rx.iter();
+            rx_iter.next().expect("Should not happen 1");
+            control_tx.send(()).expect("Should not happen 2");
+        });
+        sleep(Duration::new(0, 1_000_000));
+        match control_rx.try_recv() {
+            Ok(_) => panic!("Nothing should have arrived"),
+            Err(TryRecvError::Disconnected) => panic!("Thread should not have quit"),
+            Err(TryRecvError::Empty) => (),
+        }
+    }
+
+    #[test]
+    fn read_one_pkg() {
+        let (inject_handle, _, _, mut rx) = create_net();
+
+        let buffer = vec![0; 20];
+        inject_handle.send(Ok(buffer.into_boxed_slice())).unwrap();
+
+        let mut rx_iter = rx.iter();
+        let pkg = rx_iter.next().expect("Expected a packet");
+        assert_eq!(pkg.packet().len(), 20);
+    }
+
+    #[test]
+    fn read_multiple_pkgs() {
+        let (inject_handle, _, _, mut rx) = create_net();
+
+        for i in 0..3 {
+            let buffer = vec![i; 20];
+            inject_handle.send(Ok(buffer.into_boxed_slice())).unwrap();
+        }
+
+        let mut rx_iter = rx.iter();
+        {
+            let pkg1 = rx_iter.next().expect("Expected a packet");
+            assert_eq!(pkg1.packet()[0], 0);
+        }
+        {
+            let pkg2 = rx_iter.next().expect("Expected a packet");
+            assert_eq!(pkg2.packet()[0], 1);
+        }
+        {
+            let pkg3 = rx_iter.next().expect("Expected a packet");
+            assert_eq!(pkg3.packet()[0], 2);
+        }
+    }
+
+    fn create_net()
+        -> (Sender<io::Result<Box<[u8]>>>,
+            Receiver<Box<[u8]>>,
+            Box<EthernetDataLinkSender>,
+            Box<EthernetDataLinkReceiver>) {
+        let interface = super::dummy_interface(56);
+        let mut config = super::Config::default();
+        let inject_handle = config.inject_handle().unwrap();
+        let read_handle = config.read_handle().unwrap();
+
+        let channel = super::channel(&interface, config);
+        let (tx, rx) = match channel {
+            Ok(Ethernet(tx, rx)) => (tx, rx),
+            _ => panic!("Not a valid channel returned"),
+        };
+        (inject_handle, read_handle, tx, rx)
     }
 }

--- a/src/datalink/dummy.rs
+++ b/src/datalink/dummy.rs
@@ -153,7 +153,7 @@ impl<'a> EthernetDataLinkChannelIterator<'a> for MockEthernetDataLinkChannelIter
                 // inject_handle. This means there will never be any more packets sent to this
                 // dummy network. To simulate an idle network we block and sleep forever here.
                 loop {
-                    thread::sleep(time::Duration::new(::std::u64::MAX, 0));
+                    thread::sleep(time::Duration::new(10, 0));
                 }
             }
         }

--- a/src/datalink/dummy.rs
+++ b/src/datalink/dummy.rs
@@ -1,0 +1,152 @@
+// Copyright (c) 2016 Linus Färnstrand <faern@faern.net>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Support for sending and receiving data link layer packets on a fake network managed
+//! by in memory FIFO queues. Useful for writing tests.
+
+use std::io;
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::thread;
+use std::time;
+
+use datalink::{self, EthernetDataLinkChannelIterator, EthernetDataLinkReceiver,
+               EthernetDataLinkSender, NetworkInterface};
+use packet::ethernet::{EthernetPacket, MutableEthernetPacket};
+use util::MacAddr;
+
+/// Configuration for the dummy datalink backend
+#[derive(Debug)]
+pub struct Config {
+    /// The fake network will pull packets (or errors) form this `Receiver`
+    pub in_packets: Receiver<io::Result<Box<[u8]>>>,
+
+    /// All packets sent to this fake network will end up on this `Sender`
+    pub out_packets: Sender<Vec<u8>>,
+}
+
+impl<'a> From<&'a datalink::Config> for Config {
+    /// This conversion will not allow injecting and reading packets from the dummy network.
+    /// To do that please create your own `dummy::Config`
+    fn from(_config: &datalink::Config) -> Config {
+        Config {
+            in_packets: mpsc::channel().1,
+            out_packets: mpsc::channel().0,
+        }
+    }
+}
+
+impl Default for Config {
+    /// This conversion will not allow injecting and reading packets from the dummy network.
+    /// To do that please create your own `dummy::Config`
+    fn default() -> Config {
+        Config {
+            in_packets: mpsc::channel().1,
+            out_packets: mpsc::channel().0,
+        }
+    }
+}
+
+/// Create a data link channel backed by FIFO queues. Useful for debugging and testing.
+pub fn channel(_: &NetworkInterface, config: Config) -> io::Result<datalink::Channel> {
+    let sender = Box::new(MockEthernetDataLinkSender { out_packets: config.out_packets_tx });
+    let receiver =
+        Box::new(MockEthernetDataLinkReceiver { in_packets: Some(config.in_packets_rx) });
+
+    Ok(datalink::Channel::Ethernet(sender, receiver))
+}
+
+
+struct MockEthernetDataLinkSender {
+    out_packets: Sender<Vec<u8>>,
+}
+
+impl EthernetDataLinkSender for MockEthernetDataLinkSender {
+    fn build_and_send(&mut self,
+                      _num_packets: usize,
+                      packet_size: usize,
+                      func: &mut FnMut(MutableEthernetPacket))
+        -> Option<io::Result<()>> {
+        let mut buffer = vec![0; packet_size];
+        {
+            let pkg = MutableEthernetPacket::new(&mut buffer[..]).unwrap();
+            func(pkg);
+        }
+        // Send the data to the queue. Don't care if it's closed
+        self.out_packets.send(buffer).unwrap_or(());
+        Some(Ok(()))
+    }
+
+    fn send_to(&mut self,
+               _packet: &EthernetPacket,
+               _dst: Option<NetworkInterface>)
+        -> Option<io::Result<()>> {
+        panic!("Not implemented in mock");
+    }
+}
+
+struct MockEthernetDataLinkReceiver {
+    in_packets: Option<Receiver<io::Result<Box<[u8]>>>>,
+}
+
+impl EthernetDataLinkReceiver for MockEthernetDataLinkReceiver {
+    fn iter<'a>(&'a mut self) -> Box<EthernetDataLinkChannelIterator + 'a> {
+        Box::new(MockEthernetDataLinkChannelIterator {
+            in_packets: self.in_packets.take().expect("Only one receiver allowed"),
+            used_packets: vec![],
+        })
+    }
+}
+
+struct MockEthernetDataLinkChannelIterator {
+    in_packets: Receiver<io::Result<Box<[u8]>>>,
+    used_packets: Vec<Box<[u8]>>,
+}
+
+impl<'a> EthernetDataLinkChannelIterator<'a> for MockEthernetDataLinkChannelIterator {
+    fn next(&mut self) -> io::Result<EthernetPacket> {
+        match self.in_packets.recv() {
+            Ok(result) => {
+                match result {
+                    Ok(buffer) => {
+                        self.used_packets.push(buffer);
+                        let buffer_ref = &*self.used_packets[self.used_packets.len() - 1];
+                        let packet = EthernetPacket::new(buffer_ref).unwrap();
+                        Ok(packet)
+                    }
+                    Err(e) => Err(e),
+                }
+            }
+            Err(_) => {
+                // When we run out of test packets we sleep forever.
+                // Simulating no more packets arrive
+                loop {
+                    thread::sleep(time::Duration::new(1, 0));
+                }
+            }
+        }
+    }
+}
+
+/// Get three fake interfaces generated with `dummy_interface`
+pub fn interfaces() -> Vec<NetworkInterface> {
+    (0..3).map(|i| dummy_interface(i)).collect()
+}
+
+/// Generates a fake `NetworkInterface`.
+/// The name of the interface will be `ethX` where X is the integer `i`.
+/// The index will be `i`.
+/// The MAC will be `01:02:03:04:05:i`.
+pub fn dummy_interface(i: u8) -> NetworkInterface {
+    NetworkInterface {
+        name: format!("eth{}", i),
+        index: i as u32,
+        mac: Some(MacAddr::new(1, 2, 3, 4, 5, i)),
+        ips: None,
+        flags: 0,
+    }
+}

--- a/src/datalink/linux.rs
+++ b/src/datalink/linux.rs
@@ -80,7 +80,7 @@ impl Default for Config {
 
 /// Create a data link channel using the Linux's AF_PACKET socket type
 #[inline]
-pub fn channel(network_interface: &NetworkInterface, config: &Config)
+pub fn channel(network_interface: &NetworkInterface, config: Config)
     -> io::Result<datalink::Channel> {
     let eth_p_all = 0x0003;
     let (typ, proto) = match config.channel_type {

--- a/src/datalink/mod.rs
+++ b/src/datalink/mod.rs
@@ -128,9 +128,9 @@ impl Default for Config {
 /// When matching on the returned channel, make sure to include a catch-all so that code doesn't
 /// break when new channel types are added.
 #[inline]
-pub fn channel(network_interface: &NetworkInterface, configuration: &Config)
+pub fn channel(network_interface: &NetworkInterface, configuration: Config)
     -> io::Result<Channel> {
-    backend::channel(network_interface, &configuration.into())
+    backend::channel(network_interface, (&configuration).into())
 }
 
 macro_rules! dls {

--- a/src/datalink/mod.rs
+++ b/src/datalink/mod.rs
@@ -52,6 +52,8 @@ mod backend;
 #[cfg(feature = "netmap")]
 pub mod netmap;
 
+pub mod dummy;
+
 /// Type of data link channel to present (Linux only)
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum ChannelType {

--- a/src/datalink/netmap.rs
+++ b/src/datalink/netmap.rs
@@ -110,7 +110,7 @@ impl Default for Config {
 
 /// Create a datalink channel using the netmap library
 #[inline]
-pub fn channel(network_interface: &NetworkInterface, _config: &Config)
+pub fn channel(network_interface: &NetworkInterface, _config: Config)
     -> io::Result<datalink::Channel> {
     // FIXME probably want one for each of send/recv
     let desc = NmDesc::new(network_interface);

--- a/src/datalink/winpcap.rs
+++ b/src/datalink/winpcap.rs
@@ -82,7 +82,7 @@ impl Default for Config {
 
 /// Create a datalink channel using the WinPcap library
 #[inline]
-pub fn channel(network_interface: &NetworkInterface, config: &Config)
+pub fn channel(network_interface: &NetworkInterface, config: Config)
     -> io::Result<datalink::Channel> {
     let mut read_buffer = Vec::new();
     read_buffer.resize(config.read_buffer_size, 0u8);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@
 //!                               .unwrap();
 //!
 //!     // Create a new channel, dealing with layer 2 packets
-//!     let (mut tx, mut rx) = match datalink::channel(&interface, &Default::default()) {
+//!     let (mut tx, mut rx) = match datalink::channel(&interface, Default::default()) {
 //!         Ok(Ethernet(tx, rx)) => (tx, rx),
 //!         Ok(_) => panic!("Unhandled channel type"),
 //!         Err(e) => panic!("An error occurred when creating the datalink channel: {}", e)

--- a/src/test.rs
+++ b/src/test.rs
@@ -353,7 +353,7 @@ fn layer2() {
 
     let (tx, rx) = channel();
 
-    let dlc = datalink::channel(&interface, &Default::default());
+    let dlc = datalink::channel(&interface, Default::default());
     let (mut dltx, mut dlrx) = match dlc {
         Ok(Ethernet(tx, rx)) => (tx, rx),
         Ok(_) => panic!("layer2: unexpected L2 packet type"),


### PR DESCRIPTION
Adding a datalink backend for testing. It's based on in memory FIFO queues that can be used to inject and read packets on the fake network. Useful for testing stuff built on top of pnet.

@mrmonday 