### PR TITLE
Fix issue 399 by using u16::from_be_bytes so we aren't using any raw …

### DIFF
--- a/pnet_packet/src/util.rs
+++ b/pnet_packet/src/util.rs
@@ -170,6 +170,7 @@ fn sum_be_words(data: &[u8], skipword: usize) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::sum_be_words;
+    use std::slice;
 
     #[test]
     fn sum_be_words_different_skipwords() {
@@ -180,6 +181,29 @@ mod tests {
         // results
         assert_eq!(7705, sum_be_words(&data, 99));
         assert_eq!(7705, sum_be_words(&data, 101));
+    }
+
+    #[test]
+    fn sum_be_words_misaligned_ptr() {
+        let mut data = vec![0; 13];
+        let ptr = match data.as_ptr() as usize % 2 { 
+            0 => {
+                unsafe { data.as_mut_ptr().offset(1) }
+            }
+            _ => data.as_mut_ptr(),
+        }; 
+        unsafe {
+            let slice_data = slice::from_raw_parts_mut(ptr, 12);
+            for i in 0..11 {
+                slice_data[i] = i as u8;
+            }
+            assert_eq!(7190, sum_be_words(&slice_data, 1));
+            assert_eq!(6676, sum_be_words(&slice_data, 2));
+            // Assert having the skipword outside the range gives correct and equal
+            // results
+            assert_eq!(7705, sum_be_words(&slice_data, 99));
+            assert_eq!(7705, sum_be_words(&slice_data, 101));
+        }
     }
 }
 

--- a/pnet_packet/src/util.rs
+++ b/pnet_packet/src/util.rs
@@ -160,7 +160,7 @@ fn sum_be_words(data: &[u8], skipword: usize) -> u32 {
     }
 
     // If the length is odd, make sure to checksum the final byte
-    if len & 1 != 0 {
+    if i != skipword && len & 1 != 0 {
         sum += (data[len - 1] as u32) << 8;
     }
 
@@ -181,6 +181,24 @@ mod tests {
         // results
         assert_eq!(7705, sum_be_words(&data, 99));
         assert_eq!(7705, sum_be_words(&data, 101));
+    }
+
+    #[test]
+    fn sum_be_words_small_sizes() {
+        let data_zero = vec![0; 0];
+        assert_eq!(0, sum_be_words(&data_zero, 0));
+        assert_eq!(0, sum_be_words(&data_zero, 10));
+        let data_one = vec![1; 1];
+        assert_eq!(0, sum_be_words(&data_zero, 0));
+        assert_eq!(256, sum_be_words(&data_one, 1));
+        let data_two = vec![1; 2];
+        assert_eq!(0, sum_be_words(&data_two, 0));
+        assert_eq!(257, sum_be_words(&data_two, 1));
+        let data_three = vec![4; 3];
+        assert_eq!(1024, sum_be_words(&data_three, 0));
+        assert_eq!(1028, sum_be_words(&data_three, 1));
+        assert_eq!(2052, sum_be_words(&data_three, 2));
+        assert_eq!(2052, sum_be_words(&data_three, 3));
     }
 
     #[test]

--- a/pnet_packet/src/util.rs
+++ b/pnet_packet/src/util.rs
@@ -12,7 +12,6 @@ use ip::IpNextHeaderProtocol;
 use pnet_macros_support::types::u16be;
 
 use std::net::{Ipv4Addr, Ipv6Addr};
-use std::slice;
 use std::u8;
 use std::u16;
 use std::convert::TryInto;
@@ -145,7 +144,7 @@ fn ipv6_word_sum(ip: &Ipv6Addr) -> u32 {
 
 /// Sum all words (16 bit chunks) in the given data. The word at word offset
 /// `skipword` will be skipped. Each word is treated as big endian. 
-fn sum_be_words(data: &[u8], mut skipword: usize) -> u32 {
+fn sum_be_words(data: &[u8], skipword: usize) -> u32 {
     if data.len() == 0 { return 0 }
     let len = data.len();
     let mut cur_data = &data[..];


### PR DESCRIPTION
This fixes the panic (#399) that was happening when the memory used in checksum calculations was not 16-bit aligned.  The code no longer uses raw pointers so we don't need any checks for alignment.  I ran the pnet_packet unit tests.