### PR TITLE
Update build.rs to use globbing instead of hard-coded file list.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,5 +72,6 @@ version = ">=0.1"
 time = ">=0.1"
 
 [build-dependencies]
+glob = "*"
 syntex = { version = "0.42.*", optional = true }
 pnet_macros = { path = "pnet_macros", version = ">=0.6" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,6 @@ version = ">=0.1"
 time = ">=0.1"
 
 [build-dependencies]
-glob = "*"
+glob = "0.2.*"
 syntex = { version = "0.42.*", optional = true }
 pnet_macros = { path = "pnet_macros", version = ">=0.6" }

--- a/build.rs
+++ b/build.rs
@@ -28,22 +28,16 @@ mod macros {
     
     pub fn expand() {
         // globbing for files to pre-process:
-        let pattern = "./**/*.rs.in";
+        let pattern = "./src/packet/**/*.rs.in";
         for entry in glob::glob( pattern ).expect("Failed to read glob pattern") {
-            match entry {
-                Ok(path) => {
-                    println!(" CMP-- {}", path.display() );
-                    //src: Path::new() = /full/path/file.rs.in
-                    let src     = Path::new( path.to_str().expect("Invalid src Specified.") );
-                    //src -> dst: Path::new() = OUT_DIR/file.rs
-                    let out_dir = env::var_os( "OUT_DIR" ).expect("Invalid OUT_DIR.");
-                    let file    = Path::new( path.file_stem().expect("Invalid file_stem.") );
-                    let dst     = Path::new( &out_dir ).join(file);
-                    let mut registry = syntex::Registry::new();
-                    pnet_macros::register(&mut registry);
-                    registry.expand("", &src, &dst).unwrap();
-                },
-                Err(_) => {},
+            if let Ok(path) = entry {
+                let src     = Path::new( path.to_str().expect("Invalid src Specified.") );
+                let out_dir = env::var_os( "OUT_DIR" ).expect("Invalid OUT_DIR.");
+                let file    = Path::new( path.file_stem().expect("Invalid file_stem.") );
+                let dst     = Path::new( &out_dir ).join(file);
+                let mut registry = syntex::Registry::new();
+                pnet_macros::register(&mut registry);
+                registry.expand("", &src, &dst).unwrap();
             }
         }
     }

--- a/docs/using_packet.md
+++ b/docs/using_packet.md
@@ -29,6 +29,7 @@ version = "0.1.0"
 authors = ["My Name <my.email@mydomain.com>"]
 build = "build.rs"
 [build-dependencies]
+glob = "*"
 syntex = "X" # where X is the version of syntex used in pnet_macros/Cargo.toml
 pnet_macros = "*"
 [dependencies]
@@ -181,27 +182,38 @@ Invoking Syntex From Your Build Script
 --------------------------------------
 
 To pull everything together, we need to invoke `syntex` within the build script.
-This is a simple build script for building just a single packet type; see the
-`build.rs` from `libpnet` for an example of how to build a bunch of them:
+This is a simple build script for recursively building files using the pnet_macros; see also the
+`build.rs` from `libpnet` as an example of how many packets are built:
 
 ```rust
-
-extern crate syntex;
-extern crate pnet_macros;
-
-use std::env;
-use std::path::Path;
-
 fn main() {
-    let mut registry = syntex::Registry::new();
-    pnet_macros::register(&mut registry);
-
-    let src = Path::new("src/packet/my_protocol.rs.in");
-    let dst = Path::new(&env::var_os("OUT_DIR").unwrap()).join("my_protocol.rs");
-
-    registry.expand("", &src, &dst).unwrap();
+    extern crate pnet_macros;
+    extern crate syntex;
+    extern crate glob;
+    
+    use std::env;
+    use std::path::Path;
+    
+    // globbing for files to pre-process:
+    let pattern = "./**/*.rs.in";
+    for entry in glob::glob( pattern ).expect("Failed to read glob pattern") {
+	    match entry {
+	        Ok(path) => {
+                println!(" CMP-- {}", path.display() );
+                //src: Path::new() = /full/path/file.rs.in
+                let src     = Path::new( path.to_str().expect("Invalid src Specified.") );
+                //src -> dst: Path::new() = OUT_DIR/file.rs
+                let out_dir = env::var_os( "OUT_DIR" ).expect("Invalid OUT_DIR.");
+                let file    = Path::new( path.file_stem().expect("Invalid file_stem.") );
+                let dst     = Path::new( &out_dir ).join(file);
+                let mut registry = syntex::Registry::new();
+                pnet_macros::register(&mut registry);
+                registry.expand("", &src, &dst).unwrap();
+            },
+	    	Err(_) => {},
+        }
+    }
 }
-
 ```
 
 Upstreaming Packet Definitions

--- a/docs/using_packet.md
+++ b/docs/using_packet.md
@@ -182,8 +182,7 @@ Invoking Syntex From Your Build Script
 --------------------------------------
 
 To pull everything together, we need to invoke `syntex` within the build script.
-This is a simple build script for recursively building files using the pnet_macros; see also the
-`build.rs` from `libpnet` as an example of how many packets are built:
+This is an example `build.rs` script which uses a glob "pattern" to specify that all `.rs.in` files under `./src/` should be pre-processed by `syntex`.
 
 ```rust
 fn main() {
@@ -195,22 +194,16 @@ fn main() {
     use std::path::Path;
     
     // globbing for files to pre-process:
-    let pattern = "./**/*.rs.in";
+    let pattern = "./src/packet/**/*.rs.in";
     for entry in glob::glob( pattern ).expect("Failed to read glob pattern") {
-	    match entry {
-	        Ok(path) => {
-                println!(" CMP-- {}", path.display() );
-                //src: Path::new() = /full/path/file.rs.in
-                let src     = Path::new( path.to_str().expect("Invalid src Specified.") );
-                //src -> dst: Path::new() = OUT_DIR/file.rs
-                let out_dir = env::var_os( "OUT_DIR" ).expect("Invalid OUT_DIR.");
-                let file    = Path::new( path.file_stem().expect("Invalid file_stem.") );
-                let dst     = Path::new( &out_dir ).join(file);
-                let mut registry = syntex::Registry::new();
-                pnet_macros::register(&mut registry);
-                registry.expand("", &src, &dst).unwrap();
-            },
-	    Err(_) => {},
+        if let Ok(path) = entry {
+            let src     = Path::new( path.to_str().expect("Invalid src Specified.") );
+            let out_dir = env::var_os( "OUT_DIR" ).expect("Invalid OUT_DIR.");
+            let file    = Path::new( path.file_stem().expect("Invalid file_stem.") );
+            let dst     = Path::new( &out_dir ).join(file);
+            let mut registry = syntex::Registry::new();
+            pnet_macros::register(&mut registry);
+            registry.expand("", &src, &dst).unwrap();
         }
     }
 }

--- a/docs/using_packet.md
+++ b/docs/using_packet.md
@@ -29,7 +29,7 @@ version = "0.1.0"
 authors = ["My Name <my.email@mydomain.com>"]
 build = "build.rs"
 [build-dependencies]
-glob = "*"
+glob = "0.2.*"
 syntex = "X" # where X is the version of syntex used in pnet_macros/Cargo.toml
 pnet_macros = "*"
 [dependencies]
@@ -210,7 +210,7 @@ fn main() {
                 pnet_macros::register(&mut registry);
                 registry.expand("", &src, &dst).unwrap();
             },
-	    	Err(_) => {},
+	    Err(_) => {},
         }
     }
 }


### PR DESCRIPTION
This would add `glob = "*"` to build-dependencies, but remove the hard-coded files list in build.rs.
Otherwise build.rs works in the same fashion as before.

The docs-example at `docs/using_packet.md` are updated to reflect the new build-dependency and its example build.rs uses a simplified version of the build.rs.

Both the example and libpnet-build.rs successfully ran the `cargo test` tests under Linux Mint 18.1 Serena / cargo-0.18.0-nightly (6f1b860 2017-02-11) for their respective source(s).