### PR TITLE
Correct the bit used for the 'more fragments' flag

### DIFF
--- a/src/packet/ipv4.rs.in
+++ b/src/packet/ipv4.rs.in
@@ -22,7 +22,7 @@ pub mod Ipv4Flags {
     /// Don't Fragment flag
     pub const DontFragment: u3 = 0b010;
     /// More Fragments flag
-    pub const MoreFragments: u3 = 0b100;
+    pub const MoreFragments: u3 = 0b001;
 }
 
 /// IPv4 header options numbers as defined in


### PR DESCRIPTION
RFC 791 describes the flags field as:

```
      Bit 0: reserved, must be zero
      Bit 1: (DF) 0 = May Fragment,  1 = Don't Fragment.
      Bit 2: (MF) 0 = Last Fragment, 1 = More Fragments.

          0   1   2
        +---+---+---+
        |   | D | M |
        | 0 | F | F |
        +---+---+---+
```
