### PR TITLE
Fix a bug in calling `pselect`

### DIFF
--- a/pnet_datalink/src/bpf.rs
+++ b/pnet_datalink/src/bpf.rs
@@ -260,6 +260,7 @@ impl DataLinkSender for DataLinkSenderImpl {
             for chunk in self.write_buffer[..len].chunks_mut(packet_size) {
                 func(chunk);
                 let ret = unsafe {
+                    libc::FD_SET(self.fd.fd, &mut self.fd_set as *mut libc::fd_set);
                     libc::pselect(self.fd.fd + 1,
                                   ptr::null_mut(),
                                   &mut self.fd_set as *mut libc::fd_set,
@@ -299,6 +300,7 @@ impl DataLinkSender for DataLinkSenderImpl {
         // The OS will prepend the packet with 4 bytes set to AF_INET.
         let offset = if self.loopback { ETHERNET_HEADER_SIZE } else { 0 };
         let ret = unsafe {
+            libc::FD_SET(self.fd.fd, &mut self.fd_set as *mut libc::fd_set);
             libc::pselect(self.fd.fd + 1,
                           ptr::null_mut(),
                           &mut self.fd_set as *mut libc::fd_set,
@@ -348,6 +350,7 @@ impl DataLinkReceiver for DataLinkReceiverImpl {
         if self.packets.is_empty() {
             let buffer = &mut self.read_buffer[buffer_offset..];
             let ret = unsafe {
+                libc::FD_SET(self.fd.fd, &mut self.fd_set as *mut libc::fd_set);
                 libc::pselect(self.fd.fd + 1,
                               &mut self.fd_set as *mut libc::fd_set,
                               ptr::null_mut(),


### PR DESCRIPTION
Per `pselect` [man pages](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/select.2.html#//apple_ref/doc/man/2/select), the `k`th bit of `self.fd_set` must be set if we are interested in file descriptor `k`. libpnet does this once in [here](https://github.com/libpnet/libpnet/blob/dc2203a32a00981995b548eed4b4a90010e9491e/pnet_datalink/src/bpf.rs#L232), when the datalink receiver/sender is initialized. However, if no descriptors are available during a `pselect` call, the kernel will clear `self.fd_set`, and next time when pnet calls `pselect`, it will pass a `fd_set` with all bits 0. The kernel will interpret this as "I don't care if any of the file descriptors are available", and will happily return 0 even if there are some packets available. See screenshot, all bits in the `fd_set` bit mask are set to 0(this is not supposed to happen!).

![Xnip2020-01-03_16-46-22](https://user-images.githubusercontent.com/5873227/71751147-9e810500-2e48-11ea-9b7d-2698285f3c01.jpg)

This caused an issue in another rust open source project, see discussion [here](https://github.com/imsnif/bandwhich/issues/51#issuecomment-570704211).
