### PR TITLE
Add error message when invalid interface is provided

### DIFF
--- a/examples/packetdump.rs
+++ b/examples/packetdump.rs
@@ -234,7 +234,7 @@ fn main() {
         .into_iter()
         .filter(interface_names_match)
         .next()
-        .unwrap();
+        .unwrap_or_else(|| panic!("No such network interface: {}", iface_name));
 
     // Create a channel to receive on
     let (_, mut rx) = match datalink::channel(&interface, Default::default()) {


### PR DESCRIPTION
In the packetdump example, a generic error message is thrown when the provided interface can't be found in the list of system interfaces:
```
$ cargo run invalid_interface
    Finished dev [unoptimized + debuginfo] target(s) in 0.04s
     Running `/home/trstruth/rust/beacon/target/debug/beacon invalid_interface`
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', src/libcore/option.rs:378:21
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```
This change adds a short error message explaining the panic.