### PR TITLE
Added flags argument to recv_from and flag field to transport_channel_iterator

### DIFF
--- a/src/datalink/linux.rs
+++ b/src/datalink/linux.rs
@@ -312,7 +312,7 @@ impl<'a> EthernetDataLinkChannelIterator<'a> for DataLinkChannelIteratorImpl<'a>
         } else if ret == 0 {
             Err(io::Error::new(io::ErrorKind::TimedOut, "Timed out"))
         } else {
-            let res = internal::recv_from(self.pc.socket.fd, &mut self.pc.read_buffer, &mut caddr);
+            let res = internal::recv_from(self.pc.socket.fd, &mut self.pc.read_buffer, &mut caddr, 0);
             match res {
                 Ok(len) => Ok(EthernetPacket::new(&self.pc.read_buffer[0..len]).unwrap()),
                 Err(e) => Err(e),

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -66,14 +66,15 @@ pub fn send_to(socket: sockets::CSocket,
 
 pub fn recv_from(socket: sockets::CSocket,
                  buffer: &mut [u8],
-                 caddr: *mut sockets::SockAddrStorage)
+                 caddr: *mut sockets::SockAddrStorage,
+                 flags: i32)
     -> io::Result<usize> {
     let mut caddrlen = mem::size_of::<sockets::SockAddrStorage>() as sockets::SockLen;
     let len = retry(&mut || unsafe {
         sockets::recvfrom(socket,
                           buffer.as_ptr() as sockets::MutBuf,
                           buffer.len() as sockets::BufLen,
-                          0,
+                          flags,
                           caddr as *mut sockets::SockAddr,
                           &mut caddrlen)
     });


### PR DESCRIPTION
I want to be able to set custom flags for calls to `sockets::recvfrom`. Specifically, I want to be able to call `iter.next()` (where `iter` is a [`pnet::transport::Ipv4TransportChannelIterator`](https://octarineparrot.com/assets/libpnet/doc/pnet/transport/struct.Ipv4TransportChannelIterator.html)) in a non-blocking fashion by passing a [**MSG_DONTWAIT** flag](https://linux.die.net/man/2/recv). This would prevent me from having to add any threads at the application level.

Although this is a pretty simple change, it might not be in the best place!