### PR TITLE
datalink: fix pcap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     - secure: kd+Q+IWrHUZK+BwwEh37IiR7B76yyvfjAB3Gx6roshKyAk2KmduoyLGv6v902gbLAtt/8JtPMBHZdKbMv7A1eKBsCOF/rMz1rHziuTbnFwfnx6UN+jalZZRIYmn20M7I1UfvhcvWXqvcrpo84NbhOYlXMmvI+X6HZ2rSIsYta6E=
     - VERBOSE: 1
   matrix:
-    - PNET_FEATURES="travis" PNET_MACROS_FEATURES="travis"
+    - PNET_FEATURES="travis pcap" PNET_MACROS_FEATURES="travis"
 matrix:
   allow_failures:
     - rust: nightly


### PR DESCRIPTION
* rename the "pcap" feature to "with-pcap" (because of dep conflict)
* pass through the with-pcap feature to pnet_datalink
* fix random build errors