### PR TITLE
Add endianness documentation to #[packet]-generated code

### DIFF
--- a/pnet_macros/src/decorator.rs
+++ b/pnet_macros/src/decorator.rs
@@ -1214,7 +1214,23 @@ fn generate_mutator_str(name: &str,
         {operations}
     }}", struct_name = struct_name, name = name, ty = ty, co = offset, operations = op_strings)
     } else {
-        format!("/// Set the {name} field
+        let desc = if let Some((_, endianness, end_specified)) = parse_ty(ty) {
+            if end_specified == EndiannessSpecified::Yes {
+                if endianness == Endianness::Big {
+                    format!("/// Set the {name} field. This field is always stored big-endian within
+                    /// the struct, but this mutator wants a host order argument.", name = name)
+                } else {
+                    format!("/// Set the {name} field. This field is always stored little-endian
+                    /// within the struct, but this mutator wants a host order argument.",
+                    name = name)
+                }
+            } else {
+                format!("/// Set the {name} field.", name = name)
+            }
+        } else {
+            format!("/// Set the {name} field.", name = name)
+        };
+        format!("{desc}
     #[inline]
     #[allow(trivial_numeric_casts)]
     #[cfg_attr(feature = \"clippy\", allow(used_underscore_binding))]
@@ -1222,7 +1238,7 @@ fn generate_mutator_str(name: &str,
         let _self = self;
         let co = {co};
         {operations}
-    }}", name = name, ty = ty, co = offset, operations = op_strings)
+    }}", desc = desc, name = name, ty = ty, co = offset, operations = op_strings)
     };
 
     mutator
@@ -1314,7 +1330,23 @@ fn generate_accessor_str(name: &str,
             {operations}
         }}", struct_name = struct_name, name = name, ty = ty, co = offset, operations = op_strings)
     } else {
-        format!("/// Get the {name} field
+        let desc = if let Some((_, endianness, end_specified)) = parse_ty(ty) {
+            if end_specified == EndiannessSpecified::Yes {
+                if endianness == Endianness::Big {
+                    format!("/// Get the {name} field. This field is always stored big-endian within
+                    /// the struct, but this accessor returns it in host order.", name = name)
+                } else {
+                    format!("/// Get the {name} field. This field is always stored little-endian
+                    /// within the struct, but this accessor returns it in host order.",
+                    name = name)
+                }
+            } else {
+                format!("/// Get the {name} field.", name = name)
+            }
+        } else {
+            format!("/// Get the {name} field.", name = name)
+        };
+        format!("{desc}
         #[inline]
         #[allow(trivial_numeric_casts)]
         #[cfg_attr(feature = \"clippy\", allow(used_underscore_binding))]
@@ -1322,7 +1354,7 @@ fn generate_accessor_str(name: &str,
             let _self = self;
             let co = {co};
             {operations}
-        }}", name = name, ty = ty, co = offset, operations = op_strings)
+        }}", desc = desc, name = name, ty = ty, co = offset, operations = op_strings)
     };
 
     accessor

--- a/pnet_macros/src/decorator.rs
+++ b/pnet_macros/src/decorator.rs
@@ -1204,21 +1204,15 @@ fn generate_accessor_or_mutator_comment(name: &str, ty: &str, op_type: AccessorM
         if end_specified == EndiannessSpecified::Yes {
             let return_or_want = match op_type { AccessorMutator::Accessor => "accessor returns",
                                                  AccessorMutator::Mutator  => "mutator wants" };
-            if endianness == Endianness::Big {
-                format!("/// {get_or_set} the {name} field. This field is always stored big-endian
+            let endian_str = if endianness == Endianness::Big { "big-endian" }
+                             else                             { "little-endian" };
+            return format!("/// {get_or_set} the {name} field. This field is always stored {endian}
                 /// within the struct, but this {return_or_want} host order.",
-                get_or_set = get_or_set, name = name, return_or_want = return_or_want)
-            } else {
-                format!("/// {get_or_set} the {name} field. This field is always stored
-                /// little-endian within the struct, but this {return_or_want} host order.",
-                get_or_set = get_or_set, name = name, return_or_want = return_or_want)
-            }
-        } else {
-            format!("/// {get_or_set} the {name} field.", get_or_set = get_or_set, name = name)
+                get_or_set = get_or_set, name = name, endian = endian_str,
+                return_or_want = return_or_want);
         }
-    } else {
-        format!("/// {get_or_set} the {name} field.", get_or_set = get_or_set, name = name)
     }
+    format!("/// {get_or_set} the {name} field.", get_or_set = get_or_set, name = name)
 }
 
 /// Given the name of a field, and a set of operations required to set that field, return

--- a/pnet_macros_support/src/types.rs
+++ b/pnet_macros_support/src/types.rs
@@ -44,339 +44,451 @@ pub type u6 = u8;
 pub type u7 = u8;
 
 
-/// Represents an unsigned, 9-bit, big endian integer
+/// Represents an unsigned 9-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u9be = u16;
 
-/// Represents an unsigned, 10-bit, big endian integer
+/// Represents an unsigned 10-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u10be = u16;
 
-/// Represents an unsigned, 11-bit, big endian integer
+/// Represents an unsigned 11-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u11be = u16;
 
-/// Represents an unsigned, 12-bit, big endian integer
+/// Represents an unsigned 12-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u12be = u16;
 
-/// Represents an unsigned, 13-bit, big endian integer
+/// Represents an unsigned 13-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u13be = u16;
 
-/// Represents an unsigned, 14-bit, big endian integer
+/// Represents an unsigned 14-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u14be = u16;
 
-/// Represents an unsigned, 15-bit, big endian integer
+/// Represents an unsigned 15-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u15be = u16;
 
-/// Represents an unsigned, 16-bit, big endian integer
+/// Represents an unsigned 16-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u16be = u16;
 
-/// Represents an unsigned, 17-bit, big endian integer
+/// Represents an unsigned 17-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u17be = u32;
 
-/// Represents an unsigned, 18-bit, big endian integer
+/// Represents an unsigned 18-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u18be = u32;
 
-/// Represents an unsigned, 19-bit, big endian integer
+/// Represents an unsigned 19-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u19be = u32;
 
-/// Represents an unsigned, 20-bit, big endian integer
+/// Represents an unsigned 20-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u20be = u32;
 
-/// Represents an unsigned, 21-bit, big endian integer
+/// Represents an unsigned 21-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u21be = u32;
 
-/// Represents an unsigned, 22-bit, big endian integer
+/// Represents an unsigned 22-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u22be = u32;
 
-/// Represents an unsigned, 23-bit, big endian integer
+/// Represents an unsigned 23-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u23be = u32;
 
-/// Represents an unsigned, 24-bit, big endian integer
+/// Represents an unsigned 24-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u24be = u32;
 
-/// Represents an unsigned, 25-bit, big endian integer
+/// Represents an unsigned 25-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u25be = u32;
 
-/// Represents an unsigned, 26-bit, big endian integer
+/// Represents an unsigned 26-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u26be = u32;
 
-/// Represents an unsigned, 27-bit, big endian integer
+/// Represents an unsigned 27-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u27be = u32;
 
-/// Represents an unsigned, 28-bit, big endian integer
+/// Represents an unsigned 28-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u28be = u32;
 
-/// Represents an unsigned, 29-bit, big endian integer
+/// Represents an unsigned 29-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u29be = u32;
 
-/// Represents an unsigned, 30-bit, big endian integer
+/// Represents an unsigned 30-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u30be = u32;
 
-/// Represents an unsigned, 31-bit, big endian integer
+/// Represents an unsigned 31-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u31be = u32;
 
-/// Represents an unsigned, 32-bit, big endian integer
+/// Represents an unsigned 32-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u32be = u32;
 
-/// Represents an unsigned, 33-bit, big endian integer
+/// Represents an unsigned 33-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u33be = u64;
 
-/// Represents an unsigned, 34-bit, big endian integer
+/// Represents an unsigned 34-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u34be = u64;
 
-/// Represents an unsigned, 35-bit, big endian integer
+/// Represents an unsigned 35-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u35be = u64;
 
-/// Represents an unsigned, 36-bit, big endian integer
+/// Represents an unsigned 36-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u36be = u64;
 
-/// Represents an unsigned, 37-bit, big endian integer
+/// Represents an unsigned 37-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u37be = u64;
 
-/// Represents an unsigned, 38-bit, big endian integer
+/// Represents an unsigned 38-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u38be = u64;
 
-/// Represents an unsigned, 39-bit, big endian integer
+/// Represents an unsigned 39-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u39be = u64;
 
-/// Represents an unsigned, 40-bit, big endian integer
+/// Represents an unsigned 40-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u40be = u64;
 
-/// Represents an unsigned, 41-bit, big endian integer
+/// Represents an unsigned 41-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u41be = u64;
 
-/// Represents an unsigned, 42-bit, big endian integer
+/// Represents an unsigned 42-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u42be = u64;
 
-/// Represents an unsigned, 43-bit, big endian integer
+/// Represents an unsigned 43-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u43be = u64;
 
-/// Represents an unsigned, 44-bit, big endian integer
+/// Represents an unsigned 44-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u44be = u64;
 
-/// Represents an unsigned, 45-bit, big endian integer
+/// Represents an unsigned 45-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u45be = u64;
 
-/// Represents an unsigned, 46-bit, big endian integer
+/// Represents an unsigned 46-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u46be = u64;
 
-/// Represents an unsigned, 47-bit, big endian integer
+/// Represents an unsigned 47-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u47be = u64;
 
-/// Represents an unsigned, 48-bit, big endian integer
+/// Represents an unsigned 48-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u48be = u64;
 
-/// Represents an unsigned, 49-bit, big endian integer
+/// Represents an unsigned 49-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u49be = u64;
 
-/// Represents an unsigned, 50-bit, big endian integer
+/// Represents an unsigned 50-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u50be = u64;
 
-/// Represents an unsigned, 51-bit, big endian integer
+/// Represents an unsigned 51-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u51be = u64;
 
-/// Represents an unsigned, 52-bit, big endian integer
+/// Represents an unsigned 52-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u52be = u64;
 
-/// Represents an unsigned, 53-bit, big endian integer
+/// Represents an unsigned 53-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u53be = u64;
 
-/// Represents an unsigned, 54-bit, big endian integer
+/// Represents an unsigned 54-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u54be = u64;
 
-/// Represents an unsigned, 55-bit, big endian integer
+/// Represents an unsigned 55-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u55be = u64;
 
-/// Represents an unsigned, 56-bit, big endian integer
+/// Represents an unsigned 56-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u56be = u64;
 
-/// Represents an unsigned, 57-bit, big endian integer
+/// Represents an unsigned 57-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u57be = u64;
 
-/// Represents an unsigned, 58-bit, big endian integer
+/// Represents an unsigned 58-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u58be = u64;
 
-/// Represents an unsigned, 59-bit, big endian integer
+/// Represents an unsigned 59-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u59be = u64;
 
-/// Represents an unsigned, 60-bit, big endian integer
+/// Represents an unsigned 60-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u60be = u64;
 
-/// Represents an unsigned, 61-bit, big endian integer
+/// Represents an unsigned 61-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u61be = u64;
 
-/// Represents an unsigned, 62-bit, big endian integer
+/// Represents an unsigned 62-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u62be = u64;
 
-/// Represents an unsigned, 63-bit, big endian integer
+/// Represents an unsigned 63-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u63be = u64;
 
-/// Represents an unsigned, 64-bit, big endian integer
+/// Represents an unsigned 64-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u64be = u64;
 
 
-/// Represents an unsigned, 9-bit, little endian integer
+/// Represents an unsigned 9-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u9le = u16;
 
-/// Represents an unsigned, 10-bit, little endian integer
+/// Represents an unsigned 10-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u10le = u16;
 
-/// Represents an unsigned, 11-bit, little endian integer
+/// Represents an unsigned 11-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u11le = u16;
 
-/// Represents an unsigned, 12-bit, little endian integer
+/// Represents an unsigned 12-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u12le = u16;
 
-/// Represents an unsigned, 13-bit, little endian integer
+/// Represents an unsigned 13-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u13le = u16;
 
-/// Represents an unsigned, 14-bit, little endian integer
+/// Represents an unsigned 14-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u14le = u16;
 
-/// Represents an unsigned, 15-bit, little endian integer
+/// Represents an unsigned 15-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u15le = u16;
 
-/// Represents an unsigned, 16-bit, little endian integer
+/// Represents an unsigned 16-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u16le = u16;
 
-/// Represents an unsigned, 17-bit, little endian integer
+/// Represents an unsigned 17-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u17le = u32;
 
-/// Represents an unsigned, 18-bit, little endian integer
+/// Represents an unsigned 18-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u18le = u32;
 
-/// Represents an unsigned, 19-bit, little endian integer
+/// Represents an unsigned 19-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u19le = u32;
 
-/// Represents an unsigned, 20-bit, little endian integer
+/// Represents an unsigned 20-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u20le = u32;
 
-/// Represents an unsigned, 21-bit, little endian integer
+/// Represents an unsigned 21-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u21le = u32;
 
-/// Represents an unsigned, 22-bit, little endian integer
+/// Represents an unsigned 22-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u22le = u32;
 
-/// Represents an unsigned, 23-bit, little endian integer
+/// Represents an unsigned 23-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u23le = u32;
 
-/// Represents an unsigned, 24-bit, little endian integer
+/// Represents an unsigned 24-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u24le = u32;
 
-/// Represents an unsigned, 25-bit, little endian integer
+/// Represents an unsigned 25-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u25le = u32;
 
-/// Represents an unsigned, 26-bit, little endian integer
+/// Represents an unsigned 26-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u26le = u32;
 
-/// Represents an unsigned, 27-bit, little endian integer
+/// Represents an unsigned 27-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u27le = u32;
 
-/// Represents an unsigned, 28-bit, little endian integer
+/// Represents an unsigned 28-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u28le = u32;
 
-/// Represents an unsigned, 29-bit, little endian integer
+/// Represents an unsigned 29-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u29le = u32;
 
-/// Represents an unsigned, 30-bit, little endian integer
+/// Represents an unsigned 30-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u30le = u32;
 
-/// Represents an unsigned, 31-bit, little endian integer
+/// Represents an unsigned 31-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u31le = u32;
 
-/// Represents an unsigned, 32-bit, little endian integer
+/// Represents an unsigned 32-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u32le = u32;
 
-/// Represents an unsigned, 33-bit, little endian integer
+/// Represents an unsigned 33-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u33le = u64;
 
-/// Represents an unsigned, 34-bit, little endian integer
+/// Represents an unsigned 34-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u34le = u64;
 
-/// Represents an unsigned, 35-bit, little endian integer
+/// Represents an unsigned 35-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u35le = u64;
 
-/// Represents an unsigned, 36-bit, little endian integer
+/// Represents an unsigned 36-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u36le = u64;
 
-/// Represents an unsigned, 37-bit, little endian integer
+/// Represents an unsigned 37-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u37le = u64;
 
-/// Represents an unsigned, 38-bit, little endian integer
+/// Represents an unsigned 38-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u38le = u64;
 
-/// Represents an unsigned, 39-bit, little endian integer
+/// Represents an unsigned 39-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u39le = u64;
 
-/// Represents an unsigned, 40-bit, little endian integer
+/// Represents an unsigned 40-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u40le = u64;
 
-/// Represents an unsigned, 41-bit, little endian integer
+/// Represents an unsigned 41-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u41le = u64;
 
-/// Represents an unsigned, 42-bit, little endian integer
+/// Represents an unsigned 42-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u42le = u64;
 
-/// Represents an unsigned, 43-bit, little endian integer
+/// Represents an unsigned 43-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u43le = u64;
 
-/// Represents an unsigned, 44-bit, little endian integer
+/// Represents an unsigned 44-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u44le = u64;
 
-/// Represents an unsigned, 45-bit, little endian integer
+/// Represents an unsigned 45-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u45le = u64;
 
-/// Represents an unsigned, 46-bit, little endian integer
+/// Represents an unsigned 46-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u46le = u64;
 
-/// Represents an unsigned, 47-bit, little endian integer
+/// Represents an unsigned 47-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u47le = u64;
 
-/// Represents an unsigned, 48-bit, little endian integer
+/// Represents an unsigned 48-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u48le = u64;
 
-/// Represents an unsigned, 49-bit, little endian integer
+/// Represents an unsigned 49-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u49le = u64;
 
-/// Represents an unsigned, 50-bit, little endian integer
+/// Represents an unsigned 50-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u50le = u64;
 
-/// Represents an unsigned, 51-bit, little endian integer
+/// Represents an unsigned 51-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u51le = u64;
 
-/// Represents an unsigned, 52-bit, little endian integer
+/// Represents an unsigned 52-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u52le = u64;
 
-/// Represents an unsigned, 53-bit, little endian integer
+/// Represents an unsigned 53-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u53le = u64;
 
-/// Represents an unsigned, 54-bit, little endian integer
+/// Represents an unsigned 54-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u54le = u64;
 
-/// Represents an unsigned, 55-bit, little endian integer
+/// Represents an unsigned 55-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u55le = u64;
 
-/// Represents an unsigned, 56-bit, little endian integer
+/// Represents an unsigned 56-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u56le = u64;
 
-/// Represents an unsigned, 57-bit, little endian integer
+/// Represents an unsigned 57-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u57le = u64;
 
-/// Represents an unsigned, 58-bit, little endian integer
+/// Represents an unsigned 58-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u58le = u64;
 
-/// Represents an unsigned, 59-bit, little endian integer
+/// Represents an unsigned 59-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u59le = u64;
 
-/// Represents an unsigned, 60-bit, little endian integer
+/// Represents an unsigned 60-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u60le = u64;
 
-/// Represents an unsigned, 61-bit, little endian integer
+/// Represents an unsigned 61-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u61le = u64;
 
-/// Represents an unsigned, 62-bit, little endian integer
+/// Represents an unsigned 62-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u62le = u64;
 
-/// Represents an unsigned, 63-bit, little endian integer
+/// Represents an unsigned 63-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u63le = u64;
 
-/// Represents an unsigned, 64-bit, little endian integer
+/// Represents an unsigned 64-bit integer. libpnet #[packet]-derived structs using this type will
+/// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u64le = u64;


### PR DESCRIPTION
Adds explanations of pnet's endianness handling to the uXXbe and uXXle type definitions' documentation. Adds similar explanations to the documentation that the #[packet] accessor and mutator templates generates.

Fixes #259.