### PR TITLE
Add convenient method for get/set socket receive timeout

### DIFF
--- a/pnet_sys/src/lib.rs
+++ b/pnet_sys/src/lib.rs
@@ -11,6 +11,7 @@ extern crate libc;
 use std::io;
 use std::mem;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+use std::time::Duration;
 
 #[cfg(unix)]
 #[path = "unix.rs"]

--- a/pnet_sys/src/lib.rs
+++ b/pnet_sys/src/lib.rs
@@ -11,8 +11,6 @@ extern crate libc;
 use std::io;
 use std::mem;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
-use std::time::Duration;
-
 
 #[cfg(unix)]
 #[path = "unix.rs"]

--- a/pnet_sys/src/lib.rs
+++ b/pnet_sys/src/lib.rs
@@ -113,11 +113,11 @@ pub fn set_socket_receive_timeout(socket: CSocket, t: Duration)
 pub fn get_socket_receive_timeout(socket: CSocket)
     -> io::Result<Duration> {
     let ts = libc::timespec { tv_sec: 0, tv_nsec: 0 };
-    let len : MutSockLen = mem::size_of::<libc::timespec>() as MutSockLen;
+    let len : SockLen = 0;
     let r = unsafe{
         getsockopt(socket, SOL_SOCKET, SO_RCVTIMEO,
                    (&ts as *const libc::timespec) as MutBuf,
-                   len
+                   (&len as *const libc::socklen_t) as MutSockLen
         )
     };
     

--- a/pnet_sys/src/unix.rs
+++ b/pnet_sys/src/unix.rs
@@ -21,10 +21,10 @@ pub mod public {
     pub type InAddr = libc::in_addr;
     pub type In6Addr = libc::in6_addr;
 
-    #[cfg(not(any(target_os = "macos")))]
+    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
     pub type TvUsecType = libc::c_long;
-    #[cfg(any(target_os = "macos"))]
-    pub type TvUsecType = libc::__darwin_suseconds_t;
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    pub type TvUsecType = libc::c_int;
 
     pub const AF_INET: libc::c_int = libc::AF_INET;
     pub const AF_INET6: libc::c_int = libc::AF_INET6;

--- a/pnet_sys/src/unix.rs
+++ b/pnet_sys/src/unix.rs
@@ -24,6 +24,9 @@ pub mod public {
     pub const AF_INET6: libc::c_int = libc::AF_INET6;
     pub const SOCK_RAW: libc::c_int = libc::SOCK_RAW;
 
+    pub const SOL_SOCKET: libc::c_int = libc::SOL_SOCKET;
+    pub const SO_RCVTIMEO: libc::c_int = libc::SO_RCVTIMEO;
+
     pub const IPPROTO_IP: libc::c_int = libc::IPPROTO_IP;
     pub const IP_HDRINCL: libc::c_int = libc::IP_HDRINCL;
 
@@ -39,6 +42,15 @@ pub mod public {
     pub unsafe fn socket(af: libc::c_int, sock: libc::c_int, proto: libc::c_int) -> CSocket {
         libc::socket(af, sock, proto)
     }
+
+    //pub unsafe fn getsockopt(socket: CSocket,
+    //                        level: libc::c_int,
+    //                        name: libc::c_int,
+    //                        value: &mut Buf,
+    //                        option_len: SockLen)
+    //    -> libc::c_int {
+    //    libc::getsockopt(socket, level, name, value, option_len)
+    //}
 
     pub unsafe fn setsockopt(socket: CSocket,
                             level: libc::c_int,

--- a/pnet_sys/src/unix.rs
+++ b/pnet_sys/src/unix.rs
@@ -4,7 +4,6 @@ use std::io;
 pub mod public {
     use libc;
     use std::time::Duration;
-    use std::mem;
 
     pub type CSocket = libc::c_int;
     pub type Buf = *const libc::c_void;

--- a/pnet_sys/src/unix.rs
+++ b/pnet_sys/src/unix.rs
@@ -27,6 +27,7 @@ pub mod public {
 
     pub const SOL_SOCKET: libc::c_int = libc::SOL_SOCKET;
     pub const SO_RCVTIMEO: libc::c_int = libc::SO_RCVTIMEO;
+    pub const SO_SNDTIMEO: libc::c_int = libc::SO_SNDTIMEO;
 
     pub const IPPROTO_IP: libc::c_int = libc::IPPROTO_IP;
     pub const IP_HDRINCL: libc::c_int = libc::IP_HDRINCL;
@@ -60,6 +61,17 @@ pub mod public {
                             option_len: SockLen)
         -> libc::c_int {
         libc::setsockopt(socket, level, name, value, option_len)
+    }
+
+    pub fn timeval_to_duration(tv: libc::timeval) -> Duration {
+        Duration::new(tv.tv_sec as u64, (tv.tv_usec as u32) * 1000)
+    }
+
+    pub fn duration_to_timeval(dur: Duration) -> libc::timeval {
+        libc::timeval {
+            tv_sec: dur.as_secs() as libc::time_t,
+            tv_usec: dur.subsec_micros() as libc::c_long,
+        }
     }
 
     pub fn timespec_to_duration(ts: libc::timespec) -> Duration {
@@ -123,4 +135,29 @@ pub fn retry<F>(f: &mut F) -> libc::ssize_t
 
 fn errno() -> i32 {
     io::Error::last_os_error().raw_os_error().unwrap()
+}
+
+
+
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+    use duration_to_timespec;
+    use timespec_to_duration;
+
+    #[test]
+    fn test_duration_to_timespec(){
+        let d1 = Duration::new(1, 0);
+        let d2 = Duration::from_millis(500);
+
+        let t1 = duration_to_timespec(d1);
+        let t2 = duration_to_timespec(d2);
+
+        let r1 = timespec_to_duration(t1);
+        let r2 = timespec_to_duration(t2);
+
+        assert_eq!(d1, r1);
+        assert_eq!(d2, r2);
+    }
 }

--- a/pnet_sys/src/unix.rs
+++ b/pnet_sys/src/unix.rs
@@ -21,6 +21,11 @@ pub mod public {
     pub type InAddr = libc::in_addr;
     pub type In6Addr = libc::in6_addr;
 
+    #[cfg(not(targetos="macos"))]
+    pub type TvUsecType = libc::c_long;
+    #[cfg(targetos="macos")]
+    pub type TvUsecType = libc::__darwin_suseconds_t;
+
     pub const AF_INET: libc::c_int = libc::AF_INET;
     pub const AF_INET6: libc::c_int = libc::AF_INET6;
     pub const SOCK_RAW: libc::c_int = libc::SOCK_RAW;
@@ -64,25 +69,29 @@ pub mod public {
         libc::setsockopt(socket, level, name, value, option_len)
     }
 
+    /// Convert a platform specific `timeval` into a Duration
     pub fn timeval_to_duration(tv: libc::timeval) -> Duration {
         Duration::new(tv.tv_sec as u64, (tv.tv_usec as u32) * 1000)
     }
 
+    /// Convert a Duration into a platform specific `timeval`
     pub fn duration_to_timeval(dur: Duration) -> libc::timeval {
         libc::timeval {
             tv_sec: dur.as_secs() as libc::time_t,
-            tv_usec: dur.subsec_micros() as libc::c_long,
+            tv_usec: dur.subsec_micros() as TvUsecType
         }
     }
 
+    /// Convert a platform specific `timespec` into a Duration
     pub fn timespec_to_duration(ts: libc::timespec) -> Duration {
         Duration::new(ts.tv_sec as u64, ts.tv_nsec as u32)
     }
 
+    /// Convert a Duration into a platform specific `timespec`
     pub fn duration_to_timespec(dur: Duration) -> libc::timespec {
         libc::timespec {
             tv_sec: dur.as_secs() as libc::time_t,
-            tv_nsec: dur.subsec_nanos() as libc::c_long,
+            tv_nsec: dur.subsec_nanos() as TvUsecType
         }
     }
 

--- a/pnet_sys/src/unix.rs
+++ b/pnet_sys/src/unix.rs
@@ -21,9 +21,9 @@ pub mod public {
     pub type InAddr = libc::in_addr;
     pub type In6Addr = libc::in6_addr;
 
-    #[cfg(not(targetos="macos"))]
+    #[cfg(not(any(target_os = "macos")))]
     pub type TvUsecType = libc::c_long;
-    #[cfg(targetos="macos")]
+    #[cfg(any(target_os = "macos"))]
     pub type TvUsecType = libc::__darwin_suseconds_t;
 
     pub const AF_INET: libc::c_int = libc::AF_INET;

--- a/pnet_sys/src/unix.rs
+++ b/pnet_sys/src/unix.rs
@@ -91,7 +91,7 @@ pub mod public {
     pub fn duration_to_timespec(dur: Duration) -> libc::timespec {
         libc::timespec {
             tv_sec: dur.as_secs() as libc::time_t,
-            tv_nsec: dur.subsec_nanos() as TvUsecType
+            tv_nsec: (dur.subsec_nanos() as TvUsecType).into()
         }
     }
 

--- a/pnet_sys/src/unix.rs
+++ b/pnet_sys/src/unix.rs
@@ -4,6 +4,7 @@ use std::io;
 pub mod public {
     use libc;
     use std::time::Duration;
+    use std::mem;
 
     pub type CSocket = libc::c_int;
     pub type Buf = *const libc::c_void;
@@ -11,6 +12,7 @@ pub mod public {
     pub type BufLen = libc::size_t;
     pub type CouldFail = libc::ssize_t;
     pub type SockLen = libc::socklen_t;
+    pub type MutSockLen = *mut libc::socklen_t;
     pub type SockAddr = libc::sockaddr;
     pub type SockAddrIn = libc::sockaddr_in;
     pub type SockAddrIn6 = libc::sockaddr_in6;
@@ -43,14 +45,14 @@ pub mod public {
         libc::socket(af, sock, proto)
     }
 
-    //pub unsafe fn getsockopt(socket: CSocket,
-    //                        level: libc::c_int,
-    //                        name: libc::c_int,
-    //                        value: &mut Buf,
-    //                        option_len: SockLen)
-    //    -> libc::c_int {
-    //    libc::getsockopt(socket, level, name, value, option_len)
-    //}
+    pub unsafe fn getsockopt(socket: CSocket,
+                            level: libc::c_int,
+                            name: libc::c_int,
+                            value: MutBuf,
+                            option_len: MutSockLen)
+        -> libc::c_int {
+        libc::getsockopt(socket, level, name, value, option_len)
+    }
 
     pub unsafe fn setsockopt(socket: CSocket,
                             level: libc::c_int,
@@ -59,6 +61,10 @@ pub mod public {
                             option_len: SockLen)
         -> libc::c_int {
         libc::setsockopt(socket, level, name, value, option_len)
+    }
+
+    pub fn timespec_to_duration(ts: libc::timespec) -> Duration {
+        Duration::new(ts.tv_sec as u64, ts.tv_nsec as u32)
     }
 
     pub fn duration_to_timespec(dur: Duration) -> libc::timespec {

--- a/pnet_sys/src/windows.rs
+++ b/pnet_sys/src/windows.rs
@@ -15,7 +15,7 @@ pub mod public {
     pub type BufLen = libc::c_int;
     pub type CouldFail = libc::c_int;
     pub type SockLen = winapi::socklen_t;
-    pub type SockLen = *mut winapi::socklen_t;
+    pub type MutSockLen = *mut winapi::socklen_t;
     pub type SockAddr = winapi::SOCKADDR;
     pub type SockAddrIn = winapi::SOCKADDR_IN;
     pub type SockAddrIn6 = winapi::sockaddr_in6;

--- a/pnet_sys/src/windows.rs
+++ b/pnet_sys/src/windows.rs
@@ -15,6 +15,7 @@ pub mod public {
     pub type BufLen = libc::c_int;
     pub type CouldFail = libc::c_int;
     pub type SockLen = winapi::socklen_t;
+    pub type SockLen = *mut winapi::socklen_t;
     pub type SockAddr = winapi::SOCKADDR;
     pub type SockAddrIn = winapi::SOCKADDR_IN;
     pub type SockAddrIn6 = winapi::sockaddr_in6;
@@ -57,6 +58,16 @@ pub mod public {
         -> libc::c_int {
         ws2_32::setsockopt(socket, level, name, value, option_len)
     }
+
+    pub unsafe fn getsockopt(socket: CSocket,
+                            level: libc::c_int,
+                            name: libc::c_int,
+                            value: MutBuf,
+                            option_len: MutSockLen)
+        -> libc::c_int {
+        ws2_32::getsockopt(socket, level, name, value, option_len)
+    }
+
 }
 
 use self::public::*;

--- a/pnet_transport/src/lib.rs
+++ b/pnet_transport/src/lib.rs
@@ -295,12 +295,18 @@ macro_rules! transport_channel_iterator {
                 let socket_fd = self.tr.socket.fd;
                 
                 let old_timeout = match pnet_sys::get_socket_receive_timeout(socket_fd) {
-                    Err(e) => return Err(e),
+                    Err(e) => {
+                        eprintln!("Can not get socket timeout before receiving: {}", e);
+                        return Err(e)
+                    }
                     Ok(t) => t
                 };
 
                 match pnet_sys::set_socket_receive_timeout(socket_fd, t) {
-                    Err(e) => return Err(e),
+                    Err(e) => {
+                        eprintln!("Can not set socket timeout for receiving: {}", e);
+                        return Err(e)
+                    }
                     Ok(_) => {}
                 }
                     
@@ -315,7 +321,9 @@ macro_rules! transport_channel_iterator {
                 };
                 
                 match pnet_sys::set_socket_receive_timeout(socket_fd, old_timeout) {
-                    Err(e) => eprintln!("Warning: can not reset timeout: {}", e),
+                    Err(e) => {
+                        eprintln!("Can not reset socket timeout after receiving: {}", e);
+                    },
                     _ => {}
                 };
 


### PR DESCRIPTION
Hi,
in this pull request, I created convenience functions for common task of setting or getting the timeout on the socket directly (implemented in pnet_sys). This comes in handy when one does not want to explicitly create the channels using a configuration. For example, I use libpnet to create an ICMP channel and later want to change the socket timeouts.

I furthermore added few basic tests to check if the setting/getting works.

The implementation is usable for `unix.rs` only because winapi has a slightly different API and I can't test it there because I have only Linux PC. However, this code may help already to implement the convenience functions there too.

Disclaimer: I am relatively new and my Rust may not be optimal yet. If I can improve my code to support your library, please let me know! 

Thanks a lot for your great work!