### PR TITLE
extract payload length for IPv4 and IPv6 packets

### DIFF
--- a/src/packet/ipv4.rs.in
+++ b/src/packet/ipv4.rs.in
@@ -273,8 +273,9 @@ fn ipv4_option_payload_length(ipv4_option: &Ipv4OptionPacket) -> usize {
 #[test]
 fn ipv4_packet_test() {
     use packet::ip::IpNextHeaderProtocols;
+    use packet::Packet;
 
-    let mut packet = [0u8; 20];
+    let mut packet = [0u8; 200];
     {
         let mut ip_header = MutableIpv4Packet::new(&mut packet[..]).unwrap();
         ip_header.set_version(4);
@@ -291,6 +292,7 @@ fn ipv4_packet_test() {
 
         ip_header.set_total_length(115);
         assert_eq!(ip_header.get_total_length(), 115);
+        assert_eq!(110, ip_header.payload().len());
 
         ip_header.set_identification(257);
         assert_eq!(ip_header.get_identification(), 257);
@@ -330,7 +332,7 @@ fn ipv4_packet_test() {
                       0xc0, 0xa8, 0x00, 0x01, /* source ip */
                       0xc0, 0xa8, 0x00, 0xc7  /* dest ip */];
 
-    assert_eq!(&ref_packet[..], &packet[..]);
+    assert_eq!(&ref_packet[..], &packet[..ref_packet.len()]);
 }
 
 #[test]

--- a/src/packet/ipv4.rs.in
+++ b/src/packet/ipv4.rs.in
@@ -150,6 +150,7 @@ pub struct Ipv4 {
     pub destination: Ipv4Addr,
     #[length_fn = "ipv4_options_length"]
     pub options: Vec<Ipv4Option>,
+    #[length_fn = "ipv4_payload_length"]
     #[payload]
     pub payload: Vec<u8>,
 }
@@ -229,6 +230,10 @@ fn ipv4_options_length_test() {
     let mut ip_header = MutableIpv4Packet::new(&mut packet[..]).unwrap();
     ip_header.set_header_length(5);
     assert_eq!(ipv4_options_length(&ip_header.to_immutable()), 0);
+}
+
+fn ipv4_payload_length(ipv4: &Ipv4Packet) -> usize {
+    (ipv4.get_total_length() as usize).saturating_sub(ipv4.get_header_length() as usize)
 }
 
 /// Represents the IPv4 Option field

--- a/src/packet/ipv6.rs.in
+++ b/src/packet/ipv6.rs.in
@@ -26,6 +26,7 @@ pub struct Ipv6 {
     pub source: Ipv6Addr,
     #[construct_with(u16, u16, u16, u16, u16, u16, u16, u16)]
     pub destination: Ipv6Addr,
+    #[length = "payload_length"]
     #[payload]
     pub payload: Vec<u8>,
 }

--- a/src/packet/ipv6.rs.in
+++ b/src/packet/ipv6.rs.in
@@ -34,7 +34,9 @@ pub struct Ipv6 {
 #[test]
 fn ipv6_header_test() {
     use packet::ip::IpNextHeaderProtocols;
-    let mut packet = [0u8; 40];
+    use packet::Packet;
+
+    let mut packet = [0u8; 0x200];
     {
         let mut ip_header = MutableIpv6Packet::new(&mut packet[..]).unwrap();
         ip_header.set_version(6);
@@ -48,6 +50,7 @@ fn ipv6_header_test() {
 
         ip_header.set_payload_length(0x0101);
         assert_eq!(ip_header.get_payload_length(), 0x0101);
+        assert_eq!(0x0101, ip_header.payload().len());
 
         ip_header.set_next_header(IpNextHeaderProtocols::Udp);
         assert_eq!(ip_header.get_next_header(), IpNextHeaderProtocols::Udp);
@@ -80,5 +83,5 @@ fn ipv6_header_test() {
                       0x01, 0x10, 0x10, 0x01,
                       0x01, 0x10, 0x10, 0x01,
                       0x01, 0x10, 0x10, 0x01];
-    assert_eq!(&ref_packet[..], &packet[..]);
+    assert_eq!(&ref_packet[..], &packet[..ref_packet.len()]);
 }


### PR DESCRIPTION
Both IPv4 and IPv6 frames carry information how large their payloads actually are.

This commit makes use of them, instead of relying on the size of the buffer that was passed in.