### PR TITLE
Unbreak the pcap datalink

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,25 +13,25 @@ env:
     - secure: kd+Q+IWrHUZK+BwwEh37IiR7B76yyvfjAB3Gx6roshKyAk2KmduoyLGv6v902gbLAtt/8JtPMBHZdKbMv7A1eKBsCOF/rMz1rHziuTbnFwfnx6UN+jalZZRIYmn20M7I1UfvhcvWXqvcrpo84NbhOYlXMmvI+X6HZ2rSIsYta6E=
     - VERBOSE: 1
   matrix:
-    - PNET_FEATURES="travis with-syntex" PNET_MACROS_FEATURES="travis with-syntex"
-    - PNET_FEATURES="travis nightly clippy" PNET_MACROS_FEATURES="travis clippy"
-    - PNET_FEATURES="travis nightly" PNET_MACROS_FEATURES="travis"
+    - PNET_FEATURES="travis pcap with-syntex" PNET_MACROS_FEATURES="travis with-syntex"
+    - PNET_FEATURES="travis pcap nightly clippy" PNET_MACROS_FEATURES="travis clippy"
+    - PNET_FEATURES="travis pcap nightly" PNET_MACROS_FEATURES="travis"
 matrix:
   allow_failures:
     - rust: nightly
   exclude:
     - rust: 1.15.0
-      env: PNET_FEATURES="travis nightly clippy" PNET_MACROS_FEATURES="travis clippy"
+      env: PNET_FEATURES="travis pcap nightly clippy" PNET_MACROS_FEATURES="travis clippy"
     - rust: 1.15.0
-      env: PNET_FEATURES="travis nightly" PNET_MACROS_FEATURES="travis"
+      env: PNET_FEATURES="travis pcap nightly" PNET_MACROS_FEATURES="travis"
     - rust: stable
-      env: PNET_FEATURES="travis nightly clippy" PNET_MACROS_FEATURES="travis clippy"
+      env: PNET_FEATURES="travis pcap nightly clippy" PNET_MACROS_FEATURES="travis clippy"
     - rust: stable
-      env: PNET_FEATURES="travis nightly" PNET_MACROS_FEATURES="travis"
+      env: PNET_FEATURES="travis pcap nightly" PNET_MACROS_FEATURES="travis"
     - rust: beta
-      env: PNET_FEATURES="travis nightly clippy" PNET_MACROS_FEATURES="travis clippy"
+      env: PNET_FEATURES="travis pcap nightly clippy" PNET_MACROS_FEATURES="travis clippy"
     - rust: beta
-      env: PNET_FEATURES="travis nightly" PNET_MACROS_FEATURES="travis"
+      env: PNET_FEATURES="travis pcap nightly" PNET_MACROS_FEATURES="travis"
 script:
     - make travis_script
 notifications:
@@ -39,3 +39,7 @@ notifications:
         channels:
             - "chat.freenode.net#libpnet"
         use_notice: true
+addons:
+    apt:
+        packages:
+            - libpcap-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 language: rust
 rust:
     - 1.15.0

--- a/src/datalink/pcap.rs
+++ b/src/datalink/pcap.rs
@@ -184,7 +184,7 @@ pub fn interfaces() -> Vec<NetworkInterface> {
                 name: dev.name.clone(),
                 index: i as u32,
                 mac: None,
-                ips: None,
+                ips: Vec::new(),
                 flags: 0,
             }
         }).collect()

--- a/src/datalink/pcap.rs
+++ b/src/datalink/pcap.rs
@@ -108,7 +108,7 @@ impl EthernetDataLinkSender for DataLinkSenderImpl {
                 func(eh);
             }
             let mut cap = self.capture.lock().unwrap();
-            if let Err(e) = cap.sendpacket(&data) {
+            if let Err(e) = cap.sendpacket(data) {
                 return Some(Err(io::Error::new(io::ErrorKind::Other, e)))
             }
         }


### PR DESCRIPTION
There was an API change in pcap crate earlier this year, which seems to have been added in 0.6.0 affecting the sendpacket parameter.

To avoid getting this breakage again I added libpcap-dev, and enabled the pcap feature. Before doing this I had to enable sudo support for the builds to work. Are you running some special kind of payed-for Travis that doesn't need the sudo-flag?

The .travis.yml syntax for APT packages only work on Debian, but the tests don't exercise the pcap parts so the build doesn't fail if it's missing. Ideally the matrix defined in .travis.yml would take OS into account and possibly disable pcap on macOS, or perhaps install it via brew.