### PR TITLE
reexport extern crate ipnetwork

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@
 #[cfg(feature = "benchmark")]
 extern crate test;
 
-extern crate ipnetwork;
+pub extern crate ipnetwork;
 
 extern crate pnet_base;
 extern crate pnet_datalink;


### PR DESCRIPTION
Fixes #274 

### Problem:
- Types imported from `ipnetwork` are in the public interface of `pnet`, but are not reexported.
- This forces users to manually add `ipnetwork` to their dependencies to use those parts of `pnet`'s interface

### Changes:
- the crate `ipnetwork` is reexported

### Benefits:
- Usability: Users won't have to manually add their own `ipnetwork` dependency to their Cargo.toml
- Compatibility: Avoids versioning conflicts if users already use an incompatible version of `ipnetwork`

I can't think of any downsides for this change tbf.