### PR TITLE
Serde support for MAC addresses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     - secure: kd+Q+IWrHUZK+BwwEh37IiR7B76yyvfjAB3Gx6roshKyAk2KmduoyLGv6v902gbLAtt/8JtPMBHZdKbMv7A1eKBsCOF/rMz1rHziuTbnFwfnx6UN+jalZZRIYmn20M7I1UfvhcvWXqvcrpo84NbhOYlXMmvI+X6HZ2rSIsYta6E=
     - VERBOSE: 1
   matrix:
-    - PNET_FEATURES="travis pcap" PNET_MACROS_FEATURES="travis"
+    - PNET_FEATURES="travis pcap serde" PNET_MACROS_FEATURES="travis"
 matrix:
   allow_failures:
     - rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ netmap = ["pnet_datalink/netmap_sys", "pnet_datalink/netmap"]
 pcap = ["pnet_datalink/pcap"]
 appveyor = []
 travis = []
+serde = ["pnet_base/serde"]
 
 [dependencies]
 ipnetwork = "0.12"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,6 +41,6 @@ install:
  - cargo -V
 build: false
 test_script:
-    - cargo test --verbose --features appveyor
+    - cargo test --verbose --features "appveyor serde"
 
 skip_branch_with_pr: true

--- a/pnet_base/Cargo.toml
+++ b/pnet_base/Cargo.toml
@@ -8,3 +8,13 @@ repository = "https://github.com/libpnet/libpnet"
 description = "Fundamental base types and code used by pnet."
 keywords = ["networking", "ethernet"]
 categories = ["network-programming"]
+
+[dependencies]
+serde = { version = "~1", optional = true, default-features = false }
+
+[dev-dependencies]
+serde_test = "~1"
+
+[package.metadata.docs.rs]
+# Enable the serde feature when generating docs on docs.rs, so the traits are visible
+features = ["serde"]

--- a/pnet_base/src/lib.rs
+++ b/pnet_base/src/lib.rs
@@ -6,5 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[cfg(feature = "serde")]
+extern crate serde;
+
 mod macaddr;
 pub use macaddr::*;


### PR DESCRIPTION
For #318.

* I got lost in the `build.sh` script used in travis, so I enabled the feature only on appveyor.
* I suspect there might be some more types that may benefit from being serializable, but I'll search for them at some other time.