### PR TITLE
Make all types inside IcmpPacket hashable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pnet"
-version = "0.11.0"
+version = "0.11.1"
 authors = [ "Robert Clipsham <robert@octarineparrot.com>" ]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"

--- a/src/packet/icmp.rs.in
+++ b/src/packet/icmp.rs.in
@@ -10,7 +10,7 @@ use packet::{Packet, PrimitiveValues};
 use pnet_macros_support::types::*;
 
 /// Represents the "ICMP type" header field.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IcmpType(pub u8);
 
 impl IcmpType {
@@ -28,7 +28,7 @@ impl PrimitiveValues for IcmpType {
 }
 
 /// Represents the "ICMP code" header field.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IcmpCode(pub u8);
 
 impl IcmpCode {
@@ -126,7 +126,7 @@ pub mod echo_reply {
     use pnet_macros_support::types::*;
 
     /// Represent the "identifier" field of the ICMP echo replay header.
-    #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct Identifier(pub u16);
 
     impl Identifier {
@@ -144,7 +144,7 @@ pub mod echo_reply {
     }
 
     /// Represent the "sequence number" field of the ICMP echo replay header.
-    #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct SequenceNumber(pub u16);
 
     impl SequenceNumber {
@@ -193,7 +193,7 @@ pub mod echo_request {
     use pnet_macros_support::types::*;
 
     /// Represents an indentifier field
-    #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct Identifier(pub u16);
 
     impl Identifier {
@@ -211,7 +211,7 @@ pub mod echo_request {
     }
 
     /// Represents a sequence number field
-    #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct SequenceNumber(pub u16);
 
     impl SequenceNumber {


### PR DESCRIPTION
I can't see a reason not to have them hashable. I need some of them hashable in [librips](https://github.com/faern/librips)

@mrmonday 