### PR TITLE
Make pnet_datalink dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming", "parser-implementations"]
 build = "build.rs"
 
 [features]
-default = ["with-syntex"]
+default = ["with-syntex", "pnet_datalink"]
 nightly = ["pnet_macros_plugin"]
 benchmark = []
 netmap = ["netmap_sys"]
@@ -26,7 +26,7 @@ ipnetwork = "0.12"
 
 pnet_base = { path = "pnet_base" }
 pnet_sys = { path = "pnet_sys" }
-pnet_datalink = { path = "pnet_datalink" }
+pnet_datalink = { path = "pnet_datalink", optional = true }
 pnet_macros = { path = "pnet_macros", optional = true, version = ">=0.9" }
 pnet_macros_support = { path = "pnet_macros_support", version = ">=0.1" }
 pnet_macros_plugin = { path = "pnet_macros_plugin", optional = true, version = ">=0.1" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,9 +123,11 @@ extern crate pnet_macros_support;
 
 extern crate pnet_base;
 extern crate pnet_sys;
+#[cfg(feature = "pnet_datalink")]
 extern crate pnet_datalink;
 
 /// Support for sending and receiving data link layer packets
+#[cfg(feature = "pnet_datalink")]
 pub mod datalink {
     pub use pnet_datalink::*;
 }


### PR DESCRIPTION
The largest reason to split the crates up is to be able to just use a few of them. So it might be good to be able to depend on the top `pnet` crate without pulling in `datalink` if desired. The tests won't build without `pnet_datalink` now because tests depend on that, but the crate can build without it at least.