### PR TITLE
fix panic on invalid payload start index

### DIFF
--- a/pnet_macros/src/decorator.rs
+++ b/pnet_macros/src/decorator.rs
@@ -1035,6 +1035,9 @@ fn generate_packet_trait_impls(cx: &mut GenContext,
             fn payload{u_mut}<'p>(&'p {mut_} self) -> &'p {mut_} [u8] {{
                 let _self = self;
                 {pre}
+                if _self.packet.len() <= {start} {{
+                    return &{mut_} [];
+                }}
                 &{mut_} _self.packet[{start}..{end}]
             }}
         }}", name = name,

--- a/src/packet/tcp.rs.in
+++ b/src/packet/tcp.rs.in
@@ -414,3 +414,17 @@ fn tcp_test_option_invalid_len() {
         }
     }
 }
+
+#[test]
+fn tcp_test_payload_slice_invalid_offset() {
+    let mut buf = [0; 20];
+    {
+        if let Some(mut tcp) = MutableTcpPacket::new(&mut buf[..]) {
+            tcp.set_data_offset(10); // set invalid offset
+        }
+    }
+
+    if let Some(tcp) = TcpPacket::new(&buf[..]) {
+        assert_eq!(tcp.payload().len(), 0);
+    }
+}


### PR DESCRIPTION
Hello, thanks for libpnet! I'm using it to parse some live network traffic and occasionally seeing a panic caused by the `payload()` function using a starting slice index beyond the bounds of the packet. Here's a fix that returns an empty slice if the starting index is invalid.