### PR TITLE
Updated Rust Compiler version in travis and appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: required
 language: rust
 rust:
-    - 1.15.0
     - stable
     - beta
     - nightly

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,19 +2,11 @@ environment:
   RUST_TEST_THREADS: 1
   matrix:
   - TARGET: x86_64-pc-windows-msvc
-    RUST_CHANNEL: 1.15.0
+    RUST_CHANNEL: 1.23.0
     WPD_LIB_PATH: "C:/dl/wpdpack/WpdPack/Lib/x64/Packet.lib"
     VCVARS: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\amd64\\vcvars64.bat"
   - TARGET: i686-pc-windows-msvc
-    RUST_CHANNEL: 1.15.0
-    WPD_LIB_PATH: "C:/dl/wpdpack/WpdPack/Lib/Packet.lib"
-    VCVARS: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\vcvars32.bat"
-  - TARGET: x86_64-pc-windows-msvc
-    RUST_CHANNEL: 1.20.0
-    WPD_LIB_PATH: "C:/dl/wpdpack/WpdPack/Lib/x64/Packet.lib"
-    VCVARS: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\amd64\\vcvars64.bat"
-  - TARGET: i686-pc-windows-msvc
-    RUST_CHANNEL: 1.20.0
+    RUST_CHANNEL: 1.23.0
     WPD_LIB_PATH: "C:/dl/wpdpack/WpdPack/Lib/Packet.lib"
     VCVARS: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\vcvars32.bat"
   - TARGET: x86_64-pc-windows-msvc


### PR DESCRIPTION
The Rust compiler version in travis configuration is 1.15 which causes the builds to fail. 


I updated compiler version to 1.23 and now it passes build tests.  