### PR TITLE
Unaligned checksum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,4 @@ pnet_transport = { path = "pnet_transport", version = "0.25.0" }
 pnet_packet = { path = "pnet_packet", version = "0.25.0" }
 
 [dev-dependencies]
-time = ">=0.1"
+time = "=0.1"


### PR DESCRIPTION
Here is an attempt to fix #399 (panic in `pnet_packet::ipv4::checksum` if data is not aligned, which is a pretty common case in pcap files).

I re-implemented a standard sum (skipping the word provided as argument). It *may* be slower, but not much.

Note that unit tests were failing, but it is not related to my changes: the `time` crate did some API-breaking changes. Regarding dependencies, I **strongly** suggest to never use "greater-or-equal" dependencies (`time = ">=0.1"`) to avoid breaking both upgrades and downgrades (see #398 for another example).
I added a commit to fix that as well.