### PR TITLE
Add dyn to trait object.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,11 @@ environment:
   RUST_TEST_THREADS: 1
   matrix:
   - TARGET: x86_64-pc-windows-msvc
-    RUST_CHANNEL: 1.27.1
+    RUST_CHANNEL: 1.43.0
     WPD_LIB_PATH: "C:/dl/wpdpack/WpdPack/Lib/x64/Packet.lib"
     VCVARS: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\amd64\\vcvars64.bat"
   - TARGET: i686-pc-windows-msvc
-    RUST_CHANNEL: 1.27.1
+    RUST_CHANNEL: 1.43.0
     WPD_LIB_PATH: "C:/dl/wpdpack/WpdPack/Lib/Packet.lib"
     VCVARS: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\vcvars32.bat"
   - TARGET: x86_64-pc-windows-msvc

--- a/pnet_datalink/src/bpf.rs
+++ b/pnet_datalink/src/bpf.rs
@@ -248,7 +248,7 @@ impl DataLinkSender for DataLinkSenderImpl {
     fn build_and_send(&mut self,
                       num_packets: usize,
                       packet_size: usize,
-                      func: &mut FnMut(&mut [u8]))
+                      func: &mut dyn FnMut(&mut [u8]))
         -> Option<io::Result<()>> {
         let len = num_packets * packet_size;
         if len >= self.write_buffer.len() {


### PR DESCRIPTION
Edition 2018 rust compiler has dyn keyword for trait object.  It is recommended to specify dyn to trait object.