### PR TITLE
Little endian?

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pnet"
-version = "0.15.0"
+version = "0.16.0"
 authors = [ "Robert Clipsham <robert@octarineparrot.com>" ]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To use `libpnet` in your project, add the following to your Cargo.toml:
 
 ```
 [dependencies.pnet]
-version = "0.15.0"
+version = "0.16.0"
 ```
 
 `libpnet` should work on any Rust channel (stable, beta, or nightly), starting

--- a/pnet_macros/Cargo.toml
+++ b/pnet_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pnet_macros"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Robert Clipsham <robert@octarineparrot.com>"]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"

--- a/pnet_macros/src/util.rs
+++ b/pnet_macros/src/util.rs
@@ -915,6 +915,7 @@ fn test_to_mutator() {
 /// Takes a set of operations to get a field in big endian, and converts them to get the field in
 /// little endian.
 pub fn to_little_endian(_ops: Vec<GetOperation>) -> Vec<GetOperation> {
-    // FIXME
-    unimplemented!()
+    let mut ops = _ops.clone();
+    ops.reverse();
+    ops
 }

--- a/pnet_macros/src/util.rs
+++ b/pnet_macros/src/util.rs
@@ -916,6 +916,8 @@ fn test_to_mutator() {
 /// little endian.
 pub fn to_little_endian(_ops: Vec<GetOperation>) -> Vec<GetOperation> {
     let mut ops = _ops.clone();
-    ops.reverse();
+    for (op, be_op) in ops.iter_mut().zip(_ops.iter().rev()) {
+	op.shiftl = be_op.shiftl;
+    }
     ops
 }

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 //! Provides interfaces for interacting with packets and headers
-
+#![allow(missing_docs)]
 #![macro_use]
 
 use std::ops::{Deref, DerefMut, Index, IndexMut, Range, RangeFrom, RangeFull, RangeTo};
@@ -81,20 +81,22 @@ macro_rules! impl_index_mut {
 }
 
 #[derive(PartialEq)]
-enum PacketData<'p> {
+pub enum PacketData<'p> {
+    /// Packet owns its contents
     Owned(Vec<u8>),
+    /// Packet borrows its contents
     Borrowed(&'p [u8]),
 }
 
 impl<'p> PacketData<'p> {
-    fn as_slice(&self) -> &[u8] {
+    pub fn as_slice(&self) -> &[u8] {
         match self {
             &PacketData::Owned(ref data) => data.deref(),
             &PacketData::Borrowed(ref data) => data,
         }
     }
 
-    fn to_immutable(self) -> PacketData<'p> {
+    pub fn to_immutable(self) -> PacketData<'p> {
         self
     }
 
@@ -110,27 +112,27 @@ impl_index!(PacketData, RangeFrom<usize>, [u8]);
 impl_index!(PacketData, RangeFull, [u8]);
 
 #[derive(PartialEq)]
-enum MutPacketData<'p> {
+pub enum MutPacketData<'p> {
     Owned(Vec<u8>),
     Borrowed(&'p mut [u8]),
 }
 
 impl<'p> MutPacketData<'p> {
-    fn as_slice(&self) -> &[u8] {
+    pub fn as_slice(&self) -> &[u8] {
         match self {
             &MutPacketData::Owned(ref data) => data.deref(),
             &MutPacketData::Borrowed(ref data) => data,
         }
     }
 
-    fn as_mut_slice(&mut self) -> &mut [u8] {
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
         match self {
             &mut MutPacketData::Owned(ref mut data) => data.deref_mut(),
             &mut MutPacketData::Borrowed(ref mut data) => data,
         }
     }
 
-    fn to_immutable(self) -> PacketData<'p> {
+    pub fn to_immutable(self) -> PacketData<'p> {
         match self {
             MutPacketData::Owned(data) => PacketData::Owned(data),
             MutPacketData::Borrowed(data) => PacketData::Borrowed(data),


### PR DESCRIPTION
I just started working on [Netlink](https://en.wikipedia.org/wiki/Netlink) library based on libpnet/pnet_macros. The problem is that Netlink messages are encoded in little endian.
It seems like this little diff works as intended.
