### PR TITLE
[IMP] Add net device flag constants and update examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ appveyor = []
 travis = []
 
 [dependencies]
-libc = "0.2"
 ipnetwork = "0.12"
 
 pnet_base = { path = "pnet_base", version = "0.20.0" }

--- a/examples/list_interfaces.rs
+++ b/examples/list_interfaces.rs
@@ -12,14 +12,6 @@ extern crate pnet_datalink;
 
 fn main() {
     for interface in pnet_datalink::interfaces() {
-        let mac = interface.mac.map(|mac| mac.to_string()).unwrap_or("N/A".to_owned());
-        println!("{}:", interface.name);
-        println!("  index: {}", interface.index);
-        println!("  flags: {}", interface.flags);
-        println!("  MAC: {}", mac);
-        println!("  IPs:");
-        for ip in interface.ips {
-            println!("    {:?}", ip);
-        }
+        println!("{}", interface);
     }
 }

--- a/pnet_datalink/Cargo.toml
+++ b/pnet_datalink/Cargo.toml
@@ -10,10 +10,10 @@ keywords = ["networking", "datalink", "ethernet", "raw"]
 categories = ["network-programming"]
 
 [dependencies]
-libc = "0.2"
+libc = "0.2.34"
 ipnetwork = "0.12"
 pnet_base = { path = "../pnet_base", version = "0.20.0" }
-pnet_sys = { path = "../pnet_sys", version = "0.20.0" }
+pnet_sys = { path = "../pnet_sys", version = "0.20.1" }
 
 pcap = { version = "0.6", optional = true }
 netmap_sys = { version = ">=0.0", optional = true, features = ["netmap_with_libs"] }

--- a/pnet_sys/Cargo.toml
+++ b/pnet_sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pnet_sys"
-version = "0.20.0"
+version = "0.20.1"
 authors = ["Robert Clipsham <robert@octarineparrot.com>", "Linus Färnstrand <faern@faern.net>"]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"
@@ -10,7 +10,7 @@ keywords = ["networking", "datalink", "ethernet", "raw"]
 categories = ["network-programming"]
 
 [dependencies]
-libc = "0.2"
+libc = "0.2.34"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.2"

--- a/pnet_sys/src/unix.rs
+++ b/pnet_sys/src/unix.rs
@@ -27,8 +27,8 @@ pub mod public {
     pub const IPPROTO_IP: libc::c_int = libc::IPPROTO_IP;
     pub const IP_HDRINCL: libc::c_int = libc::IP_HDRINCL;
 
-    pub const IFF_LOOPBACK: libc::c_int = libc::IFF_LOOPBACK;
-
+    pub use libc::{IFF_UP, IFF_BROADCAST, IFF_LOOPBACK, IFF_POINTOPOINT, IFF_MULTICAST};
+    
     pub const INVALID_SOCKET: CSocket = -1;
 
 

--- a/pnet_sys/src/windows.rs
+++ b/pnet_sys/src/windows.rs
@@ -31,8 +31,13 @@ pub mod public {
     pub const IPPROTO_IP: libc::c_int = winapi::IPPROTO_IP;
     pub const IP_HDRINCL: libc::c_int = winapi::IP_HDRINCL;
 
+    pub const IFF_UP: libc::c_int = 0x00000001;
+    pub const IFF_BROADCAST: libc::c_int = 0x00000002;
     pub const IFF_LOOPBACK: libc::c_int = 0x00000004;
-
+    pub const IFF_POINTTOPOINT: libc::c_int = 0x00000008;
+    pub const IFF_POINTOPOINT: libc::c_int = IFF_POINTTOPOINT;
+    pub const IFF_MULTICAST: libc::c_int = 0x00000010;
+    
     pub const INVALID_SOCKET: CSocket = winapi::INVALID_SOCKET;
 
 

--- a/pnet_transport/Cargo.toml
+++ b/pnet_transport/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["networking", "transport", "raw", "socket"]
 categories = ["network-programming"]
 
 [dependencies]
-libc = "0.2"
+libc = "0.2.34"
 pnet_base = { path = "../pnet_base", version = "0.20.0" }
-pnet_sys = { path = "../pnet_sys", version = "0.20.0" }
+pnet_sys = { path = "../pnet_sys", version = "0.20.1" }
 pnet_packet = { path = "../pnet_packet", version = "0.20.0" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,8 +116,6 @@
 #[cfg(feature = "benchmark")]
 extern crate test;
 
-#[cfg(not(windows))]
-extern crate libc;
 extern crate ipnetwork;
 
 extern crate pnet_base;

--- a/src/pnettest.rs
+++ b/src/pnettest.rs
@@ -8,8 +8,6 @@
 
 #![allow(warnings)]
 
-extern crate libc;
-
 use datalink;
 
 use packet::Packet;


### PR DESCRIPTION
Changes:

File: [pnet_sys/src/unix.rs](https://github.com/LuoZijun/libpnet/blob/patch-1/pnet_sys/src/unix.rs#L32-L68)
* Add network device flags constant for xnu and linux kernel.

File: [pnet_datalink/src/lib.rs](https://github.com/LuoZijun/libpnet/blob/patch-1/pnet_datalink/src/lib.rs#L219-L238)
* Add function for check device flag.

File: [examples/list_interfaces.rs](https://github.com/LuoZijun/libpnet/blob/patch-1/examples/list_interfaces.rs#L46)
* let `list_interfaces`  output device flag info.

File: [examples/packetdump.rs](https://github.com/LuoZijun/libpnet/blob/patch-1/examples/packetdump.rs#L213-L229)
* let `packetdump`  support `TUN` network device.

*Network Device Flags:*

* [XNU](https://github.com/aosm/xnu/blob/master/bsd/net/if.h#L140-L156)
* [Linux](https://github.com/torvalds/linux/blob/master/include/uapi/linux/if.h#L83-L100)