### PR TITLE
Add basic support for ICMPv6

### DIFF
--- a/src/packet/icmpv6.rs
+++ b/src/packet/icmpv6.rs
@@ -1,0 +1,15 @@
+// Copyright (c) 2015 Robert Clipsham <robert@octarineparrot.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! ICMPv6 packet abstraction
+
+#[cfg(feature = "with-syntex")]
+include!(concat!(env!("OUT_DIR"), "/icmpv6.rs"));
+
+#[cfg(not(feature = "with-syntex"))]
+include!("icmpv6.rs.in");

--- a/src/packet/icmpv6.rs.in
+++ b/src/packet/icmpv6.rs.in
@@ -1,0 +1,130 @@
+// Copyright (c) 2014, 2015 Robert Clipsham <robert@octarineparrot.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use packet::ip::IpNextHeaderProtocols;
+use packet::PrimitiveValues;
+use pnet_macros_support::types::*;
+use std::net::Ipv6Addr;
+
+/// Represents the "ICMPv6 type" header field.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Icmpv6Type(pub u8);
+
+impl Icmpv6Type {
+    /// Create an ICMPv6 type
+    pub fn new(val: u8) -> Icmpv6Type {
+        Icmpv6Type(val)
+    }
+}
+
+impl PrimitiveValues for Icmpv6Type {
+    type T = (u8,);
+    fn to_primitive_values(&self) -> (u8,) {
+        (self.0,)
+    }
+}
+
+/// Represents the "ICMPv6 code" header field.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Icmpv6Code(pub u8);
+
+impl Icmpv6Code {
+    /// Create an ICMPv6 code
+    pub fn new(val: u8) -> Icmpv6Code {
+        Icmpv6Code(val)
+    }
+}
+
+impl PrimitiveValues for Icmpv6Code {
+    type T = (u8,);
+    fn to_primitive_values(&self) -> (u8,) {
+        (self.0,)
+    }
+}
+
+/// Represents a generic ICMPv6 packet
+///
+/// ```text
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |     Type      |     Code      |          Checksum             |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |                                                               |
+/// +                         Message Body                          +
+/// |                                                               |
+/// ```
+#[packet]
+pub struct Icmpv6 {
+    #[construct_with(u8)]
+    pub icmpv6_type: Icmpv6Type,
+    #[construct_with(u8)]
+    pub icmpv6_code: Icmpv6Code,
+    pub checksum: u16be,
+    #[payload]
+    pub payload: Vec<u8>,
+}
+
+/// Calculates the checksum of an ICMPv6 packet
+pub fn checksum(packet: &Icmpv6Packet, source: Ipv6Addr, destination: Ipv6Addr) -> u16be {
+    use packet::Packet;
+    use util;
+
+    util::ipv6_checksum(packet.packet(), 1, &[], source, destination, IpNextHeaderProtocols::Icmpv6)
+}
+
+#[cfg(test)]
+mod checksum_tests {
+    use super::*;
+
+    #[test]
+    fn checksum_echo_request() {
+        // The equivalent of your typical ping -6 ::1%lo
+        let lo = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1);
+        let mut data = vec![
+            0x80, // Icmpv6 Type
+            0x00, // Code
+            0xff, 0xff, // Checksum
+            0x00, 0x00, // Id
+            0x00, 0x01, // Sequence
+            // 56 bytes of "random" data
+            0x20, 0x20, 0x75, 0x73, 0x74, 0x20, 0x61, 0x20,
+            0x66, 0x6c, 0x65, 0x73, 0x68, 0x20, 0x77, 0x6f,
+            0x75, 0x6e, 0x64, 0x20, 0x20, 0x74, 0x69, 0x73,
+            0x20, 0x62, 0x75, 0x74, 0x20, 0x61, 0x20, 0x73,
+            0x63, 0x72, 0x61, 0x74, 0x63, 0x68, 0x20, 0x20,
+            0x6b, 0x6e, 0x69, 0x67, 0x68, 0x74, 0x73, 0x20,
+            0x6f, 0x66, 0x20, 0x6e, 0x69, 0x20, 0x20, 0x20
+        ];
+        let mut pkg = MutableIcmpv6Packet::new(&mut data[..]).unwrap();
+        assert_eq!(checksum(&pkg.to_immutable(), lo, lo), 0x1d2e);
+
+        // Check
+        pkg.set_icmpv6_type(Icmpv6Type(0x81));
+        assert_eq!(checksum(&pkg.to_immutable(), lo, lo), 0x1c2e);
+    }
+}
+
+
+/// Enumeration of the recognized ICMPv6 types
+#[allow(non_snake_case)]
+#[allow(non_upper_case_globals)]
+pub mod Icmpv6Types {
+
+    use packet::icmpv6::Icmpv6Type;
+    /// ICMPv6 type for "destination unreachable"
+    pub const DestinationUnreachable: Icmpv6Type = Icmpv6Type(1);
+    /// ICMPv6 type for "packet too big"
+    pub const PacketTooBig: Icmpv6Type = Icmpv6Type(2);
+    /// ICMPv6 type for "time exceeded"
+    pub const TimeExceeded: Icmpv6Type = Icmpv6Type(3);
+    /// ICMPv6 type for "parameter problem"
+    pub const ParameterProblem: Icmpv6Type = Icmpv6Type(4);
+    /// ICMPv6 type for "echo request"
+    pub const EchoRequest: Icmpv6Type = Icmpv6Type(128);
+    /// ICMPv6 type for "echo reply"
+    pub const EchoReply: Icmpv6Type = Icmpv6Type(129);
+}

--- a/src/packet/ip.rs
+++ b/src/packet/ip.rs
@@ -198,8 +198,11 @@ pub mod IpNextHeaderProtocols {
     /// SKIP
     pub const Skip: IpNextHeaderProtocol = IpNextHeaderProtocol(57);
 
-    /// ICMP for IPv6 [RFC2460]
+    #[deprecated(note="Please use `IpNextHeaderProtocols::Icmpv6` instead")]
     pub const Ipv6Icmp: IpNextHeaderProtocol = IpNextHeaderProtocol(58);
+
+    /// ICMPv6 [RFC4443]
+    pub const Icmpv6: IpNextHeaderProtocol = IpNextHeaderProtocol(58);
 
     /// No Next Header for IPv6 [RFC2460]
     pub const Ipv6NoNxt: IpNextHeaderProtocol = IpNextHeaderProtocol(59);
@@ -546,7 +549,7 @@ impl fmt::Display for IpNextHeaderProtocol {
                    &IpNextHeaderProtocols::Mobile => "Mobile", // 55
                    &IpNextHeaderProtocols::Tlsp => "Tlsp", // 56
                    &IpNextHeaderProtocols::Skip => "Skip", // 57
-                   &IpNextHeaderProtocols::Ipv6Icmp => "Ipv6Icmp", // 58
+                   &IpNextHeaderProtocols::Icmpv6 => "Icmpv6", // 58
                    &IpNextHeaderProtocols::Ipv6NoNxt => "Ipv6NoNxt", // 59
                    &IpNextHeaderProtocols::Ipv6Opts => "Ipv6Opts", // 60
                    &IpNextHeaderProtocols::HostInternal => "HostInternal", // 61

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -200,4 +200,5 @@ pub mod udp;
 pub mod tcp;
 pub mod arp;
 pub mod icmp;
+pub mod icmpv6;
 pub mod vlan;

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -28,6 +28,7 @@ use packet::ip::IpNextHeaderProtocol;
 use packet::ipv4::Ipv4Packet;
 use packet::udp::UdpPacket;
 use packet::icmp::IcmpPacket;
+use packet::icmpv6::Icmpv6Packet;
 use packet::tcp::TcpPacket;
 use self::TransportChannelType::{Layer3, Layer4};
 use self::TransportProtocol::{Ipv4, Ipv6};
@@ -293,5 +294,7 @@ transport_channel_iterator!(Ipv4Packet, Ipv4TransportChannelIterator, ipv4_packe
 transport_channel_iterator!(UdpPacket, UdpTransportChannelIterator, udp_packet_iter);
 
 transport_channel_iterator!(IcmpPacket, IcmpTransportChannelIterator, icmp_packet_iter);
+
+transport_channel_iterator!(Icmpv6Packet, Icmpv6TransportChannelIterator, icmpv6_packet_iter);
 
 transport_channel_iterator!(TcpPacket, TcpTransportChannelIterator, tcp_packet_iter);


### PR DESCRIPTION
 - Add packet structures for icmpv6
 - Add Tests
   - Add unit tests for icmpv6 checksum calculation
   - Update packetdump to handle icmpv6 packets

The implementation of `icmpv6` was heavily based on the implementation of `icmp`. Comments and critiques are very much welcomed.