### PR TITLE
Improve MacAddr ergonomics

### DIFF
--- a/pnet_base/src/macaddr.rs
+++ b/pnet_base/src/macaddr.rs
@@ -6,11 +6,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::error::Error;
 use std::fmt;
 use std::str::FromStr;
 
 /// A MAC address
-#[derive(PartialEq, Eq, Clone, Copy, Hash)]
+#[derive(PartialEq, Eq, Clone, Copy, Hash, Ord, PartialOrd)]
 pub struct MacAddr(pub u8, pub u8, pub u8, pub u8, pub u8, pub u8);
 
 impl MacAddr {
@@ -39,9 +40,6 @@ impl fmt::Debug for MacAddr {
     }
 }
 
-// FIXME Is this the right way to do this? Which occurs is an implementation
-//       issue rather than actually defined - is it useful to provide these
-//       errors, or would it be better to just give ()?
 /// Represents an error which occurred whilst parsing a MAC address
 #[derive(Copy, Debug, PartialEq, Eq, Clone)]
 pub enum ParseMacAddrErr {
@@ -51,6 +49,22 @@ pub enum ParseMacAddrErr {
     TooFewComponents,
     /// One of the components contains an invalid value, eg. 00:GG:22:33:44:55
     InvalidComponent,
+}
+
+impl Error for ParseMacAddrErr {
+    fn description(&self) -> &str {
+        match *self {
+            ParseMacAddrErr::TooManyComponents => "Too many components in a MAC address string",
+            ParseMacAddrErr::TooFewComponents => "Too few components in a MAC address string",
+            ParseMacAddrErr::InvalidComponent => "Invalid component in a MAC address string",
+        }
+    }
+}
+
+impl fmt::Display for ParseMacAddrErr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.description())
+    }
 }
 
 impl FromStr for MacAddr {


### PR DESCRIPTION
* Make it Ord, so it can be used as a part of a key in
  BTreeMap/BTreeSet, or sorted.
* Make the ParseMacAddrErr actually an error, which makes it easier to
  integrate with things like error chain or failure.
* Removed a FIXME comment suggesting to use () instead of an error:
  - It is recommended never to use () as an error, but always at least
    provide empty struct (and implement Error on that), for ergonomics,
    type separation and clearer meaning.
  - There are use cases where MAC addresses come from eg. a
    configuration file, so it makes sense to do proper error handling
    around it, not only a programmer errors as the comment suggested.