### PR TITLE
Fixed bug when pulling Windows net interfaces

### DIFF
--- a/pnet_datalink/src/winpcap.rs
+++ b/pnet_datalink/src/winpcap.rs
@@ -324,16 +324,16 @@ pub fn interfaces() -> Vec<NetworkInterface> {
         }
     }
 
-    let mut buf = [0u8; 4096];
+    const IFACE_BUF_LEN: usize = 4096;
+    let mut buf = vec![0u8; IFACE_BUF_LEN];
     let mut buflen = buf.len() as u32;
 
-    // Gets list of supported adapters in form:
-    // adapter1\0adapter2\0\0desc1\0desc2\0\0
     if unsafe { winpcap::PacketGetAdapterNames(buf.as_mut_ptr() as *mut i8, &mut buflen) } == 0 {
-        // FIXME [windows] Should allocate a buffer big enough and try again
-        //        - size should be buf.len() + buflen (buflen is overwritten)
-        panic!("FIXME [windows] unable to get interface list");
+
+        buf = vec![0u8; IFACE_BUF_LEN + buflen as usize];
+        unsafe { winpcap::PacketGetAdapterNames(buf.as_mut_ptr() as *mut i8, &mut buflen) };
     }
+
 
     let buf_str = unsafe { from_utf8_unchecked(&buf) };
     let iface_names = buf_str.split("\0\0").next();


### PR DESCRIPTION
The following PR is related to https://github.com/libpnet/libpnet/issues/329

---

###### Stdout

```rust
extern crate pnet_datalink;

fn send_tcp_packet() {
    pnet_datalink::interfaces();
}


fn main() {
    send_tcp_packet();
}
```
```
$ cargo build
   Compiling pnet_datalink v0.21.0 (file:///C:/Users/JDB/Projects/libpnet/pnet_datalink)
   Compiling pnet v0.21.0 (file:///C:/Users/JDB/Projects/libpnet)
    Finished dev [unoptimized + debuginfo] target(s) in 1.71 secs
```
```
$ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
     Running `target\debug\pnet.exe
```

---

###### Description

When calling `winpcap::PacketGetAdapterNames` the initial buffer length was being set to `4096`, which may not always be sufficient (i.e. Windows with multiple Hyper-V adapters), however when the call fails, the `buflen` is mutated to the correct value. 

In that case, `buf` is adjusted to me `4096` bytes + `buflen` which should always align correctly. Finally, a second call to `winpcap::PacketGetAdapterNames` is made with the _new_ correct buffer size.

--- 

PS: I'm not too proficient in `Rust` unfortunately, so the code may not turn out too nice. I tried wrapping the `winpcap` function call in a closure, however it kept on causing all sorts of reference issues that I could not solve. :-) 