### PR TITLE
Disallow warnings when building for CI

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,7 @@
 #![cfg_attr(feature="clippy", plugin(clippy))]
 // We can't implement Iterator since we use streaming iterators
 #![cfg_attr(feature="clippy", allow(should_implement_trait))]
+#![cfg_attr(any(feature = "appveyor", feature = "travis"), deny(warnings))]
 
 #[cfg(feature = "benchmark")]
 extern crate test;

--- a/src/pnettest.rs
+++ b/src/pnettest.rs
@@ -6,6 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(warnings)]
+
 extern crate libc;
 
 use datalink;


### PR DESCRIPTION
Only deny on CI - it's an annoyance while developing, but important for final code.