### PR TITLE
Make datalink layer use &[u8] instead of packet

### DIFF
--- a/benches/rs_receiver.rs
+++ b/benches/rs_receiver.rs
@@ -35,9 +35,8 @@ fn main() {
     let mut timestamps = Vec::with_capacity(201);
     timestamps.push(time::precise_time_ns() / 1_000);
 
-    let mut iter = rx.iter();
     loop {
-        match iter.next() {
+        match rx.next() {
             Ok(_) => {
                 i += 1;
                 if i == 1_000_000 {

--- a/benches/rs_sender.rs
+++ b/benches/rs_sender.rs
@@ -12,10 +12,8 @@ use pnet::datalink;
 use pnet::packet::{MutablePacket, Packet};
 use pnet::packet::ethernet::{EtherTypes, EthernetPacket, MutableEthernetPacket};
 use pnet::packet::ip::IpNextHeaderProtocols;
-use pnet::packet::ipv4;
-use pnet::packet::ipv4::MutableIpv4Packet;
-use pnet::packet::udp;
-use pnet::packet::udp::MutableUdpPacket;
+use pnet::packet::ipv4::{self, MutableIpv4Packet};
+use pnet::packet::udp::{self, MutableUdpPacket};
 
 use std::env;
 use std::net::Ipv4Addr;
@@ -90,17 +88,15 @@ fn main() {
     };
 
     let mut buffer = [0u8; 64];
-    let mut mut_ethernet_header = MutableEthernetPacket::new(&mut buffer[..]).unwrap();
     {
+        let mut mut_ethernet_header = MutableEthernetPacket::new(&mut buffer[..]).unwrap();
         mut_ethernet_header.set_destination(destination);
         mut_ethernet_header.set_source(interface.mac_address());
         mut_ethernet_header.set_ethertype(EtherTypes::Ipv4);
         build_udp4_packet(mut_ethernet_header.payload_mut(), "rmesg");
     }
 
-    let ethernet_header = EthernetPacket::new(mut_ethernet_header.packet()).unwrap();
-
     loop {
-        tx.send_to(&ethernet_header, None);
+        tx.send_to(&buffer, None);
     }
 }

--- a/examples/arp_packet.rs
+++ b/examples/arp_packet.rs
@@ -11,7 +11,7 @@ use pnet::datalink::Channel;
 use pnet::packet::ethernet::MutableEthernetPacket;
 use pnet::packet::arp::MutableArpPacket;
 use pnet::packet::ethernet::EtherTypes;
-use pnet::packet::MutablePacket;
+use pnet::packet::{Packet, MutablePacket};
 use pnet::packet::arp::{ArpHardwareTypes, ArpOperations, ArpOperation};
 
 
@@ -44,7 +44,7 @@ fn send_arp_packet(interface: NetworkInterface, source_ip: Ipv4Addr, source_mac:
 
     ethernet_packet.set_payload(arp_packet.packet_mut());
 
-    tx.send_to(&ethernet_packet.to_immutable(), Some(interface));
+    tx.send_to(ethernet_packet.packet(), Some(interface));
 }
 
 fn main() {

--- a/examples/packetdump.rs
+++ b/examples/packetdump.rs
@@ -226,7 +226,7 @@ fn main() {
     let mut iter = rx.iter();
     loop {
         match iter.next() {
-            Ok(packet) => handle_packet(&interface.name[..], &packet),
+            Ok(packet) => handle_packet(&interface.name[..], &EthernetPacket::new(packet).unwrap()),
             Err(e) => panic!("packetdump: unable to receive packet: {}", e),
         }
     }

--- a/examples/packetdump.rs
+++ b/examples/packetdump.rs
@@ -223,9 +223,8 @@ fn main() {
         Err(e) => panic!("packetdump: unable to create channel: {}", e),
     };
 
-    let mut iter = rx.iter();
     loop {
-        match iter.next() {
+        match rx.next() {
             Ok(packet) => handle_packet(&interface.name[..], &EthernetPacket::new(packet).unwrap()),
             Err(e) => panic!("packetdump: unable to receive packet: {}", e),
         }

--- a/src/datalink/bpf.rs
+++ b/src/datalink/bpf.rs
@@ -13,7 +13,7 @@ extern crate libc;
 
 use bindings::bpf;
 use datalink::{self, NetworkInterface};
-use datalink::{DataLinkChannelIterator, DataLinkReceiver, DataLinkSender};
+use datalink::{DataLinkReceiver, DataLinkSender};
 use datalink::Channel::Ethernet;
 use internal;
 use sockets;
@@ -229,6 +229,8 @@ pub fn channel(network_interface: &NetworkInterface,
         read_buffer: repeat(0u8).take(allocated_read_buffer_size).collect(),
         loopback: loopback,
         timeout: config.read_timeout.map(|to| internal::duration_to_timespec(to)),
+        // Enough room for minimally sized packets without reallocating
+        packets: VecDeque::with_capacity(allocated_read_buffer_size / 64),
     });
     unsafe {
         libc::FD_ZERO(&mut receiver.fd_set as *mut libc::fd_set);
@@ -336,41 +338,26 @@ struct DataLinkReceiverImpl {
     read_buffer: Vec<u8>,
     loopback: bool,
     timeout: Option<libc::timespec>,
-}
-
-impl DataLinkReceiver for DataLinkReceiverImpl {
-    fn iter<'a>(&'a mut self) -> Box<DataLinkChannelIterator + 'a> {
-        let buflen = self.read_buffer.len();
-        Box::new(DataLinkChannelIteratorImpl {
-            pc: self,
-            // Enough room for minimally sized packets without reallocating
-            packets: VecDeque::with_capacity(buflen / 64),
-        })
-    }
-}
-
-struct DataLinkChannelIteratorImpl<'a> {
-    pc: &'a mut DataLinkReceiverImpl,
     packets: VecDeque<(usize, usize)>,
 }
 
-impl<'a> DataLinkChannelIterator<'a> for DataLinkChannelIteratorImpl<'a> {
+impl DataLinkReceiver for DataLinkReceiverImpl {
     fn next(&mut self) -> io::Result<&[u8]> {
         // Loopback packets arrive with a 4 byte header instead of normal ethernet header.
         // Discard that header and replace with zeroed out ethernet header.
-        let (header_size, buffer_offset) = if self.pc.loopback {
+        let (header_size, buffer_offset) = if self.loopback {
             (4, ETHERNET_HEADER_SIZE)
         } else {
             (0, 0)
         };
         if self.packets.is_empty() {
-            let buffer = &mut self.pc.read_buffer[buffer_offset..];
+            let buffer = &mut self.read_buffer[buffer_offset..];
             let ret = unsafe {
-                libc::pselect(self.pc.fd.fd + 1,
-                              &mut self.pc.fd_set as *mut libc::fd_set,
+                libc::pselect(self.fd.fd + 1,
+                              &mut self.fd_set as *mut libc::fd_set,
                               ptr::null_mut(),
                               ptr::null_mut(),
-                              self.pc
+                              self
                                   .timeout
                                   .as_ref()
                                   .map(|to| to as *const libc::timespec)
@@ -383,7 +370,7 @@ impl<'a> DataLinkChannelIterator<'a> for DataLinkChannelIteratorImpl<'a> {
                 return Err(io::Error::new(io::ErrorKind::TimedOut, "Timed out"));
             } else {
                 let buflen = match unsafe {
-                    libc::read(self.pc.fd.fd,
+                    libc::read(self.fd.fd,
                                buffer.as_ptr() as *mut libc::c_void,
                                buffer.len() as libc::size_t)
                 } {
@@ -408,10 +395,10 @@ impl<'a> DataLinkChannelIterator<'a> for DataLinkChannelIteratorImpl<'a> {
         let (start, mut len) = self.packets.pop_front().unwrap();
         len += buffer_offset;
         // Zero out part that will become fake ethernet header if on loopback.
-        for i in (&mut self.pc.read_buffer[start..start + buffer_offset]).iter_mut() {
+        for i in (&mut self.read_buffer[start..start + buffer_offset]).iter_mut() {
             *i = 0;
         }
-        Ok(&self.pc.read_buffer[start..start + len])
+        Ok(&self.read_buffer[start..start + len])
     }
 }
 

--- a/src/datalink/bpf.rs
+++ b/src/datalink/bpf.rs
@@ -13,7 +13,7 @@ extern crate libc;
 
 use bindings::bpf;
 use datalink::{self, NetworkInterface};
-use datalink::{EthernetDataLinkChannelIterator, EthernetDataLinkReceiver, EthernetDataLinkSender};
+use datalink::{DataLinkChannelIterator, DataLinkReceiver, DataLinkSender};
 use datalink::Channel::Ethernet;
 use internal;
 use sockets;
@@ -246,7 +246,7 @@ struct DataLinkSenderImpl {
     timeout: Option<libc::timespec>,
 }
 
-impl EthernetDataLinkSender for DataLinkSenderImpl {
+impl DataLinkSender for DataLinkSenderImpl {
     #[inline]
     fn build_and_send(&mut self,
                       num_packets: usize,
@@ -338,8 +338,8 @@ struct DataLinkReceiverImpl {
     timeout: Option<libc::timespec>,
 }
 
-impl EthernetDataLinkReceiver for DataLinkReceiverImpl {
-    fn iter<'a>(&'a mut self) -> Box<EthernetDataLinkChannelIterator + 'a> {
+impl DataLinkReceiver for DataLinkReceiverImpl {
+    fn iter<'a>(&'a mut self) -> Box<DataLinkChannelIterator + 'a> {
         let buflen = self.read_buffer.len();
         Box::new(DataLinkChannelIteratorImpl {
             pc: self,
@@ -354,7 +354,7 @@ struct DataLinkChannelIteratorImpl<'a> {
     packets: VecDeque<(usize, usize)>,
 }
 
-impl<'a> EthernetDataLinkChannelIterator<'a> for DataLinkChannelIteratorImpl<'a> {
+impl<'a> DataLinkChannelIterator<'a> for DataLinkChannelIteratorImpl<'a> {
     fn next(&mut self) -> io::Result<&[u8]> {
         // Loopback packets arrive with a 4 byte header instead of normal ethernet header.
         // Discard that header and replace with zeroed out ethernet header.

--- a/src/datalink/linux.rs
+++ b/src/datalink/linux.rs
@@ -13,7 +13,7 @@ extern crate libc;
 
 use bindings::linux;
 use datalink::{self, NetworkInterface};
-use datalink::{EthernetDataLinkChannelIterator, EthernetDataLinkReceiver, EthernetDataLinkSender};
+use datalink::{DataLinkChannelIterator, DataLinkReceiver, DataLinkSender};
 use datalink::Channel::Ethernet;
 use datalink::ChannelType::{Layer2, Layer3};
 use internal;
@@ -176,7 +176,7 @@ struct DataLinkSenderImpl {
     timeout: Option<libc::timespec>,
 }
 
-impl EthernetDataLinkSender for DataLinkSenderImpl {
+impl DataLinkSender for DataLinkSenderImpl {
     // FIXME Layer 3
     #[inline]
     fn build_and_send(&mut self,
@@ -272,9 +272,9 @@ struct DataLinkReceiverImpl {
     timeout: Option<libc::timespec>,
 }
 
-impl EthernetDataLinkReceiver for DataLinkReceiverImpl {
+impl DataLinkReceiver for DataLinkReceiverImpl {
     // FIXME Layer 3
-    fn iter<'a>(&'a mut self) -> Box<EthernetDataLinkChannelIterator + 'a> {
+    fn iter<'a>(&'a mut self) -> Box<DataLinkChannelIterator + 'a> {
         Box::new(DataLinkChannelIteratorImpl { pc: self })
     }
 }
@@ -283,7 +283,7 @@ struct DataLinkChannelIteratorImpl<'a> {
     pc: &'a mut DataLinkReceiverImpl,
 }
 
-impl<'a> EthernetDataLinkChannelIterator<'a> for DataLinkChannelIteratorImpl<'a> {
+impl<'a> DataLinkChannelIterator<'a> for DataLinkChannelIteratorImpl<'a> {
     fn next(&mut self) -> io::Result<&[u8]> {
         let mut caddr: libc::sockaddr_storage = unsafe { mem::zeroed() };
         unsafe {

--- a/src/datalink/linux.rs
+++ b/src/datalink/linux.rs
@@ -17,7 +17,6 @@ use datalink::{EthernetDataLinkChannelIterator, EthernetDataLinkReceiver, Ethern
 use datalink::Channel::Ethernet;
 use datalink::ChannelType::{Layer2, Layer3};
 use internal;
-use packet::ethernet::EtherType;
 use sockets;
 use std::cmp;
 use std::io;
@@ -98,7 +97,7 @@ pub fn channel(network_interface: &NetworkInterface,
     let eth_p_all = 0x0003;
     let (typ, proto) = match config.channel_type {
         Layer2 => (libc::SOCK_RAW, eth_p_all),
-        Layer3(EtherType(proto)) => (libc::SOCK_DGRAM, proto),
+        Layer3(proto) => (libc::SOCK_DGRAM, proto),
     };
     let socket = unsafe { libc::socket(libc::AF_PACKET, typ, proto.to_be() as i32) };
     if socket == -1 {

--- a/src/datalink/mod.rs
+++ b/src/datalink/mod.rs
@@ -177,17 +177,8 @@ pub trait DataLinkSender: Send {
 /// Structure for receiving packets at the data link layer. Should be constructed using
 /// datalink_channel().
 pub trait DataLinkReceiver: Send {
-    /// Returns an iterator over Ethernet frames.
-    ///
-    /// This will likely be removed once other layer two types are supported.
     #[inline]
-    fn iter<'a>(&'a mut self) -> Box<DataLinkChannelIterator + 'a>;
-}
-
-/// An iterator over data link layer packets
-pub trait DataLinkChannelIterator<'a> {
     /// Get the next Ethernet frame in the channel
-    #[inline]
     fn next(&mut self) -> io::Result<&[u8]>;
 }
 

--- a/src/datalink/mod.rs
+++ b/src/datalink/mod.rs
@@ -8,7 +8,7 @@
 
 //! Support for sending and receiving data link layer packets
 
-use packet::ethernet::{EtherType, EthernetPacket, MutableEthernetPacket};
+use packet::ethernet::EtherType;
 use sockets;
 use std::io;
 use std::option::Option;
@@ -144,65 +144,52 @@ pub fn channel(network_interface: &NetworkInterface, configuration: Config) -> i
     backend::channel(network_interface, (&configuration).into())
 }
 
-macro_rules! dls {
-    ($name:ident, $mut_packet:ident, $packet:ident) => {
-        /// Trait to enable sending $packet packets
-        pub trait $name : Send {
-            /// Create and send a number of packets
-            ///
-            /// This will call `func` `num_packets` times. The function will be provided with a
-            /// mutable packet to manipulate, which will then be sent. This allows packets to be
-            /// built in-place, avoiding the copy required for `send`. If there is not sufficient
-            /// capacity in the buffer, None will be returned.
-            #[inline]
-            fn build_and_send(&mut self,
-                              num_packets: usize,
-                              packet_size: usize,
-                              func: &mut FnMut($mut_packet))
-            -> Option<io::Result<()>>;
 
-            /// Send a packet
-            ///
-            /// This may require an additional copy compared to `build_and_send`, depending on the
-            /// operating system being used. The second parameter is currently ignored, however
-            /// `None` should be passed.
-            #[inline]
-            fn send_to(&mut self,
-                       packet: &$packet,
-                       dst: Option<NetworkInterface>)
-                -> Option<io::Result<()>>;
-        }
-    }
+/// Trait to enable sending $packet packets
+pub trait EthernetDataLinkSender: Send {
+    /// Create and send a number of packets
+    ///
+    /// This will call `func` `num_packets` times. The function will be provided with a
+    /// mutable packet to manipulate, which will then be sent. This allows packets to be
+    /// built in-place, avoiding the copy required for `send`. If there is not sufficient
+    /// capacity in the buffer, None will be returned.
+    #[inline]
+    fn build_and_send(&mut self,
+                      num_packets: usize,
+                      packet_size: usize,
+                      func: &mut FnMut(&mut [u8]))
+    -> Option<io::Result<()>>;
+
+    /// Send a packet
+    ///
+    /// This may require an additional copy compared to `build_and_send`, depending on the
+    /// operating system being used. The second parameter is currently ignored, however
+    /// `None` should be passed.
+    #[inline]
+    fn send_to(&mut self,
+                packet: &[u8],
+                dst: Option<NetworkInterface>)
+        -> Option<io::Result<()>>;
 }
 
-dls!(EthernetDataLinkSender,
-     MutableEthernetPacket,
-     EthernetPacket);
 
-macro_rules! dlr {
-    ($recv_name:ident, $iter_name:ident, $packet:ident) => {
-        /// Structure for receiving packets at the data link layer. Should be constructed using
-        /// datalink_channel().
-        pub trait $recv_name : Send {
-            /// Returns an iterator over `EthernetPacket`s.
-            ///
-            /// This will likely be removed once other layer two types are supported.
-            #[inline]
-            fn iter<'a>(&'a mut self) -> Box<$iter_name + 'a>;
-        }
-
-        /// An iterator over data link layer packets
-        pub trait $iter_name<'a> {
-            /// Get the next EthernetPacket in the channel
-            #[inline]
-            fn next(&mut self) -> io::Result<$packet>;
-        }
-    }
+/// Structure for receiving packets at the data link layer. Should be constructed using
+/// datalink_channel().
+pub trait EthernetDataLinkReceiver: Send {
+    /// Returns an iterator over Ethernet frames.
+    ///
+    /// This will likely be removed once other layer two types are supported.
+    #[inline]
+    fn iter<'a>(&'a mut self) -> Box<EthernetDataLinkChannelIterator + 'a>;
 }
 
-dlr!(EthernetDataLinkReceiver,
-     EthernetDataLinkChannelIterator,
-     EthernetPacket);
+/// An iterator over data link layer packets
+pub trait EthernetDataLinkChannelIterator<'a> {
+    /// Get the next Ethernet frame in the channel
+    #[inline]
+    fn next(&mut self) -> io::Result<&[u8]>;
+}
+
 
 /// Represents a network interface and its associated addresses
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]

--- a/src/datalink/mod.rs
+++ b/src/datalink/mod.rs
@@ -8,7 +8,6 @@
 
 //! Support for sending and receiving data link layer packets
 
-use packet::ethernet::EtherType;
 use sockets;
 use std::io;
 use std::option::Option;
@@ -57,6 +56,8 @@ pub mod pcap;
 
 pub mod dummy;
 
+/// Type alias for an EtherType.
+pub type EtherType = u16;
 
 /// Type of data link channel to present (Linux only)
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]

--- a/src/datalink/mod.rs
+++ b/src/datalink/mod.rs
@@ -81,7 +81,7 @@ pub enum ChannelType {
 /// ```
 pub enum Channel {
     /// A datalink channel which sends and receives Ethernet packets
-    Ethernet(Box<EthernetDataLinkSender>, Box<EthernetDataLinkReceiver>),
+    Ethernet(Box<DataLinkSender>, Box<DataLinkReceiver>),
 
     /// This variant should never be used
     ///
@@ -147,7 +147,7 @@ pub fn channel(network_interface: &NetworkInterface, configuration: Config) -> i
 
 
 /// Trait to enable sending $packet packets
-pub trait EthernetDataLinkSender: Send {
+pub trait DataLinkSender: Send {
     /// Create and send a number of packets
     ///
     /// This will call `func` `num_packets` times. The function will be provided with a
@@ -176,16 +176,16 @@ pub trait EthernetDataLinkSender: Send {
 
 /// Structure for receiving packets at the data link layer. Should be constructed using
 /// datalink_channel().
-pub trait EthernetDataLinkReceiver: Send {
+pub trait DataLinkReceiver: Send {
     /// Returns an iterator over Ethernet frames.
     ///
     /// This will likely be removed once other layer two types are supported.
     #[inline]
-    fn iter<'a>(&'a mut self) -> Box<EthernetDataLinkChannelIterator + 'a>;
+    fn iter<'a>(&'a mut self) -> Box<DataLinkChannelIterator + 'a>;
 }
 
 /// An iterator over data link layer packets
-pub trait EthernetDataLinkChannelIterator<'a> {
+pub trait DataLinkChannelIterator<'a> {
     /// Get the next Ethernet frame in the channel
     #[inline]
     fn next(&mut self) -> io::Result<&[u8]>;

--- a/src/datalink/netmap.rs
+++ b/src/datalink/netmap.rs
@@ -15,7 +15,7 @@ extern crate libc;
 
 
 use datalink::{self, NetworkInterface};
-use datalink::{EthernetDataLinkChannelIterator, EthernetDataLinkReceiver, EthernetDataLinkSender};
+use datalink::{DataLinkChannelIterator, DataLinkReceiver, DataLinkSender};
 use datalink::Channel::Ethernet;
 use self::netmap_sys::netmap::{netmap_slot, nm_ring_empty};
 use self::netmap_sys::netmap_user::{NETMAP_BUF, NETMAP_FD, NETMAP_TXRING, nm_close, nm_desc,
@@ -163,7 +163,7 @@ struct DataLinkSenderImpl {
     timeout: Option<libc::timespec>,
 }
 
-impl EthernetDataLinkSender for DataLinkSenderImpl {
+impl DataLinkSender for DataLinkSenderImpl {
     #[inline]
     fn build_and_send(&mut self,
                       num_packets: usize,
@@ -222,9 +222,9 @@ struct DataLinkReceiverImpl {
     timeout: Option<libc::timespec>,
 }
 
-impl EthernetDataLinkReceiver for DataLinkReceiverImpl {
+impl DataLinkReceiver for DataLinkReceiverImpl {
     // FIXME Layer 3
-    fn iter<'a>(&'a mut self) -> Box<EthernetDataLinkChannelIterator + 'a> {
+    fn iter<'a>(&'a mut self) -> Box<DataLinkChannelIterator + 'a> {
         Box::new(DataLinkChannelIteratorImpl { pc: self })
     }
 }
@@ -233,7 +233,7 @@ struct DataLinkChannelIteratorImpl<'a> {
     pc: &'a mut DataLinkReceiverImpl,
 }
 
-impl<'a> EthernetDataLinkChannelIterator<'a> for DataLinkChannelIteratorImpl<'a> {
+impl<'a> DataLinkChannelIterator<'a> for DataLinkChannelIteratorImpl<'a> {
     fn next(&mut self) -> io::Result<&[u8]> {
         let desc = self.pc.desc.desc;
         let mut h: nm_pkthdr = unsafe { mem::uninitialized() };

--- a/src/datalink/pcap.rs
+++ b/src/datalink/pcap.rs
@@ -7,7 +7,7 @@ use std::io;
 use std::iter::repeat;
 use self::pcap::{Active, Activated};
 use datalink::{self, NetworkInterface};
-use datalink::{EthernetDataLinkChannelIterator, EthernetDataLinkReceiver, EthernetDataLinkSender};
+use datalink::{DataLinkChannelIterator, DataLinkReceiver, DataLinkSender};
 use datalink::Channel::Ethernet;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -92,7 +92,7 @@ struct DataLinkSenderImpl {
     capture: Arc<Mutex<pcap::Capture<Active>>>,
 }
 
-impl EthernetDataLinkSender for DataLinkSenderImpl {
+impl DataLinkSender for DataLinkSenderImpl {
     #[inline]
     fn build_and_send(&mut self,
                       num_packets: usize,
@@ -124,7 +124,7 @@ impl EthernetDataLinkSender for DataLinkSenderImpl {
 
 struct InvalidDataLinkSenderImpl {}
 
-impl EthernetDataLinkSender for InvalidDataLinkSenderImpl {
+impl DataLinkSender for InvalidDataLinkSenderImpl {
     #[inline]
     fn build_and_send(&mut self,
                       _num_packets: usize,
@@ -147,8 +147,8 @@ struct DataLinkReceiverImpl<T: Activated + Send + Sync> {
     read_buffer: Vec<u8>,
 }
 
-impl <T: Activated + Send + Sync> EthernetDataLinkReceiver for DataLinkReceiverImpl<T> {
-    fn iter<'a>(&'a mut self) -> Box<EthernetDataLinkChannelIterator + 'a> {
+impl <T: Activated + Send + Sync> DataLinkReceiver for DataLinkReceiverImpl<T> {
+    fn iter<'a>(&'a mut self) -> Box<DataLinkChannelIterator + 'a> {
         Box::new(DataLinkChannelIteratorImpl { pc: self })
     }
 }
@@ -157,7 +157,7 @@ struct DataLinkChannelIteratorImpl<'a, T: Activated + Send + Sync + 'a> {
     pc: &'a mut DataLinkReceiverImpl<T>,
 }
 
-impl<'a, T: Activated + Send + Sync> EthernetDataLinkChannelIterator<'a> for DataLinkChannelIteratorImpl<'a, T> {
+impl<'a, T: Activated + Send + Sync> DataLinkChannelIterator<'a> for DataLinkChannelIteratorImpl<'a, T> {
     fn next(&mut self) -> io::Result<&[u8]> {
         let mut cap = self.pc.capture.lock().unwrap();
         match cap.next() {

--- a/src/datalink/winpcap.rs
+++ b/src/datalink/winpcap.rs
@@ -13,7 +13,7 @@ extern crate libc;
 
 use bindings::{bpf, winpcap};
 use datalink::{self, NetworkInterface};
-use datalink::{EthernetDataLinkChannelIterator, EthernetDataLinkReceiver, EthernetDataLinkSender};
+use datalink::{DataLinkChannelIterator, DataLinkReceiver, DataLinkSender};
 use datalink::Channel::Ethernet;
 
 use ipnetwork::{ip_mask_to_prefix, IpNetwork};
@@ -164,7 +164,7 @@ struct DataLinkSenderImpl {
     packet: WinPcapPacket,
 }
 
-impl EthernetDataLinkSender for DataLinkSenderImpl {
+impl DataLinkSender for DataLinkSenderImpl {
     #[inline]
     fn build_and_send(&mut self,
                       num_packets: usize,
@@ -225,8 +225,8 @@ struct DataLinkReceiverImpl {
     packet: WinPcapPacket,
 }
 
-impl EthernetDataLinkReceiver for DataLinkReceiverImpl {
-    fn iter<'a>(&'a mut self) -> Box<EthernetDataLinkChannelIterator + 'a> {
+impl DataLinkReceiver for DataLinkReceiverImpl {
+    fn iter<'a>(&'a mut self) -> Box<DataLinkChannelIterator + 'a> {
         let buflen = unsafe { (*self.packet.packet).Length } as usize;
         Box::new(DataLinkChannelIteratorImpl {
             pc: self,
@@ -244,7 +244,7 @@ struct DataLinkChannelIteratorImpl<'a> {
     packets: VecDeque<(usize, usize)>,
 }
 
-impl<'a> EthernetDataLinkChannelIterator<'a> for DataLinkChannelIteratorImpl<'a> {
+impl<'a> DataLinkChannelIterator<'a> for DataLinkChannelIteratorImpl<'a> {
     fn next(&mut self) -> io::Result<&[u8]> {
         // NOTE Most of the logic here is identical to FreeBSD/OS X
         if self.packets.is_empty() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@
 //! use pnet::datalink::{self, NetworkInterface};
 //! use pnet::datalink::Channel::Ethernet;
 //! use pnet::packet::{Packet, MutablePacket};
+//! use pnet::packet::ethernet::{EthernetPacket, MutableEthernetPacket};
 //!
 //! use std::env;
 //!
@@ -73,6 +74,8 @@
 //!     loop {
 //!         match iter.next() {
 //!             Ok(packet) => {
+//!                 let packet = EthernetPacket::new(packet).unwrap();
+//!
 //!                 // Constructs a single packet, the same length as the the one received,
 //!                 // using the provided closure. This allows the packet to be constructed
 //!                 // directly in the write buffer, without copying. If copying is not a
@@ -81,6 +84,8 @@
 //!                 // The packet is sent once the closure has finished executing.
 //!                 tx.build_and_send(1, packet.packet().len(),
 //!                     &mut |mut new_packet| {
+//!                         let mut new_packet = MutableEthernetPacket::new(new_packet).unwrap();
+//!
 //!                         // Create a clone of the original packet
 //!                         new_packet.clone_from(&packet);
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,9 +70,8 @@
 //!         Err(e) => panic!("An error occurred when creating the datalink channel: {}", e)
 //!     };
 //!
-//!     let mut iter = rx.iter();
 //!     loop {
-//!         match iter.next() {
+//!         match rx.next() {
 //!             Ok(packet) => {
 //!                 let packet = EthernetPacket::new(packet).unwrap();
 //!

--- a/src/pnettest.rs
+++ b/src/pnettest.rs
@@ -371,7 +371,7 @@ fn layer2() {
                     if i == 10_000 {
                         panic!("layer2: did not find matching packet after 10_000 iterations");
                     }
-                    if EthernetPacket::new(&packet[..]).unwrap().payload() == eh.payload() {
+                    if EthernetPacket::new(&packet[..]).unwrap().payload() == EthernetPacket::new(eh).unwrap().payload() {
                         return;
                     }
                     i += 1;
@@ -384,7 +384,7 @@ fn layer2() {
     });
 
     rx.recv().unwrap();
-    match dltx.send_to(&EthernetPacket::new(&packet[..]).unwrap(), None) {
+    match dltx.send_to(&packet[..], None) {
         Some(Ok(())) => (),
         Some(Err(e)) => panic!("layer2_test failed: {}", e),
         None => panic!("Provided buffer too small"),
@@ -449,7 +449,7 @@ fn layer2_timeouts() {
             match iter.next() {
                 Ok(eh) => {
                     panic!("layer2_timeouts: should have exceeded timeout ({}/{})",
-                           eh.packet().len(),
+                           eh.len(),
                            packet_len);
                 }
                 Err(e) => {
@@ -462,7 +462,7 @@ fn layer2_timeouts() {
     rx.recv().unwrap();
     // Wait a while
     thread::sleep(Duration::from_millis(1000));
-    match dltx.send_to(&EthernetPacket::new(&packet[..]).unwrap(), None) {
+    match dltx.send_to(&packet[..], None) {
         Some(Ok(())) => (),
         Some(Err(e)) => panic!("layer2_test failed: {}", e),
         None => panic!("Provided buffer too small"),

--- a/src/pnettest.rs
+++ b/src/pnettest.rs
@@ -363,9 +363,8 @@ fn layer2() {
     let res = thread::spawn(move || {
         tx.send(()).unwrap();
         let mut i = 0usize;
-        let mut iter = dlrx.iter();
         loop {
-            let next = iter.next();
+            let next = dlrx.next();
             match next {
                 Ok(eh) => {
                     if i == 10_000 {
@@ -444,9 +443,8 @@ fn layer2_timeouts() {
     let packet_len = packet.len();
     let res = thread::spawn(move || {
         tx.send(()).unwrap();
-        let mut iter = dlrx.iter();
         loop {
-            match iter.next() {
+            match dlrx.next() {
                 Ok(eh) => {
                     panic!("layer2_timeouts: should have exceeded timeout ({}/{})",
                            eh.len(),


### PR DESCRIPTION
So we talked about this on IRC. It would be nice to split up pnet into more smaller crates, since it does many fairly unrelated things. Basically I want to be able to use the `datalink` functionality without bringing in anything else. I plan on doing that is the following steps:

1. This PR: Working towards making the `datalink` module not use the packet module by using `&[u8]` and `&mut [u8]` instead of `EthernetPacket` and `MutableEthernetPacket`. This is a breaking change. Not sure if/how we would make the transition less painful, is it worth it?
2. Break out the `datalink` module to a separate crate `pnet_datalink` or `pnet-datalink`. I personally prefer the hyphen, but this repo has traditionally used underscores so I guess we will go with that.
3. If we feel the need and if there is enough motivation, do the same for the `transport` and `packet` modules, making them separate crates.