### PR TITLE
Update list_interfaces.rs

### DIFF
--- a/examples/list_interfaces.rs
+++ b/examples/list_interfaces.rs
@@ -7,10 +7,10 @@
 // except according to those terms.
 
 /// This examples simply print all interfaces to stdout
-extern crate pnet_datalink;
+extern crate pnet;
 
 fn main() {
-    for interface in pnet_datalink::interfaces() {
+    for interface in pnet::datalink::interfaces() {
         println!("{}", interface);
     }
 }


### PR DESCRIPTION
updated extern crate name
fixed:
error[E0463]: can't find crate for `pnet_datalink`
 --> src/main.rs:1:1
  |
1 | extern crate pnet_datalink;
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't find crate

error: aborting due to previous error