### PR TITLE
Remove #[inline] from function prototype.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,11 @@ environment:
   RUST_TEST_THREADS: 1
   matrix:
   - TARGET: x86_64-pc-windows-msvc
-    RUST_CHANNEL: 1.27.1
+    RUST_CHANNEL: 1.43.0
     WPD_LIB_PATH: "C:/dl/wpdpack/WpdPack/Lib/x64/Packet.lib"
     VCVARS: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\amd64\\vcvars64.bat"
   - TARGET: i686-pc-windows-msvc
-    RUST_CHANNEL: 1.27.1
+    RUST_CHANNEL: 1.43.0
     WPD_LIB_PATH: "C:/dl/wpdpack/WpdPack/Lib/Packet.lib"
     VCVARS: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\vcvars32.bat"
   - TARGET: x86_64-pc-windows-msvc

--- a/pnet_datalink/src/lib.rs
+++ b/pnet_datalink/src/lib.rs
@@ -188,7 +188,6 @@ pub trait DataLinkSender: Send {
     /// mutable packet to manipulate, which will then be sent. This allows packets to be
     /// built in-place, avoiding the copy required for `send`. If there is not sufficient
     /// capacity in the buffer, None will be returned.
-    #[inline]
     fn build_and_send(
         &mut self,
         num_packets: usize,
@@ -201,14 +200,12 @@ pub trait DataLinkSender: Send {
     /// This may require an additional copy compared to `build_and_send`, depending on the
     /// operating system being used. The second parameter is currently ignored, however
     /// `None` should be passed.
-    #[inline]
     fn send_to(&mut self, packet: &[u8], dst: Option<NetworkInterface>) -> Option<io::Result<()>>;
 }
 
 /// Structure for receiving packets at the data link layer. Should be constructed using
 /// `datalink_channel()`.
 pub trait DataLinkReceiver: Send {
-    #[inline]
     /// Get the next ethernet frame in the channel.
     fn next(&mut self) -> io::Result<&[u8]>;
 }


### PR DESCRIPTION
#[inline] for function prototype was ignored.  Newer version of rust compiler emit warnings for the usage.  So this patch simply remove #[inline] for function prototype.