### PR TITLE
Fix packet dump example on macos loopback interface.

### DIFF
--- a/examples/packetdump.rs
+++ b/examples/packetdump.rs
@@ -248,25 +248,39 @@ fn main() {
         let mut fake_ethernet_frame = MutableEthernetPacket::new(&mut buf[..]).unwrap();
         match rx.next() {
             Ok(packet) => {
-                if cfg!(target_os = "macos") && interface.is_up() && !interface.is_broadcast()
-                    && !interface.is_loopback() && interface.is_point_to_point()
+                let payload_offset;
+                if cfg!(target_os = "macos") && interface.is_up() && !interface.is_broadcast() 
+                    && ((!interface.is_loopback() && interface.is_point_to_point()) 
+                         || interface.is_loopback())
                 {
-                    // Maybe is TUN interface
-                    let version = Ipv4Packet::new(&packet).unwrap().get_version();
-                    if version == 4 {
-                        fake_ethernet_frame.set_destination(MacAddr(0, 0, 0, 0, 0, 0));
-                        fake_ethernet_frame.set_source(MacAddr(0, 0, 0, 0, 0, 0));
-                        fake_ethernet_frame.set_ethertype(EtherTypes::Ipv4);
-                        fake_ethernet_frame.set_payload(&packet);
-                        handle_ethernet_frame(&interface, &fake_ethernet_frame.to_immutable());
-                        continue;
-                    } else if version == 6 {
-                        fake_ethernet_frame.set_destination(MacAddr(0, 0, 0, 0, 0, 0));
-                        fake_ethernet_frame.set_source(MacAddr(0, 0, 0, 0, 0, 0));
-                        fake_ethernet_frame.set_ethertype(EtherTypes::Ipv6);
-                        fake_ethernet_frame.set_payload(&packet);
-                        handle_ethernet_frame(&interface, &fake_ethernet_frame.to_immutable());
-                        continue;
+                    if interface.is_loopback()
+                    {
+                        // The pnet code for BPF loopback adds a zero'd out Ethernet header
+                        payload_offset = 14;
+                    }
+                    else
+                    {
+                        // Maybe is TUN interface
+                        payload_offset = 0;
+                    }
+                    if packet.len() > payload_offset
+                    {
+                        let version = Ipv4Packet::new(&packet[payload_offset..]).unwrap().get_version();
+                        if version == 4 {
+                            fake_ethernet_frame.set_destination(MacAddr(0, 0, 0, 0, 0, 0));
+                            fake_ethernet_frame.set_source(MacAddr(0, 0, 0, 0, 0, 0));
+                            fake_ethernet_frame.set_ethertype(EtherTypes::Ipv4);
+                            fake_ethernet_frame.set_payload(&packet[payload_offset..]);
+                            handle_ethernet_frame(&interface, &fake_ethernet_frame.to_immutable());
+                            continue;
+                        } else if version == 6 {
+                            fake_ethernet_frame.set_destination(MacAddr(0, 0, 0, 0, 0, 0));
+                            fake_ethernet_frame.set_source(MacAddr(0, 0, 0, 0, 0, 0));
+                            fake_ethernet_frame.set_ethertype(EtherTypes::Ipv6);
+                            fake_ethernet_frame.set_payload(&packet[payload_offset..]);
+                            handle_ethernet_frame(&interface, &fake_ethernet_frame.to_immutable());
+                            continue;
+                        }
                     }
                 }
                 handle_ethernet_frame(&interface, &EthernetPacket::new(packet).unwrap());


### PR DESCRIPTION
This PR fixes https://github.com/libpnet/libpnet/issues/381.  The problem was that the BPF datalink code adds a zeroed out Ethernet header to the beginning of the packet when the interface is loopback.  None of the code in the packetdump example code was handling this case.