### PR TITLE
Use ipnetwork crate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-    - 1.11.0
+    - 1.15.0
     - stable
     - beta
     - nightly
@@ -19,9 +19,9 @@ matrix:
   allow_failures:
     - rust: nightly
   exclude:
-    - rust: 1.11.0
+    - rust: 1.15.0
       env: PNET_FEATURES="travis nightly clippy" PNET_MACROS_FEATURES="travis clippy"
-    - rust: 1.11.0
+    - rust: 1.15.0
       env: PNET_FEATURES="travis nightly" PNET_MACROS_FEATURES="travis"
     - rust: stable
       env: PNET_FEATURES="travis nightly clippy" PNET_MACROS_FEATURES="travis clippy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ netmap = ["netmap_sys"]
 appveyor = []
 travis = []
 with-syntex = ["syntex", "pnet_macros/with-syntex"]
-with-serde = ["serde", "serde_derive"]
 
 [dependencies]
 ipnetwork = "0.12"
@@ -47,14 +46,6 @@ version = "0.2.*"
 
 [dependencies.syntex]
 version = "0.42.*"
-optional = true
-
-[dependencies.serde]
-version = "0.9"
-optional = true
-
-[dependencies.serde_derive]
-version = "0.9"
 optional = true
 
 [dependencies.pcap]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ travis = []
 with-syntex = ["syntex", "pnet_macros/with-syntex"]
 with-serde = ["serde", "serde_derive"]
 
+[dependencies]
+ipnetwork = "0.12"
+
 [dependencies.clippy]
 optional = true
 version = ">=0.0"

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ version = "0.16.0"
 ```
 
 `libpnet` should work on any Rust channel (stable, beta, or nightly), starting
-with Rust 1.11. When using a nightly version of Rust, you may wish to use pass
+with Rust 1.15. When using a nightly version of Rust, you may wish to use pass
 `--no-default-features --features nightly` to Cargo, to enable faster build
 times.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,11 @@ environment:
   RUST_TEST_THREADS: 1
   matrix:
   - TARGET: x86_64-pc-windows-msvc
-    RUST_CHANNEL: 1.11.0
+    RUST_CHANNEL: 1.15.0
     WPD_LIB_PATH: "C:/dl/wpdpack/WpdPack/Lib/x64/Packet.lib"
     VCVARS: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\amd64\\vcvars64.bat"
   - TARGET: i686-pc-windows-msvc
-    RUST_CHANNEL: 1.11.0
+    RUST_CHANNEL: 1.15.0
     WPD_LIB_PATH: "C:/dl/wpdpack/WpdPack/Lib/Packet.lib"
     VCVARS: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\vcvars32.bat"
   - TARGET: x86_64-pc-windows-msvc

--- a/examples/list_interfaces.rs
+++ b/examples/list_interfaces.rs
@@ -1,0 +1,27 @@
+// Copyright (c) 2014, 2015 Robert Clipsham <robert@octarineparrot.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/// This examples simply print all interfaces to stdout
+
+extern crate pnet;
+
+use pnet::datalink;
+
+fn main() {
+    for interface in datalink::interfaces() {
+        let mac = interface.mac.map(|mac| mac.to_string()).unwrap_or("N/A".to_owned());
+        println!("{}:", interface.name);
+        println!("  index: {}", interface.index);
+        println!("  flags: {}", interface.flags);
+        println!("  MAC: {}", mac);
+        println!("  IPs:");
+        for ip in interface.ips {
+            println!("    {:?}", ip);
+        }
+    }
+}

--- a/src/datalink/mod.rs
+++ b/src/datalink/mod.rs
@@ -14,10 +14,11 @@ extern crate libc;
 use packet::ethernet::{EtherType, EthernetPacket, MutableEthernetPacket};
 use sockets;
 use std::io;
-use std::net::IpAddr;
 use std::option::Option;
 use std::time::Duration;
 use util::MacAddr;
+
+use ipnetwork::IpNetwork;
 
 #[cfg(windows)]
 #[path = "winpcap.rs"]
@@ -217,7 +218,7 @@ pub struct NetworkInterface {
     /// A MAC address for the interface
     pub mac: Option<MacAddr>,
     /// IP addresses and netmasks for the interface
-    pub ips: Vec<IpNetmask>,
+    pub ips: Vec<IpNetwork>,
     /// Operating system specific flags for the interface
     pub flags: u32,
 }
@@ -232,16 +233,6 @@ impl NetworkInterface {
     pub fn is_loopback(&self) -> bool {
         self.flags & (sockets::IFF_LOOPBACK as u32) != 0
     }
-}
-
-/// Represents an IP address and subnet mask
-#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
-#[derive(Clone, PartialEq, Eq, Debug, Hash)]
-pub struct IpNetmask {
-    /// IP address
-    pub ip: IpAddr,
-    /// Subnet mask
-    pub netmask: IpAddr,
 }
 
 /// Get a list of available network interfaces for the current machine.

--- a/src/datalink/mod.rs
+++ b/src/datalink/mod.rs
@@ -208,7 +208,6 @@ dlr!(EthernetDataLinkReceiver,
      EthernetPacket);
 
 /// Represents a network interface and its associated addresses
-#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub struct NetworkInterface {
     /// The name of the interface

--- a/src/datalink/winpcap.rs
+++ b/src/datalink/winpcap.rs
@@ -24,11 +24,9 @@ use std::collections::VecDeque;
 use std::ffi::{CStr, CString};
 use std::io;
 use std::mem;
-use std::net::IpAddr;
 use std::slice;
 use std::str::from_utf8_unchecked;
 use std::sync::Arc;
-use std::time::Duration;
 use util::MacAddr;
 
 struct WinPcapAdapter {

--- a/src/datalink/winpcap.rs
+++ b/src/datalink/winpcap.rs
@@ -12,11 +12,13 @@ extern crate libc;
 
 
 use bindings::{bpf, winpcap};
-use datalink::{self, NetworkInterface, IpNetmask};
+use datalink::{self, NetworkInterface};
 use datalink::{EthernetDataLinkChannelIterator, EthernetDataLinkReceiver, EthernetDataLinkSender};
 use datalink::Channel::Ethernet;
 use packet::Packet;
 use packet::ethernet::{EthernetPacket, MutableEthernetPacket};
+
+use ipnetwork::{ip_mask_to_prefix, IpNetwork};
 use std::cmp;
 use std::collections::VecDeque;
 use std::ffi::{CStr, CString};
@@ -318,20 +320,11 @@ pub fn interfaces() -> Vec<NetworkInterface> {
                     (*cursor).Address[5])
         };
         let mut ip_cursor = unsafe { &mut (*cursor).IpAddressList as winpcap::PIP_ADDR_STRING };
-        let mut ips: Vec<IpNetmask> = Vec::new();
+        let mut ips = Vec::new();
         while !ip_cursor.is_null() {
-            let ip_str_ptr = unsafe { &(*ip_cursor) }.IpAddress.String.as_ptr() as *const i8;
-            let ip_bytes = unsafe { CStr::from_ptr(ip_str_ptr).to_bytes() };
-            let ip_str = unsafe { from_utf8_unchecked(ip_bytes).to_owned() };
-
-            let mask_str_ptr = unsafe { &(*ip_cursor) }.IpMask.String.as_ptr() as *const i8;
-            let mask_bytes = unsafe { CStr::from_ptr(mask_str_ptr).to_bytes() };
-            let mask_str = unsafe { from_utf8_unchecked(mask_bytes).to_owned() };
-
-            ips.push(IpNetmask {
-                ip: ip_str.parse().unwrap(),
-                netmask: mask_str.parse().unwrap(),
-            });
+            if let Ok(ip_network) = parse_ip_network(ip_cursor) {
+                ips.push(ip_network);
+            }
             ip_cursor = unsafe { (*ip_cursor).Next };
         }
 
@@ -386,4 +379,19 @@ pub fn interfaces() -> Vec<NetworkInterface> {
     };
 
     vec
+}
+
+fn parse_ip_network(ip_cursor: winpcap::PIP_ADDR_STRING) -> Result<IpNetwork, ()> {
+    let ip_str_ptr = unsafe { &(*ip_cursor) }.IpAddress.String.as_ptr() as *const i8;
+    let ip_bytes = unsafe { CStr::from_ptr(ip_str_ptr).to_bytes() };
+    let ip_str = unsafe { from_utf8_unchecked(ip_bytes).to_owned() };
+    let ip = ip_str.parse().map_err(|_| ())?;
+
+    let mask_str_ptr = unsafe { &(*ip_cursor) }.IpMask.String.as_ptr() as *const i8;
+    let mask_bytes = unsafe { CStr::from_ptr(mask_str_ptr).to_bytes() };
+    let mask_str = unsafe { from_utf8_unchecked(mask_bytes).to_owned() };
+    let mask = mask_str.parse().map_err(|_| ())?;
+
+    let prefix = ip_mask_to_prefix(mask).map_err(|_| ())?;
+    IpNetwork::new(ip, prefix).map_err(|_| ())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,7 @@ extern crate serde_derive;
 
 extern crate libc;
 extern crate winapi;
+extern crate ipnetwork;
 extern crate pnet_macros_support;
 
 pub mod datalink;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,12 +115,6 @@
 #[cfg(feature = "benchmark")]
 extern crate test;
 
-#[cfg(feature = "with-serde")]
-extern crate serde;
-#[cfg(feature = "with-serde")]
-#[macro_use]
-extern crate serde_derive;
-
 extern crate libc;
 extern crate winapi;
 extern crate ipnetwork;

--- a/src/pnettest.rs
+++ b/src/pnettest.rs
@@ -104,8 +104,8 @@ fn build_udp4_packet(packet: &mut [u8],
     packet[data_start + 3] = msg[3];
 
     let (source, dest) = if let Some(ni) = ni {
-        let ipmask = ni.ips.iter().filter(|addr| is_ipv4(&addr.ip)).next().unwrap();
-        match (ipmask.ip).clone() {
+        let ipmask = ni.ips.iter().filter(|addr| is_ipv4(&addr.ip())).next().unwrap();
+        match (ipmask.ip()).clone() {
             IpAddr::V4(v4) => (v4, v4),
             IpAddr::V6(_) => panic!("found ipv6 addresses when expecting ipv4 addresses"),
         }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -204,7 +204,7 @@ impl TransportSender {
 /// Create an iterator for some packet type.
 ///
 /// Usage:
-/// ```
+/// ```ignore
 /// transport_channel_iterator!(Ipv4Packet, // Type to iterate over
 ///                             Ipv4TransportChannelIterator, // Name for iterator struct
 ///                             ipv4_packet_iter) // Name of function to create iterator
@@ -295,4 +295,3 @@ transport_channel_iterator!(UdpPacket, UdpTransportChannelIterator, udp_packet_i
 transport_channel_iterator!(IcmpPacket, IcmpTransportChannelIterator, icmp_packet_iter);
 
 transport_channel_iterator!(TcpPacket, TcpTransportChannelIterator, tcp_packet_iter);
-

--- a/src/util.rs
+++ b/src/util.rs
@@ -21,7 +21,6 @@ use std::str::FromStr;
 use std::u8;
 
 /// A MAC address
-#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
 #[derive(PartialEq, Eq, Clone, Copy, Hash)]
 pub struct MacAddr(pub u8, pub u8, pub u8, pub u8, pub u8, pub u8);
 


### PR DESCRIPTION
This converts from using the internal `IpNetmask` to the `IpNetwork` struct from the `ipnetwork` crate. The benefit of that is that we get a lot more functionality out of the struct and we don't have to maintain it ourselves. Always nice to use existing crates to increase interoperability between network crates in general.

I'm sorry I removed the serde functionality introduces in #249. Since `IpNetwork` does not support serialization it did not work. But also I did not see why we should provide this, for me, quite arbitrary functionality. Would transmitting interface metadata over the network be a common operation? They are machine specific and only valid in one point in time, so I don't see how transmitting it would be very useful. There might be use cases where one want to send out interface names or indexes or IPs. But I find it hard to see a case where one will need to send the entire struct.

For people who want to serialize this information it is still possible to create a custom, serializable, struct that copies the needed information. Guess some input from @petehayes102 is in order.

Another reason to remove serde is that pnet already take ages to build, more large dependencies are not optimal :P