### PR TITLE
Prevent pselect timeout parameter from being optimized out

### DIFF
--- a/src/datalink/bpf.rs
+++ b/src/datalink/bpf.rs
@@ -276,7 +276,7 @@ impl EthernetDataLinkSender for DataLinkSenderImpl {
                                   ptr::null_mut(),
                                   &mut self.fd_set as *mut libc::fd_set,
                                   ptr::null_mut(),
-                                  self.timeout.map(|to| &to as *const libc::timespec)
+                                  self.timeout.as_ref().map(|to| to as *const libc::timespec)
                                   .unwrap_or(ptr::null()),
                                   ptr::null())
                 };
@@ -317,7 +317,7 @@ impl EthernetDataLinkSender for DataLinkSenderImpl {
                           ptr::null_mut(),
                           &mut self.fd_set as *mut libc::fd_set,
                           ptr::null_mut(),
-                          self.timeout.map(|to| &to as *const libc::timespec)
+                          self.timeout.as_ref().map(|to| to as *const libc::timespec)
                           .unwrap_or(ptr::null()),
                           ptr::null())
         };
@@ -379,7 +379,7 @@ impl<'a> EthernetDataLinkChannelIterator<'a> for DataLinkChannelIteratorImpl<'a>
                               &mut self.pc.fd_set as *mut libc::fd_set,
                               ptr::null_mut(),
                               ptr::null_mut(),
-                              self.pc.timeout.map(|to| &to as *const libc::timespec)
+                              self.pc.timeout.as_ref().map(|to| to as *const libc::timespec)
                               .unwrap_or(ptr::null()),
                               ptr::null())
             };

--- a/src/datalink/linux.rs
+++ b/src/datalink/linux.rs
@@ -214,7 +214,7 @@ impl EthernetDataLinkSender for DataLinkSenderImpl {
                                   ptr::null_mut(),
                                   &mut self.fd_set as *mut libc::fd_set,
                                   ptr::null_mut(),
-                                  self.timeout.map(|to| &to as *const libc::timespec)
+                                  self.timeout.as_ref().map(|to| to as *const libc::timespec)
                                   .unwrap_or(ptr::null()),
                                   ptr::null())
                 };
@@ -248,7 +248,7 @@ impl EthernetDataLinkSender for DataLinkSenderImpl {
                           ptr::null_mut(),
                           &mut self.fd_set as *mut libc::fd_set,
                           ptr::null_mut(),
-                          self.timeout.map(|to| &to as *const libc::timespec)
+                          self.timeout.as_ref().map(|to| to as *const libc::timespec)
                           .unwrap_or(ptr::null()),
                           ptr::null())
         };
@@ -295,7 +295,7 @@ impl<'a> EthernetDataLinkChannelIterator<'a> for DataLinkChannelIteratorImpl<'a>
                           &mut self.pc.fd_set as *mut libc::fd_set,
                           ptr::null_mut(),
                           ptr::null_mut(),
-                          self.pc.timeout.map(|to| &to as *const libc::timespec)
+                          self.pc.timeout.as_ref().map(|to| to as *const libc::timespec)
                           .unwrap_or(ptr::null()),
                           ptr::null())
         };


### PR DESCRIPTION
The argument to the map closure may be optimized out by the compiler.
Instead use `as_ref()` to get a reference to the real data.

Fixes #218 