### PR TITLE
Fix pnet_datalink's netmap support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ build = "build.rs"
 
 [features]
 benchmark = []
-netmap = ["pnet_datalink/netmap_sys"]
+netmap = ["pnet_datalink/netmap_sys", "pnet_datalink/netmap"]
 pcap = ["pnet_datalink/pcap"]
 appveyor = []
 travis = []

--- a/pnet_datalink/Cargo.toml
+++ b/pnet_datalink/Cargo.toml
@@ -9,6 +9,9 @@ description = "Cross-platform, datalink layer networking."
 keywords = ["networking", "datalink", "ethernet", "raw"]
 categories = ["network-programming"]
 
+[features]
+netmap = []
+
 [dependencies]
 libc = "0.2"
 ipnetwork = "0.12"

--- a/pnet_datalink/src/netmap.rs
+++ b/pnet_datalink/src/netmap.rs
@@ -50,7 +50,6 @@ type nfds_t = libc::c_uint;
 type nfds_t = libc::c_ulong;
 
 extern "C" {
-    fn poll(fds: *mut pollfd, nfds: nfds_t, timeout: libc::c_int) -> libc::c_int;
     fn ppoll(fds: *mut pollfd,
              nfds: nfds_t,
              timeout: *const libc::timespec,
@@ -105,8 +104,8 @@ pub struct Config {
     pub write_timeout: Option<Duration>,
 }
 
-impl<'a> From<&'a datalink::Config> for Config {
-    fn from(config: &datalink::Config) -> Config {
+impl<'a> From<&'a super::Config> for Config {
+    fn from(config: &super::Config) -> Config {
         Config {
             read_timeout: config.read_timeout,
             write_timeout: config.write_timeout,
@@ -137,7 +136,7 @@ fn get_timeout(to: Option<Duration>) -> Option<libc::timespec> {
 #[inline]
 pub fn channel(network_interface: &NetworkInterface,
                config: Config)
-    -> io::Result<datalink::Channel> {
+    -> io::Result<super::Channel> {
     // FIXME probably want one for each of send/recv
     let desc = NmDesc::new(network_interface);
     match desc {
@@ -210,8 +209,8 @@ impl DataLinkSender for DataLinkSenderImpl {
         -> Option<io::Result<()>> {
         self.build_and_send(1,
                             packet.len(),
-                            &mut |mut eh: &mut [u8]| {
-                                eh.clone_from(packet);
+                            &mut |eh: &mut [u8]| {
+                                eh.clone_from_slice(packet);
                             })
     }
 }


### PR DESCRIPTION
Since pnet_datalink was split into its own crate (or at least as far as I can tell), it's actually been impossible to enable netmap because the feature was not being passed to the child crate.

Once I did that, there were some code errors (little more than renaming datalink to super, and changing clone_from to clone_from_slice).

I also cleaned up some things cargo was complaining about (unused poll, mut eh).