### PR TITLE
Bump Version 0.25.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pnet"
-version = "0.23.0"
+version = "0.25.0"
 authors = [ "Robert Clipsham <robert@octarineparrot.com>" ]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"
@@ -22,11 +22,11 @@ serde = ["pnet_base/serde"]
 [dependencies]
 ipnetwork = "0.15.0"
 
-pnet_base = { path = "pnet_base", version = "0.23.0" }
-pnet_sys = { path = "pnet_sys", version = "0.23.0" }
-pnet_datalink = { path = "pnet_datalink", version = "0.23.0" }
-pnet_transport = { path = "pnet_transport", version = "0.23.0" }
-pnet_packet = { path = "pnet_packet", version = "0.23.0" }
+pnet_base = "0.22.0"
+pnet_sys = { path = "pnet_sys", version = "0.25.0" }
+pnet_datalink = { path = "pnet_datalink", version = "0.25.0" }
+pnet_transport = { path = "pnet_transport", version = "0.25.0" }
+pnet_packet = { path = "pnet_packet", version = "0.25.0" }
 
 [dev-dependencies]
 time = ">=0.1"

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ To use `libpnet` in your project, add the following to your Cargo.toml:
 
 ```
 [dependencies.pnet]
-version = "0.23.0"
+version = "0.25.0"
 ```
 
 `libpnet` should work on any Rust channel (stable, beta, or nightly), starting

--- a/pnet_base/Cargo.toml
+++ b/pnet_base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pnet_base"
-version = "0.23.0"
+version = "0.25.0"
 authors = ["Robert Clipsham <robert@octarineparrot.com>", "Linus Färnstrand <faern@faern.net>"]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"

--- a/pnet_datalink/Cargo.toml
+++ b/pnet_datalink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pnet_datalink"
-version = "0.23.0"
+version = "0.25.0"
 authors = ["Robert Clipsham <robert@octarineparrot.com>", "Linus Färnstrand <faern@faern.net>"]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"
@@ -15,8 +15,8 @@ netmap = []
 [dependencies]
 libc = "0.2.42"
 ipnetwork = "0.15.0"
-pnet_base = { path = "../pnet_base", version = "0.23.0" }
-pnet_sys = { path = "../pnet_sys", version = "0.23.0" }
+pnet_base = "0.22.0"
+pnet_sys = { path = "../pnet_sys", version = ">=0.25.0" }
 
 pcap = { version = "0.7", optional = true }
 netmap_sys = { version = ">=0.0", optional = true, features = ["netmap_with_libs"] }

--- a/pnet_macros/Cargo.toml
+++ b/pnet_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pnet_macros"
-version = "0.23.0"
+version = "0.25.0"
 authors = ["Robert Clipsham <robert@octarineparrot.com>"]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"
@@ -15,8 +15,8 @@ default = []
 travis = []
 
 [dev-dependencies]
-pnet_base = { path = "../pnet_base", version = "0.23.0" }
-pnet_macros_support = { path = "../pnet_macros_support", version = "0.23.0" }
+pnet_base = "0.22.0"
+pnet_macros_support = { path = "../pnet_macros_support", version = "0.25.0" }
 
 [dependencies]
 regex = "1.0.*"

--- a/pnet_macros_support/Cargo.toml
+++ b/pnet_macros_support/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "pnet_macros_support"
-version = "0.23.0"
+version = "0.25.0"
 authors = ["Robert Clipsham <robert@octarineparrot.com>"]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"
@@ -11,4 +11,4 @@ readme = "../README.md"
 keywords = ["networking", "bitfields", "packet", "protocol"]
 
 [dependencies]
-pnet_base = { path = "../pnet_base", version = ">=0.23.0" }
+pnet_base = "0.22.0"

--- a/pnet_packet/Cargo.toml
+++ b/pnet_packet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pnet_packet"
-version = "0.23.0"
+version = "0.25.0"
 authors = ["Robert Clipsham <robert@octarineparrot.com>"]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"
@@ -11,8 +11,8 @@ categories = ["network-programming", "parser-implementations"]
 build = "build.rs"
 
 [dependencies]
-pnet_base = { path = "../pnet_base", version = "0.23.0" }
-pnet_macros_support = { path = "../pnet_macros_support", version = "0.23.0" }
+pnet_base = "0.22.0"
+pnet_macros_support = { path = "../pnet_macros_support", version = "0.25.0" }
 
 [build-dependencies]
 glob = "0.2"

--- a/pnet_sys/Cargo.toml
+++ b/pnet_sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pnet_sys"
-version = "0.23.0"
+version = "0.25.0"
 authors = ["Robert Clipsham <robert@octarineparrot.com>", "Linus Färnstrand <faern@faern.net>"]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"

--- a/pnet_transport/Cargo.toml
+++ b/pnet_transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pnet_transport"
-version = "0.23.0"
+version = "0.25.0"
 authors = ["Robert Clipsham <robert@octarineparrot.com>"]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"
@@ -11,6 +11,6 @@ categories = ["network-programming"]
 
 [dependencies]
 libc = "0.2.39"
-pnet_base = { path = "../pnet_base", version = "0.23.0" }
-pnet_sys = { path = "../pnet_sys", version = "0.23.0" }
-pnet_packet = { path = "../pnet_packet", version = "0.23.0" }
+pnet_base = "0.22.0"
+pnet_sys = { path = "../pnet_sys", version = "0.25.0" }
+pnet_packet = { path = "../pnet_packet", version = "0.25.0" }


### PR DESCRIPTION
Bump to version to 0.25.0. This fixes

- #391 
- #394 

@mrmonday I had to set `pnet_base` version static to `0.22.0` to avoid breaking builds (I still have 0.25.0 pushed..). 

I would love to fix the `to_primitive_value` issue but it seems to be related to macros which is out of my breadth right now (and can't dedicate the time to research it well enough 😢). If you wish, we can open a PR and I'll slowly work on it for you to review.