### PR TITLE
Add support for subnet masks

### DIFF
--- a/src/datalink/dummy.rs
+++ b/src/datalink/dummy.rs
@@ -191,7 +191,7 @@ pub fn dummy_interface(i: u8) -> NetworkInterface {
         name: format!("eth{}", i),
         index: i as u32,
         mac: Some(MacAddr::new(1, 2, 3, 4, 5, i)),
-        ips: None,
+        ips: Vec::new(),
         flags: 0,
     }
 }

--- a/src/datalink/mod.rs
+++ b/src/datalink/mod.rs
@@ -211,8 +211,8 @@ pub struct NetworkInterface {
     pub index: u32,
     /// A MAC address for the interface
     pub mac: Option<MacAddr>,
-    /// An IP addresses for the interface
-    pub ips: Option<Vec<IpAddr>>,
+    /// IP addresses and netmasks for the interface
+    pub ips: Option<Vec<IpNetmask>>,
     /// Operating system specific flags for the interface
     pub flags: u32,
 }
@@ -227,6 +227,15 @@ impl NetworkInterface {
     pub fn is_loopback(&self) -> bool {
         self.flags & (sockets::IFF_LOOPBACK as u32) != 0
     }
+}
+
+/// Represents an IP address and subnet mask
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
+pub struct IpNetmask {
+    /// IP address
+    pub ip: IpAddr,
+    /// Subnet mask
+    pub netmask: Option<IpAddr>,
 }
 
 /// Get a list of available network interfaces for the current machine.

--- a/src/datalink/mod.rs
+++ b/src/datalink/mod.rs
@@ -235,7 +235,7 @@ pub struct IpNetmask {
     /// IP address
     pub ip: IpAddr,
     /// Subnet mask
-    pub netmask: Option<IpAddr>,
+    pub netmask: IpAddr,
 }
 
 /// Get a list of available network interfaces for the current machine.

--- a/src/datalink/mod.rs
+++ b/src/datalink/mod.rs
@@ -212,7 +212,7 @@ pub struct NetworkInterface {
     /// A MAC address for the interface
     pub mac: Option<MacAddr>,
     /// IP addresses and netmasks for the interface
-    pub ips: Option<Vec<IpNetmask>>,
+    pub ips: Vec<IpNetmask>,
     /// Operating system specific flags for the interface
     pub flags: u32,
 }

--- a/src/datalink/unix_interfaces.rs
+++ b/src/datalink/unix_interfaces.rs
@@ -8,7 +8,7 @@
 
 //! Interface listing implementation for all non-Windows platforms
 
-use datalink::NetworkInterface;
+use datalink::{NetworkInterface, IpNetmask};
 
 use internal;
 use libc;
@@ -49,11 +49,15 @@ pub fn interfaces() -> Vec<NetworkInterface> {
             let bytes = CStr::from_ptr(c_str).to_bytes();
             let name = from_utf8_unchecked(bytes).to_owned();
             let (mac, ip) = sockaddr_to_network_addr((*addr).ifa_addr as *const libc::sockaddr);
+            let (_, netmask) = sockaddr_to_network_addr((*addr).ifa_netmask as *const libc::sockaddr);
             let ni = NetworkInterface {
                 name: name.clone(),
                 index: 0,
                 mac: mac,
-                ips: ip.map(|ip| [ip].to_vec()),
+                ips: ip.map(|ip| vec![IpNetmask {
+                    ip: ip,
+                    netmask: netmask
+                }]),
                 flags: (*addr).ifa_flags,
             };
             let mut found: bool = false;

--- a/src/datalink/unix_interfaces.rs
+++ b/src/datalink/unix_interfaces.rs
@@ -14,7 +14,7 @@ use internal;
 use libc;
 use std::ffi::{CStr, CString};
 use std::mem;
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::os::raw::c_char;
 use std::str::from_utf8_unchecked;
 
@@ -51,7 +51,16 @@ pub fn interfaces() -> Vec<NetworkInterface> {
                 ips: match ip {
                     Some(ip) => vec![IpNetmask {
                         ip: ip,
-                        netmask: netmask,
+                        netmask: match netmask {
+                            Some(n) => n,
+                            // Awaiting stabilisation: https://github.com/rust-lang/rust/pull/39307
+                            // None if ip.is_ipv4() => IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+                            // None if ip.is_ipv6() => IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)),
+                            None => match ip {
+                                IpAddr::V4(_) => IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+                                IpAddr::V6(_) => IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)),
+                            },
+                        },
                     }],
                     None => Vec::new(),
                 },

--- a/src/datalink/unix_interfaces.rs
+++ b/src/datalink/unix_interfaces.rs
@@ -27,13 +27,7 @@ pub fn interfaces() -> Vec<NetworkInterface> {
             None => old.mac,
             _ => new.mac,
         };
-        match (&mut old.ips, &new.ips) {
-            (&mut Some(ref mut old_ips), &Some(ref new_ips)) => {
-                old_ips.extend_from_slice(&new_ips[..])
-            }
-            (&mut ref mut old_ips @ None, &Some(ref new_ips)) => *old_ips = Some(new_ips.clone()),
-            _ => {}
-        };
+        old.ips.extend_from_slice(&new.ips[..]);
         old.flags = old.flags | new.flags;
     }
 
@@ -54,10 +48,13 @@ pub fn interfaces() -> Vec<NetworkInterface> {
                 name: name.clone(),
                 index: 0,
                 mac: mac,
-                ips: ip.map(|ip| vec![IpNetmask {
-                    ip: ip,
-                    netmask: netmask
-                }]),
+                ips: match ip {
+                    Some(ip) => vec![IpNetmask {
+                        ip: ip,
+                        netmask: netmask,
+                    }],
+                    None => Vec::new(),
+                },
                 flags: (*addr).ifa_flags,
             };
             let mut found: bool = false;

--- a/src/datalink/winpcap.rs
+++ b/src/datalink/winpcap.rs
@@ -330,7 +330,7 @@ pub fn interfaces() -> Vec<NetworkInterface> {
 
             ips.push(IpNetmask {
                 ip: ip_str.parse().unwrap(),
-                netmask: Some(mask_str.parse().unwrap()),
+                netmask: mask_str.parse().unwrap(),
             });
             ip_cursor = unsafe { (*ip_cursor).Next };
         }

--- a/src/datalink/winpcap.rs
+++ b/src/datalink/winpcap.rs
@@ -345,7 +345,7 @@ pub fn interfaces() -> Vec<NetworkInterface> {
                 name: name_str,
                 index: (*cursor).Index,
                 mac: Some(mac),
-                ips: Some(ips),
+                ips: ips,
                 // flags: (*cursor).Type, // FIXME [windows]
                 flags: 0,
             });

--- a/src/pnettest.rs
+++ b/src/pnettest.rs
@@ -104,8 +104,8 @@ fn build_udp4_packet(packet: &mut [u8],
     packet[data_start + 3] = msg[3];
 
     let (source, dest) = if let Some(ni) = ni {
-        let ip = ni.ips.as_ref().unwrap().iter().filter(|addr| is_ipv4(addr)).next().unwrap();
-        match (*ip).clone() {
+        let ipmask = ni.ips.as_ref().unwrap().iter().filter(|addr| is_ipv4(&addr.ip)).next().unwrap();
+        match (ipmask.ip).clone() {
             IpAddr::V4(v4) => (v4, v4),
             IpAddr::V6(_) => panic!("found ipv6 addresses when expecting ipv4 addresses"),
         }

--- a/src/pnettest.rs
+++ b/src/pnettest.rs
@@ -104,7 +104,7 @@ fn build_udp4_packet(packet: &mut [u8],
     packet[data_start + 3] = msg[3];
 
     let (source, dest) = if let Some(ni) = ni {
-        let ipmask = ni.ips.as_ref().unwrap().iter().filter(|addr| is_ipv4(&addr.ip)).next().unwrap();
+        let ipmask = ni.ips.iter().filter(|addr| is_ipv4(&addr.ip)).next().unwrap();
         match (ipmask.ip).clone() {
             IpAddr::V4(v4) => (v4, v4),
             IpAddr::V6(_) => panic!("found ipv6 addresses when expecting ipv4 addresses"),


### PR DESCRIPTION
Addresses libpnet/libpnet#81.

I'd appreciate someone familiar with Windows to take a look at my winpcap patch. It appears that the IP Helper API doesn't identify `IpMask` as optional. Does this mean that an IP address without a subnet mask is a blank string? I have a suspicion that my implementation might need fine tuning?