### PR TITLE
Add option to set time-to-live on the TransportSender socket.

### DIFF
--- a/pnet_sys/src/unix.rs
+++ b/pnet_sys/src/unix.rs
@@ -26,9 +26,10 @@ pub mod public {
 
     pub const IPPROTO_IP: libc::c_int = libc::IPPROTO_IP;
     pub const IP_HDRINCL: libc::c_int = libc::IP_HDRINCL;
+    pub const IP_TTL: libc::c_int = libc::IP_TTL;
 
     pub use libc::{IFF_UP, IFF_BROADCAST, IFF_LOOPBACK, IFF_POINTOPOINT, IFF_MULTICAST};
-    
+
     pub const INVALID_SOCKET: CSocket = -1;
 
 

--- a/pnet_sys/src/windows.rs
+++ b/pnet_sys/src/windows.rs
@@ -30,6 +30,7 @@ pub mod public {
 
     pub const IPPROTO_IP: libc::c_int = winapi::IPPROTO_IP;
     pub const IP_HDRINCL: libc::c_int = winapi::IP_HDRINCL;
+    pub const IP_TTL: libc::c_int = winapi::IP_TTL;
 
     pub const IFF_UP: libc::c_int = 0x00000001;
     pub const IFF_BROADCAST: libc::c_int = 0x00000002;
@@ -37,7 +38,7 @@ pub mod public {
     pub const IFF_POINTTOPOINT: libc::c_int = 0x00000008;
     pub const IFF_POINTOPOINT: libc::c_int = IFF_POINTTOPOINT;
     pub const IFF_MULTICAST: libc::c_int = 0x00000010;
-    
+
     pub const INVALID_SOCKET: CSocket = winapi::INVALID_SOCKET;
 
 

--- a/pnet_transport/src/lib.rs
+++ b/pnet_transport/src/lib.rs
@@ -69,6 +69,13 @@ pub struct TransportReceiver {
     channel_type: TransportChannelType,
 }
 
+/// Structure used for holding all configurable options for describing possible options
+/// for transport channels.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct Config {
+        time_to_live: u8,
+}
+
 /// Create a new (TransportSender, TransportReceiver) pair
 ///
 /// This allows for sending and receiving packets at the transport layer. The buffer size should be
@@ -147,6 +154,46 @@ pub fn transport_channel(buffer_size: usize,
     Ok((sender, receiver))
 }
 
+/// Create a new (TransportSender, TransportReceiver) pair using the additional
+/// options specified.
+///
+/// For a more exhaustive descriptive, see above.
+pub fn transport_channel_with(buffer_size: usize,
+                              channel_type: TransportChannelType,
+                              configuration: Config)
+    -> io::Result<(TransportSender, TransportReceiver)> {
+
+    let (sender, receiver) = transport_channel(buffer_size, channel_type)?;
+
+    set_socket_ttl(sender.socket.clone(), configuration.time_to_live)?;
+    Ok((sender, receiver))
+}
+
+/// Sets the time-to-live for all IP packets sent on the specified socket.
+fn set_socket_ttl(socket: Arc<pnet_sys::FileDesc>, ttl: u8) -> io::Result<()> {
+    let ttl = ttl as i32;
+    let res = unsafe {
+        pnet_sys::setsockopt(
+            socket.fd,
+            pnet_sys::IPPROTO_IP,
+            pnet_sys::IP_TTL,
+            (&ttl as *const libc::c_int) as pnet_sys::Buf,
+            mem::size_of::<libc::c_int>() as pnet_sys::SockLen
+        )
+    };
+
+    match res {
+        -1 => {
+            let err = Error::last_os_error();
+            unsafe {
+                pnet_sys::close(socket.fd);
+            }
+            Err(err)
+        },
+        _ => Ok(()),
+    }
+}
+
 impl TransportSender {
     fn send<T: Packet>(&mut self, packet: T, dst: IpAddr) -> io::Result<usize> {
         let mut caddr = unsafe { mem::zeroed() };
@@ -164,6 +211,11 @@ impl TransportSender {
     #[inline]
     pub fn send_to<T: Packet>(&mut self, packet: T, destination: IpAddr) -> io::Result<usize> {
         self.send_to_impl(packet, destination)
+    }
+
+    /// Sets the time-to-live on the socket, which then applies for all packets sent.
+    pub fn set_ttl(&mut self, time_to_live: u8) -> io::Result<()> {
+        set_socket_ttl(self.socket.clone(), time_to_live)
     }
 
     #[cfg(all(not(target_os = "freebsd"), not(target_os = "macos")))]


### PR DESCRIPTION
Hi folks!

While using this awesome crate for a project of mine, I discovered that I need to set the time-to-live for packets which get sent.

So I thought I would quickly hack together a possibility to do so.
Of course, I am open to suggestion for improvements!