### PR TITLE
Cleanup after crate split

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ authors = [ "Robert Clipsham <robert@octarineparrot.com>" ]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"
 repository = "https://github.com/libpnet/libpnet"
-documentation = "http://octarineparrot.com/assets/libpnet/doc/pnet/"
 description = "Cross-platform, low level networking using the Rust programming language."
 readme = "README.md"
 keywords = ["networking", "transport", "datalink", "packet", "protocol"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,6 @@ keywords = ["networking", "transport", "datalink", "packet", "protocol"]
 categories = ["network-programming", "parser-implementations"]
 build = "build.rs"
 
-[lib]
-name = "pnet"
-
 [features]
 default = ["with-syntex"]
 nightly = ["pnet_macros_plugin"]
@@ -24,51 +21,26 @@ travis = []
 with-syntex = ["syntex", "pnet_macros/with-syntex"]
 
 [dependencies]
+libc = "0.2"
 ipnetwork = "0.12"
+
 pnet_base = { path = "pnet_base" }
 pnet_sys = { path = "pnet_sys" }
 pnet_datalink = { path = "pnet_datalink" }
+pnet_macros = { path = "pnet_macros", optional = true, version = ">=0.9" }
+pnet_macros_support = { path = "pnet_macros_support", version = ">=0.1" }
+pnet_macros_plugin = { path = "pnet_macros_plugin", optional = true, version = ">=0.1" }
 
-[dependencies.clippy]
-optional = true
-version = ">=0.0"
+clippy = { version = ">=0.0", optional = true }
+syntex = { version = "0.42", optional = true }
+pcap = { version = "0.6", optional = true }
+netmap_sys = { version = ">=0.0", optional = true, features = ["netmap_with_libs"] }
 
-[dependencies.netmap_sys]
-features = ["netmap_with_libs"]
-optional = true
-version = ">=0.0"
-
-[dependencies.libc]
-version = "0.2.*"
-
-[dependencies.syntex]
-version = "0.42.*"
-optional = true
-
-[dependencies.pcap]
-version = "0.6.*"
-optional = true
-
-[dependencies.pnet_macros]
-optional = true
-default-features = false
-features = []
-path = "pnet_macros"
-version = ">=0.9"
-
-[dependencies.pnet_macros_plugin]
-optional = true
-path = "pnet_macros_plugin"
-version = ">=0.1"
-
-[dependencies.pnet_macros_support]
-path = "pnet_macros_support"
-version = ">=0.1"
 
 [dev-dependencies]
 time = ">=0.1"
 
 [build-dependencies]
-glob = "0.2.*"
-syntex = { version = "0.42.*", optional = true }
+glob = "0.2"
+syntex = { version = "0.42", optional = true }
 pnet_macros = { path = "pnet_macros", version = ">=0.13" }

--- a/benches/rs_receiver.rs
+++ b/benches/rs_receiver.rs
@@ -7,28 +7,28 @@
 // except according to those terms.
 
 
-extern crate pnet;
+extern crate pnet_datalink;
 extern crate time;
-
-use pnet::datalink::{self, NetworkInterface};
 
 use std::env;
 
 fn main() {
-    use pnet::datalink::Channel::Ethernet;
+    use pnet_datalink::Channel::Ethernet;
 
     let iface_name = env::args().nth(1).unwrap();
-    let interface_names_match = |iface: &NetworkInterface| iface.name == iface_name;
 
     // Find the network interface with the provided name
-    let interfaces = datalink::interfaces();
-    let interface = interfaces.into_iter().filter(interface_names_match).next().unwrap();
+    let interfaces = pnet_datalink::interfaces();
+    let interface = interfaces.into_iter()
+        .filter(|iface| iface.name == iface_name)
+        .next()
+        .unwrap();
 
     // Create a channel to receive on
-    let mut rx = match datalink::channel(&interface, Default::default()) {
+    let mut rx = match pnet_datalink::channel(&interface, Default::default()) {
         Ok(Ethernet(_, rx)) => rx,
         Ok(_) => panic!("rs_sender: unhandled channel type"),
-        Err(e) => panic!("rs_benchmark: unable to create channel: {}", e),
+        Err(e) => panic!("rs_sender: unable to create channel: {}", e),
     };
 
     let mut i = 0usize;
@@ -48,7 +48,7 @@ fn main() {
                 }
             }
             Err(e) => {
-                println!("rs_benchmark: unable to receive packet: {}", e);
+                println!("rs_sender: unable to receive packet: {}", e);
             }
         }
     }

--- a/examples/arp_packet.rs
+++ b/examples/arp_packet.rs
@@ -1,13 +1,13 @@
 extern crate pnet;
+extern crate pnet_datalink;
 
 use std::env;
 use std::process;
 use std::io::{self, Write};
 use std::net::{Ipv4Addr, AddrParseError};
 
-use pnet::util::{MacAddr, ParseMacAddrErr};
-use pnet::datalink::{self, NetworkInterface};
-use pnet::datalink::Channel;
+use pnet_datalink::{Channel, NetworkInterface, MacAddr, ParseMacAddrErr};
+
 use pnet::packet::ethernet::MutableEthernetPacket;
 use pnet::packet::arp::MutableArpPacket;
 use pnet::packet::ethernet::EtherTypes;
@@ -16,7 +16,7 @@ use pnet::packet::arp::{ArpHardwareTypes, ArpOperations, ArpOperation};
 
 
 fn send_arp_packet(interface: NetworkInterface, source_ip: Ipv4Addr, source_mac: MacAddr, target_ip: Ipv4Addr, target_mac: MacAddr, arp_operation: ArpOperation) {
-    let(mut tx, _) = match datalink::channel(&interface, Default::default()) {
+    let(mut tx, _) = match pnet_datalink::channel(&interface, Default::default()) {
         Ok(Channel::Ethernet(tx, rx)) => (tx, rx),
         Ok(_) => panic!("Unknown channel type"),
         Err(e) => panic!("Error happened {}", e),
@@ -80,7 +80,7 @@ fn main() {
         }
     };
 
-    let interfaces = datalink::interfaces();
+    let interfaces = pnet_datalink::interfaces();
     let interfaces_name_match = |iface: &NetworkInterface| iface.name == iface_name;
     let interface = interfaces.into_iter().filter(interfaces_name_match).next().unwrap();
     let source_mac = interface.mac_address();

--- a/examples/list_interfaces.rs
+++ b/examples/list_interfaces.rs
@@ -8,12 +8,10 @@
 
 /// This examples simply print all interfaces to stdout
 
-extern crate pnet;
-
-use pnet::datalink;
+extern crate pnet_datalink;
 
 fn main() {
-    for interface in datalink::interfaces() {
+    for interface in pnet_datalink::interfaces() {
         let mac = interface.mac.map(|mac| mac.to_string()).unwrap_or("N/A".to_owned());
         println!("{}:", interface.name);
         println!("  index: {}", interface.index);

--- a/fuzz/fuzzers/ether.rs
+++ b/fuzz/fuzzers/ether.rs
@@ -3,14 +3,14 @@ extern crate libfuzzer_sys;
 extern crate pnet;
 
 use pnet::packet::Packet;
-use pnet::packet::ethernet::{EthernetPacket, MutableEthernetPacket, EtherTypes};
+use pnet::packet::ethernet::EthernetPacket;
 
 #[export_name="rust_fuzzer_test_input"]
 pub extern fn go(data: &[u8]) {
 	if let Some(eth) = EthernetPacket::new(data) {
-		let s = eth.get_source();
-		let d = eth.get_destination();
-		let t = eth.get_ethertype();
+		let _s = eth.get_source();
+		let _d = eth.get_destination();
+		let _t = eth.get_ethertype();
 		let pl = eth.payload();
 		for b in pl.iter() {
 			*b;

--- a/fuzz/fuzzers/gre.rs
+++ b/fuzz/fuzzers/gre.rs
@@ -2,7 +2,6 @@
 extern crate libfuzzer_sys;
 extern crate pnet;
 
-use pnet::packet::Packet;
 use pnet::packet::gre::GrePacket;
 
 #[export_name="rust_fuzzer_test_input"]

--- a/pnet_datalink/Cargo.toml
+++ b/pnet_datalink/Cargo.toml
@@ -16,4 +16,4 @@ pnet_base = { path = "../pnet_base" }
 pnet_sys = { path = "../pnet_sys" }
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.2.*"
+winapi = "0.2"

--- a/pnet_datalink/src/lib.rs
+++ b/pnet_datalink/src/lib.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 
 use ipnetwork::IpNetwork;
 
-pub use pnet_base::MacAddr;
+pub use pnet_base::{MacAddr, ParseMacAddrErr};
 
 mod bindings;
 

--- a/pnet_macros/Cargo.toml
+++ b/pnet_macros/Cargo.toml
@@ -10,9 +10,6 @@ readme = "../README.md"
 keywords = ["networking", "bitfields", "packet", "protocol"]
 categories = ["network-programming", "parsing"]
 
-[lib]
-name = "pnet_macros"
-
 [features]
 default = []
 travis = []
@@ -24,7 +21,7 @@ compiletest_rs = ">=0.0"
 [dev-dependencies.pnet]
 default-features = false
 features = ["nightly"]
-path = ".."
+path = "../"
 version = ">=0.13"
 
 [dev-dependencies.pnet_macros_plugin]
@@ -37,9 +34,6 @@ version = ">=0.1"
 
 [dependencies]
 regex = "0.2.*"
-syntex = { version = "0.42.*", optional = true }
-syntex_syntax = { version = "0.42.*", optional = true }
-
-[dependencies.clippy]
-optional = true
-version = ">=0.0"
+syntex = { version = "0.42", optional = true }
+syntex_syntax = { version = "0.42", optional = true }
+clippy = { version = ">=0.0", optional = true }

--- a/pnet_macros/Cargo.toml
+++ b/pnet_macros/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Robert Clipsham <robert@octarineparrot.com>"]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"
 repository = "https://github.com/libpnet/libpnet"
-documentation = "http://octarineparrot.com/assets/libpnet/doc/pnet/"
 description = "Automatic bit manipulation for binary data formats"
 readme = "../README.md"
 keywords = ["networking", "bitfields", "packet", "protocol"]

--- a/pnet_macros_plugin/Cargo.toml
+++ b/pnet_macros_plugin/Cargo.toml
@@ -6,7 +6,6 @@ authors = ["Robert Clipsham <robert@octarineparrot.com>"]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"
 repository = "https://github.com/libpnet/libpnet"
-documentation = "http://octarineparrot.com/assets/libpnet/doc/pnet/"
 description = "Automatic bit manipulation for binary data formats"
 readme = "../README.md"
 keywords = ["networking", "bitfields", "packet", "protocol", "plugin"]

--- a/pnet_macros_support/Cargo.toml
+++ b/pnet_macros_support/Cargo.toml
@@ -9,9 +9,3 @@ repository = "https://github.com/libpnet/libpnet"
 description = "Support library for libpnet_macros"
 readme = "../README.md"
 keywords = ["networking", "bitfields", "packet", "protocol"]
-
-[lib]
-name = "pnet_macros_support"
-
-[features]
-travis = []

--- a/pnet_macros_support/Cargo.toml
+++ b/pnet_macros_support/Cargo.toml
@@ -6,7 +6,6 @@ authors = ["Robert Clipsham <robert@octarineparrot.com>"]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"
 repository = "https://github.com/libpnet/libpnet"
-documentation = "http://octarineparrot.com/assets/libpnet/doc/pnet/"
 description = "Support library for libpnet_macros"
 readme = "../README.md"
 keywords = ["networking", "bitfields", "packet", "protocol"]

--- a/pnet_sys/Cargo.toml
+++ b/pnet_sys/Cargo.toml
@@ -13,5 +13,5 @@ categories = ["network-programming"]
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.2.*"
-ws2_32-sys = "0.2.*"
+winapi = "0.2"
+ws2_32-sys = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,10 +102,6 @@
 //! }
 //! ```
 
-#![crate_name = "pnet"]
-#![crate_type = "rlib"]
-#![crate_type = "dylib"]
-
 #![deny(missing_docs)]
 
 #![cfg_attr(feature = "nightly", feature(custom_attribute, plugin))]


### PR DESCRIPTION
Found it possible to clean up a little bit.

1. Remove documentation links, so it will use docs.rs automatically.
2. Some examples could use `pnet_datalink` directly, showcasing that this is possible.
3. Some unused imports and variables.
4. "Cleaning" up Cargo.toml files. This is subjective I guess. Please provide feedback on if you like this style.