### PR TITLE
fix call api GetAdaptersInfo crash

### DIFF
--- a/pnet_datalink/src/winpcap.rs
+++ b/pnet_datalink/src/winpcap.rs
@@ -276,6 +276,10 @@ pub fn interfaces() -> Vec<NetworkInterface> {
     }
 
     let vec_size = adapters_size / mem::size_of::<winpcap::IP_ADAPTER_INFO>() as u32;
+    
+    if adapters_size % mem::size_of::<winpcap::IP_ADAPTER_INFO>() as u32 != 0 {
+        vec_size += 1;
+    }
 
     let mut adapters = Vec::with_capacity(vec_size as usize);
 

--- a/pnet_datalink/src/winpcap.rs
+++ b/pnet_datalink/src/winpcap.rs
@@ -275,12 +275,10 @@ pub fn interfaces() -> Vec<NetworkInterface> {
         winpcap::GetAdaptersInfo(&mut tmp, &mut adapters_size);
     }
 
-    let vec_size = adapters_size / mem::size_of::<winpcap::IP_ADAPTER_INFO>() as u32;
-    
+    let mut vec_size = adapters_size / mem::size_of::<winpcap::IP_ADAPTER_INFO>() as u32;
     if adapters_size % mem::size_of::<winpcap::IP_ADAPTER_INFO>() as u32 != 0 {
         vec_size += 1;
     }
-
     let mut adapters = Vec::with_capacity(vec_size as usize);
 
     // FIXME [windows] Check return code


### PR DESCRIPTION
x86_64-pc-windows-msvc Throw a crash