### PR TITLE
WIP: Add support for Layer 3 IPv6

### DIFF
--- a/pnet_sys/src/unix.rs
+++ b/pnet_sys/src/unix.rs
@@ -31,11 +31,14 @@ pub mod public {
     pub const SOCK_RAW: libc::c_int = libc::SOCK_RAW;
 
     pub const SOL_SOCKET: libc::c_int = libc::SOL_SOCKET;
+    pub const SOL_IP: libc::c_int = libc::SOL_IP;
+    pub const SOL_IPV6: libc::c_int = libc::SOL_IPV6;
     pub const SO_RCVTIMEO: libc::c_int = libc::SO_RCVTIMEO;
     pub const SO_SNDTIMEO: libc::c_int = libc::SO_SNDTIMEO;
 
     pub const IPPROTO_IP: libc::c_int = libc::IPPROTO_IP;
     pub const IP_HDRINCL: libc::c_int = libc::IP_HDRINCL;
+    pub const IPV6_HDRINCL: libc::c_int = 36; // FIXME
     pub const IP_TTL: libc::c_int = libc::IP_TTL;
 
     pub use libc::{IFF_UP, IFF_BROADCAST, IFF_LOOPBACK, IFF_POINTOPOINT, IFF_MULTICAST};

--- a/pnet_sys/src/windows.rs
+++ b/pnet_sys/src/windows.rs
@@ -31,6 +31,7 @@ pub mod public {
 
     pub const IPPROTO_IP: libc::c_int = winapi::IPPROTO_IP;
     pub const IP_HDRINCL: libc::c_int = winapi::IP_HDRINCL;
+    pub const IPV6_HDRINCL: libc::c_int = winapi::IPV6_HDRINCL;
     pub const IP_TTL: libc::c_int = winapi::IP_TTL;
 
     pub const IFF_UP: libc::c_int = 0x00000001;


### PR DESCRIPTION
This is WIP. I'm still planning to test it on Windows and FreeBSD, but haven't done so yet. And there're a couple of TODOs in the code.

But what bothers me the most is how to name new enum value. The existing `Layer3` is IPv4, and I wasn't able to solve this without either breaking compatibility (by refactoring layer 3 related enum values into something similar to what already exists for layer 4), or introducing badly named identifiers. This WIP has the latter - the new value is `Ipv6Layer3`.

Something that I've observed that might worth mentioning in the docs:
* Unlike IPv4, source address is not filled in automatically for IPv6 layer 3 packets.
* `HDRINC` (aka Layer3) has no effect for receiving IPv6 on Linux. IPv6 header is always stripped. If this is also the case with other OS, then there is no point adding `Ipv6TransportChannelIterator`

By the way, is there a way to construct an iterator over raw packets? Like `ipv4_iterator`, but with byte slice instead of `Ipv4Packet`. With `HDRINC` not working, it seems to be crucial for IPv6. Not to mention that it's generally useful for layer 4 protocols.

See #344 
ping @JuxhinDB 