### PR TITLE
Checksum flexibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-    - 1.9.0
+    - 1.11.0
     - stable
     - beta
     - nightly
@@ -19,9 +19,9 @@ matrix:
   allow_failures:
     - rust: nightly
   exclude:
-    - rust: 1.9.0
+    - rust: 1.11.0
       env: PNET_FEATURES="travis nightly clippy" PNET_MACROS_FEATURES="travis clippy"
-    - rust: 1.9.0
+    - rust: 1.11.0
       env: PNET_FEATURES="travis nightly" PNET_MACROS_FEATURES="travis"
     - rust: stable
       env: PNET_FEATURES="travis nightly clippy" PNET_MACROS_FEATURES="travis clippy"

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ version = "0.13.0"
 ```
 
 `libpnet` should work on any Rust channel (stable, beta, or nightly), starting
-with Rust 1.9. When using a nightly version of Rust, you may wish to use pass
+with Rust 1.11. When using a nightly version of Rust, you may wish to use pass
 `--no-default-features --features nightly` to Cargo, to enable faster build
 times.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,11 @@ environment:
   RUST_TEST_THREADS: 1
   matrix:
   - TARGET: x86_64-pc-windows-msvc
-    RUST_CHANNEL: 1.9.0
+    RUST_CHANNEL: 1.11.0
     WPD_LIB_PATH: "C:/dl/wpdpack/WpdPack/Lib/x64/Packet.lib"
     VCVARS: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\amd64\\vcvars64.bat"
   - TARGET: i686-pc-windows-msvc
-    RUST_CHANNEL: 1.9.0
+    RUST_CHANNEL: 1.11.0
     WPD_LIB_PATH: "C:/dl/wpdpack/WpdPack/Lib/Packet.lib"
     VCVARS: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\vcvars32.bat"
   - TARGET: x86_64-pc-windows-msvc

--- a/benches/rs_sender.rs
+++ b/benches/rs_sender.rs
@@ -69,8 +69,8 @@ pub fn build_udp4_packet(packet: &mut [u8], msg: &str) {
         data[4] = msg[4];
     }
 
-    let checksum = udp::ipv4_checksum(&udp_header.to_immutable(),
-                                      source, destination, IpNextHeaderProtocols::Udp);
+    let checksum = udp::ipv4_checksum(&udp_header.to_immutable(), &[],
+                                      source, destination);
     udp_header.set_checksum(checksum);
 }
 

--- a/benches/rs_sender.rs
+++ b/benches/rs_sender.rs
@@ -69,7 +69,7 @@ pub fn build_udp4_packet(packet: &mut [u8], msg: &str) {
         data[4] = msg[4];
     }
 
-    let checksum = udp::ipv4_checksum(&udp_header.to_immutable(), &[],
+    let checksum = udp::ipv4_checksum(&udp_header.to_immutable(),
                                       source, destination);
     udp_header.set_checksum(checksum);
 }

--- a/src/packet/tcp.rs.in
+++ b/src/packet/tcp.rs.in
@@ -235,9 +235,26 @@ fn tcp_options_length(tcp: &TcpPacket) -> usize {
 
 /// Calculate the checksum for a packet built on IPv4
 pub fn ipv4_checksum(packet: &TcpPacket,
-                     extra_data: &[u8],
                      source: Ipv4Addr,
                      destination: Ipv4Addr)
+    -> u16 {
+    ipv4_checksum_adv(packet,
+                      &[],
+                      source,
+                      destination)
+}
+
+/// Calculate the checksum for a packet built on IPv4, Advanced version which
+/// accepts an extra slice of data that will be included in the checksum
+/// as being part of the data portion of the packet.
+///
+/// If `packet` contains an odd number of bytes the last byte will not be
+/// counted as the first byte of a word together with the first byte of
+/// `extra_data`.
+pub fn ipv4_checksum_adv(packet: &TcpPacket,
+                         extra_data: &[u8],
+                         source: Ipv4Addr,
+                         destination: Ipv4Addr)
     -> u16 {
     util::ipv4_checksum(packet.packet(),
                         8,
@@ -298,10 +315,7 @@ fn tcp_header_ipv4_test() {
         let ts = TcpOption::timestamp(743951781, 44056978);
         tcp_header.set_options(&vec![TcpOption::nop(), TcpOption::nop(), ts]);
 
-        let checksum = ipv4_checksum(&tcp_header.to_immutable(),
-                                     &[],
-                                     ipv4_source,
-                                     ipv4_destination);
+        let checksum = ipv4_checksum(&tcp_header.to_immutable(), ipv4_source, ipv4_destination);
         tcp_header.set_checksum(checksum);
         assert_eq!(tcp_header.get_checksum(), 0xc031);
     }

--- a/src/packet/tcp.rs.in
+++ b/src/packet/tcp.rs.in
@@ -235,10 +235,17 @@ fn tcp_options_length(tcp: &TcpPacket) -> usize {
 
 /// Calculate the checksum for a packet built on IPv4
 pub fn ipv4_checksum(packet: &TcpPacket,
+                     extra_data: &[u8],
                      source: Ipv4Addr,
                      destination: Ipv4Addr,
-                     next_level_protocol: IpNextHeaderProtocol) -> u16 {
-    util::ipv4_checksum(packet.packet(), source, destination, next_level_protocol, 8)
+                     next_level_protocol: IpNextHeaderProtocol)
+    -> u16 {
+    util::ipv4_checksum(packet.packet(),
+                        8,
+                        extra_data,
+                        source,
+                        destination,
+                        next_level_protocol)
 }
 
 #[test]
@@ -294,6 +301,7 @@ fn tcp_header_ipv4_test() {
         tcp_header.set_options(&vec![TcpOption::nop(), TcpOption::nop(), ts]);
 
         let checksum = ipv4_checksum(&tcp_header.to_immutable(),
+                                     &[],
                                      ipv4_source,
                                      ipv4_destination,
                                      next_level_protocol);

--- a/src/packet/tcp.rs.in
+++ b/src/packet/tcp.rs.in
@@ -9,7 +9,7 @@
 use packet::Packet;
 use packet::PacketSize;
 use packet::PrimitiveValues;
-use packet::ip::IpNextHeaderProtocol;
+use packet::ip::IpNextHeaderProtocols;
 use util::{self, Octets};
 
 use pnet_macros_support::types::*;
@@ -237,15 +237,14 @@ fn tcp_options_length(tcp: &TcpPacket) -> usize {
 pub fn ipv4_checksum(packet: &TcpPacket,
                      extra_data: &[u8],
                      source: Ipv4Addr,
-                     destination: Ipv4Addr,
-                     next_level_protocol: IpNextHeaderProtocol)
+                     destination: Ipv4Addr)
     -> u16 {
     util::ipv4_checksum(packet.packet(),
                         8,
                         extra_data,
                         source,
                         destination,
-                        next_level_protocol)
+                        IpNextHeaderProtocols::Tcp)
 }
 
 #[test]
@@ -260,10 +259,9 @@ fn tcp_header_ipv4_test() {
     let mut packet = [0u8; IPV4_HEADER_LEN + TCP_HEADER_LEN + TEST_DATA_LEN];
     let ipv4_source = Ipv4Addr::new(192, 168, 2, 1);
     let ipv4_destination = Ipv4Addr::new(192, 168, 111, 51);
-    let next_level_protocol = IpNextHeaderProtocols::Tcp;
     {
         let mut ip_header = MutableIpv4Packet::new(&mut packet[..]).unwrap();
-        ip_header.set_next_level_protocol(next_level_protocol);
+        ip_header.set_next_level_protocol(IpNextHeaderProtocols::Tcp);
         ip_header.set_source(ipv4_source);
         ip_header.set_destination(ipv4_destination);
     }
@@ -303,8 +301,7 @@ fn tcp_header_ipv4_test() {
         let checksum = ipv4_checksum(&tcp_header.to_immutable(),
                                      &[],
                                      ipv4_source,
-                                     ipv4_destination,
-                                     next_level_protocol);
+                                     ipv4_destination);
         tcp_header.set_checksum(checksum);
         assert_eq!(tcp_header.get_checksum(), 0xc031);
     }

--- a/src/packet/tcp.rs.in
+++ b/src/packet/tcp.rs.in
@@ -234,14 +234,8 @@ fn tcp_options_length(tcp: &TcpPacket) -> usize {
 }
 
 /// Calculate the checksum for a packet built on IPv4
-pub fn ipv4_checksum(packet: &TcpPacket,
-                     source: Ipv4Addr,
-                     destination: Ipv4Addr)
-    -> u16 {
-    ipv4_checksum_adv(packet,
-                      &[],
-                      source,
-                      destination)
+pub fn ipv4_checksum(packet: &TcpPacket, source: Ipv4Addr, destination: Ipv4Addr) -> u16 {
+    ipv4_checksum_adv(packet, &[], source, destination)
 }
 
 /// Calculate the checksum for a packet built on IPv4, Advanced version which

--- a/src/packet/udp.rs.in
+++ b/src/packet/udp.rs.in
@@ -26,14 +26,8 @@ pub struct Udp {
 }
 
 /// Calculate the checksum for a packet built on IPv4
-pub fn ipv4_checksum(packet: &UdpPacket,
-                     source: Ipv4Addr,
-                     destination: Ipv4Addr)
-    -> u16be {
-    ipv4_checksum_adv(packet,
-                      &[],
-                      source,
-                      destination)
+pub fn ipv4_checksum(packet: &UdpPacket, source: Ipv4Addr, destination: Ipv4Addr) -> u16be {
+    ipv4_checksum_adv(packet, &[], source, destination)
 }
 
 /// Calculate the checksum for a packet built on IPv4. Advanced version which
@@ -44,9 +38,9 @@ pub fn ipv4_checksum(packet: &UdpPacket,
 /// counted as the first byte of a word together with the first byte of
 /// `extra_data`.
 pub fn ipv4_checksum_adv(packet: &UdpPacket,
-                     extra_data: &[u8],
-                     source: Ipv4Addr,
-                     destination: Ipv4Addr)
+                         extra_data: &[u8],
+                         source: Ipv4Addr,
+                         destination: Ipv4Addr)
     -> u16be {
     util::ipv4_checksum(packet.packet(),
                         3,
@@ -117,9 +111,9 @@ pub fn ipv6_checksum(packet: &UdpPacket,
 /// counted as the first byte of a word together with the first byte of
 /// `extra_data`.
 pub fn ipv6_checksum_adv(packet: &UdpPacket,
-                     extra_data: &[u8],
-                     source: Ipv6Addr,
-                     destination: Ipv6Addr)
+                         extra_data: &[u8],
+                         source: Ipv6Addr,
+                         destination: Ipv6Addr)
     -> u16be {
     util::ipv6_checksum(packet.packet(),
                         3,

--- a/src/packet/udp.rs.in
+++ b/src/packet/udp.rs.in
@@ -27,6 +27,23 @@ pub struct Udp {
 
 /// Calculate the checksum for a packet built on IPv4
 pub fn ipv4_checksum(packet: &UdpPacket,
+                     source: Ipv4Addr,
+                     destination: Ipv4Addr)
+    -> u16be {
+    ipv4_checksum_adv(packet,
+                      &[],
+                      source,
+                      destination)
+}
+
+/// Calculate the checksum for a packet built on IPv4. Advanced version which
+/// accepts an extra slice of data that will be included in the checksum
+/// as being part of the data portion of the packet.
+///
+/// If `packet` contains an odd number of bytes the last byte will not be
+/// counted as the first byte of a word together with the first byte of
+/// `extra_data`.
+pub fn ipv4_checksum_adv(packet: &UdpPacket,
                      extra_data: &[u8],
                      source: Ipv4Addr,
                      destination: Ipv4Addr)
@@ -71,10 +88,7 @@ fn udp_header_ipv4_test() {
         udp_header.set_length(8 + 4);
         assert_eq!(udp_header.get_length(), 8 + 4);
 
-        let checksum = ipv4_checksum(&udp_header.to_immutable(),
-                                     &[],
-                                     ipv4_source,
-                                     ipv4_destination);
+        let checksum = ipv4_checksum(&udp_header.to_immutable(), ipv4_source, ipv4_destination);
         udp_header.set_checksum(checksum);
         assert_eq!(udp_header.get_checksum(), 0x9178);
     }
@@ -89,6 +103,20 @@ fn udp_header_ipv4_test() {
 
 /// Calculate the checksum for a packet built on IPv6
 pub fn ipv6_checksum(packet: &UdpPacket,
+                     source: Ipv6Addr,
+                     destination: Ipv6Addr)
+    -> u16be {
+    ipv6_checksum_adv(packet, &[], source, destination)
+}
+
+/// Calculate the checksum for a packet built on IPv6. Advanced version which
+/// accepts an extra slice of data that will be included in the checksum
+/// as being part of the data portion of the packet.
+///
+/// If `packet` contains an odd number of bytes the last byte will not be
+/// counted as the first byte of a word together with the first byte of
+/// `extra_data`.
+pub fn ipv6_checksum_adv(packet: &UdpPacket,
                      extra_data: &[u8],
                      source: Ipv6Addr,
                      destination: Ipv6Addr)
@@ -134,7 +162,6 @@ fn udp_header_ipv6_test() {
         assert_eq!(udp_header.get_length(), 8 + 4);
 
         let checksum = ipv6_checksum(&udp_header.to_immutable(),
-                                     &[],
                                      ipv6_source,
                                      ipv6_destination);
         udp_header.set_checksum(checksum);

--- a/src/packet/udp.rs.in
+++ b/src/packet/udp.rs.in
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use packet::Packet;
-use packet::ip::{IpNextHeaderProtocol, IpNextHeaderProtocols};
+use packet::ip::IpNextHeaderProtocols;
 use util;
 
 use pnet_macros_support::types::*;
@@ -89,59 +89,16 @@ fn udp_header_ipv4_test() {
 
 /// Calculate the checksum for a packet built on IPv6
 pub fn ipv6_checksum(packet: &UdpPacket,
-                     ipv6_source: Ipv6Addr,
-                     ipv6_destination: Ipv6Addr,
-                     next_header: IpNextHeaderProtocol)
+                     extra_data: &[u8],
+                     source: Ipv6Addr,
+                     destination: Ipv6Addr)
     -> u16be {
-    let IpNextHeaderProtocol(next_header) = next_header;
-    let mut sum = 0u32;
-
-    // Checksum pseudo-header
-    // IPv6 source
-    let segments = ipv6_source.segments();
-    sum += segments[0] as u32;
-    sum += segments[1] as u32;
-    sum += segments[2] as u32;
-    sum += segments[3] as u32;
-    sum += segments[4] as u32;
-    sum += segments[5] as u32;
-    sum += segments[6] as u32;
-    sum += segments[7] as u32;
-
-    // IPv6 destination
-    let segments = ipv6_destination.segments();
-    sum += segments[0] as u32;
-    sum += segments[1] as u32;
-    sum += segments[2] as u32;
-    sum += segments[3] as u32;
-    sum += segments[4] as u32;
-    sum += segments[5] as u32;
-    sum += segments[6] as u32;
-    sum += segments[7] as u32;
-
-    // IPv6 Next header
-    sum += next_header as u32;
-
-    // UDP Length
-    sum += packet.get_length() as u32;
-
-    // Checksum UDP header/packet
-    let mut i = 0;
-    let len = packet.get_length() as usize;
-    while i < len && i + 1 < packet.packet().len() {
-        sum += (packet.packet()[i] as u32) << 8 | packet.packet()[i + 1] as u32;
-        i += 2;
-    }
-    // If the length is odd, make sure to checksum the final byte
-    if len & 1 != 0 && len <= packet.packet().len() {
-        sum += (packet.packet()[len - 1] as u32) << 8;
-    }
-
-    while sum >> 16 != 0 {
-        sum = (sum >> 16) + (sum & 0xFFFF);
-    }
-
-    !sum as u16
+    util::ipv6_checksum(packet.packet(),
+                        3,
+                        extra_data,
+                        source,
+                        destination,
+                        IpNextHeaderProtocols::Udp)
 }
 
 #[test]
@@ -150,12 +107,11 @@ fn udp_header_ipv6_test() {
     use packet::ipv6::MutableIpv6Packet;
 
     let mut packet = [0u8; 40 + 8 + 4];
-    let next_header = IpNextHeaderProtocols::Udp;
     let ipv6_source = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1);
     let ipv6_destination = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1);
     {
         let mut ip_header = MutableIpv6Packet::new(&mut packet[..]).unwrap();
-        ip_header.set_next_header(next_header);
+        ip_header.set_next_header(IpNextHeaderProtocols::Udp);
         ip_header.set_source(ipv6_source);
         ip_header.set_destination(ipv6_destination);
     }
@@ -178,9 +134,9 @@ fn udp_header_ipv6_test() {
         assert_eq!(udp_header.get_length(), 8 + 4);
 
         let checksum = ipv6_checksum(&udp_header.to_immutable(),
+                                     &[],
                                      ipv6_source,
-                                     ipv6_destination,
-                                     next_header);
+                                     ipv6_destination);
         udp_header.set_checksum(checksum);
         assert_eq!(udp_header.get_checksum(), 0x1390);
     }

--- a/src/packet/udp.rs.in
+++ b/src/packet/udp.rs.in
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use packet::Packet;
-use packet::ip::IpNextHeaderProtocol;
+use packet::ip::{IpNextHeaderProtocol, IpNextHeaderProtocols};
 use util;
 
 use pnet_macros_support::types::*;
@@ -29,15 +29,14 @@ pub struct Udp {
 pub fn ipv4_checksum(packet: &UdpPacket,
                      extra_data: &[u8],
                      source: Ipv4Addr,
-                     destination: Ipv4Addr,
-                     next_level_protocol: IpNextHeaderProtocol)
+                     destination: Ipv4Addr)
     -> u16be {
     util::ipv4_checksum(packet.packet(),
                         3,
                         extra_data,
                         source,
                         destination,
-                        next_level_protocol)
+                        IpNextHeaderProtocols::Udp)
 }
 
 #[test]
@@ -48,10 +47,9 @@ fn udp_header_ipv4_test() {
     let mut packet = [0u8; 20 + 8 + 4];
     let ipv4_source = Ipv4Addr::new(192, 168, 0, 1);
     let ipv4_destination = Ipv4Addr::new(192, 168, 0, 199);
-    let next_level_protocol = IpNextHeaderProtocols::Udp;
     {
         let mut ip_header = MutableIpv4Packet::new(&mut packet[..]).unwrap();
-        ip_header.set_next_level_protocol(next_level_protocol);
+        ip_header.set_next_level_protocol(IpNextHeaderProtocols::Udp);
         ip_header.set_source(ipv4_source);
         ip_header.set_destination(ipv4_destination);
     }
@@ -76,8 +74,7 @@ fn udp_header_ipv4_test() {
         let checksum = ipv4_checksum(&udp_header.to_immutable(),
                                      &[],
                                      ipv4_source,
-                                     ipv4_destination,
-                                     next_level_protocol);
+                                     ipv4_destination);
         udp_header.set_checksum(checksum);
         assert_eq!(udp_header.get_checksum(), 0x9178);
     }

--- a/src/packet/udp.rs.in
+++ b/src/packet/udp.rs.in
@@ -27,14 +27,17 @@ pub struct Udp {
 
 /// Calculate the checksum for a packet built on IPv4
 pub fn ipv4_checksum(packet: &UdpPacket,
+                     extra_data: &[u8],
                      source: Ipv4Addr,
                      destination: Ipv4Addr,
                      next_level_protocol: IpNextHeaderProtocol)
     -> u16be {
-    let len = packet.get_length() as usize;
-    assert!(len <= packet.packet().len());
-    let data = &packet.packet()[..len];
-    util::ipv4_checksum(data, source, destination, next_level_protocol, 3)
+    util::ipv4_checksum(packet.packet(),
+                        3,
+                        extra_data,
+                        source,
+                        destination,
+                        next_level_protocol)
 }
 
 #[test]
@@ -71,6 +74,7 @@ fn udp_header_ipv4_test() {
         assert_eq!(udp_header.get_length(), 8 + 4);
 
         let checksum = ipv4_checksum(&udp_header.to_immutable(),
+                                     &[],
                                      ipv4_source,
                                      ipv4_destination,
                                      next_level_protocol);

--- a/src/pnettest.rs
+++ b/src/pnettest.rs
@@ -119,7 +119,6 @@ fn build_udp4_packet(packet: &mut [u8],
 
     let slice = &mut packet[(start + IPV4_HEADER_LEN as usize)..];
     let checksum = udp::ipv4_checksum(&UdpPacket::new(slice).unwrap(),
-                                      &[],
                                       source,
                                       dest);
     MutableUdpPacket::new(slice).unwrap().set_checksum(checksum);
@@ -139,7 +138,6 @@ fn build_udp6_packet(packet: &mut [u8], start: usize, msg: &str) {
 
     let slice = &mut packet[(start + IPV6_HEADER_LEN as usize)..];
     let checksum = udp::ipv6_checksum(&UdpPacket::new(slice).unwrap(),
-                                      &[],
                                       ipv6_source(),
                                       ipv6_destination());
     MutableUdpPacket::new(slice).unwrap().set_checksum(checksum);

--- a/src/pnettest.rs
+++ b/src/pnettest.rs
@@ -118,9 +118,7 @@ fn build_udp4_packet(packet: &mut [u8],
     };
 
     let slice = &mut packet[(start + IPV4_HEADER_LEN as usize)..];
-    let checksum = udp::ipv4_checksum(&UdpPacket::new(slice).unwrap(),
-                                      source,
-                                      dest);
+    let checksum = udp::ipv4_checksum(&UdpPacket::new(slice).unwrap(), source, dest);
     MutableUdpPacket::new(slice).unwrap().set_checksum(checksum);
 }
 

--- a/src/pnettest.rs
+++ b/src/pnettest.rs
@@ -139,9 +139,9 @@ fn build_udp6_packet(packet: &mut [u8], start: usize, msg: &str) {
 
     let slice = &mut packet[(start + IPV6_HEADER_LEN as usize)..];
     let checksum = udp::ipv6_checksum(&UdpPacket::new(slice).unwrap(),
+                                      &[],
                                       ipv6_source(),
-                                      ipv6_destination(),
-                                      TEST_PROTO);
+                                      ipv6_destination());
     MutableUdpPacket::new(slice).unwrap().set_checksum(checksum);
 }
 

--- a/src/pnettest.rs
+++ b/src/pnettest.rs
@@ -8,7 +8,7 @@
 
 extern crate libc;
 
-use std::net::{Ipv4Addr, Ipv6Addr, IpAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::mpsc::channel;
 use std::thread;
 use std::iter::Iterator;
@@ -118,7 +118,11 @@ fn build_udp4_packet(packet: &mut [u8],
     };
 
     let slice = &mut packet[(start + IPV4_HEADER_LEN as usize)..];
-    let checksum = udp::ipv4_checksum(&UdpPacket::new(slice).unwrap(), source, dest, TEST_PROTO);
+    let checksum = udp::ipv4_checksum(&UdpPacket::new(slice).unwrap(),
+                                      &[],
+                                      source,
+                                      dest,
+                                      TEST_PROTO);
     MutableUdpPacket::new(slice).unwrap().set_checksum(checksum);
 }
 

--- a/src/pnettest.rs
+++ b/src/pnettest.rs
@@ -121,8 +121,7 @@ fn build_udp4_packet(packet: &mut [u8],
     let checksum = udp::ipv4_checksum(&UdpPacket::new(slice).unwrap(),
                                       &[],
                                       source,
-                                      dest,
-                                      TEST_PROTO);
+                                      dest);
     MutableUdpPacket::new(slice).unwrap().set_checksum(checksum);
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -260,7 +260,11 @@ impl Octets for u8 {
 /// Calculates a checksum. Used by ipv4 and icmp. The two bytes starting at `skipword * 2` will be
 /// ignored. Supposed to be the checksum field, which is regarded as zero during calculation.
 pub fn checksum(data: &[u8], skipword: usize) -> u16be {
-    let mut sum = sum_be_words(data, skipword);
+    let sum = sum_be_words(data, skipword);
+    finalize_checksum(sum)
+}
+
+fn finalize_checksum(mut sum: u32) -> u16be {
     while sum >> 16 != 0 {
         sum = (sum >> 16) + (sum & 0xFFFF);
     }
@@ -291,11 +295,7 @@ pub fn ipv4_checksum(data: &[u8],
     sum += sum_be_words(data, skipword);
     sum += sum_be_words(extra_data, extra_data.len()/2);
 
-    while sum >> 16 != 0 {
-        sum = (sum >> 16) + (sum & 0xFFFF);
-    }
-
-    !sum as u16
+    finalize_checksum(sum)
 }
 
 fn ipv4_word_sum(ip: Ipv4Addr) -> u32 {
@@ -327,11 +327,7 @@ pub fn ipv6_checksum(data: &[u8],
     sum += sum_be_words(data, skipword);
     sum += sum_be_words(extra_data, extra_data.len()/2);
 
-    while sum >> 16 != 0 {
-        sum = (sum >> 16) + (sum & 0xFFFF);
-    }
-
-    !sum as u16
+    finalize_checksum(sum)
 }
 
 fn ipv6_word_sum(ip: Ipv6Addr) -> u32 {


### PR DESCRIPTION
This PR more or less does three small things:

1. Make it possible to send `extra_data` to an `ipvX_checksum` function. This removes one copy when constructing packets that are fragmented. You have all the payload in a vec but the header is not attached ahead of it. With the previous checksum function one had to allocate new memory, build the header and then copy in all the payload before calculating the checksum. This fix introduces the slight annoyance of having to send `&[]` as the second argument to the checksum function whenever you want to calculate the checksum but does not have any `extra_data`. Is this OK or should I split it into two functions?

2. Removes the `next_level_protocol` argument from `udp::ipvX_checksum` and `tcp::ipv4_checksum`. Feels inappropriate to use `udp::ipv4_checksum` to calculate anything but a Udp header and similar for tcp?

3. Made `udp::ipv6_checksum` use the pretty new (and significantly faster) checksumming in `util` instead of implementing it itself.

@mrmonday 