### PR TITLE
Convert mem::uninitialized() to mem::MaybeUninit.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,11 @@ environment:
   RUST_TEST_THREADS: 1
   matrix:
   - TARGET: x86_64-pc-windows-msvc
-    RUST_CHANNEL: 1.27.1
+    RUST_CHANNEL: 1.43.0
     WPD_LIB_PATH: "C:/dl/wpdpack/WpdPack/Lib/x64/Packet.lib"
     VCVARS: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\amd64\\vcvars64.bat"
   - TARGET: i686-pc-windows-msvc
-    RUST_CHANNEL: 1.27.1
+    RUST_CHANNEL: 1.43.0
     WPD_LIB_PATH: "C:/dl/wpdpack/WpdPack/Lib/Packet.lib"
     VCVARS: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\vcvars32.bat"
   - TARGET: x86_64-pc-windows-msvc

--- a/pnet_datalink/src/unix_interfaces.rs
+++ b/pnet_datalink/src/unix_interfaces.rs
@@ -34,7 +34,7 @@ pub fn interfaces() -> Vec<NetworkInterface> {
 
     let mut ifaces: Vec<NetworkInterface> = Vec::new();
     unsafe {
-        let mut addrs: *mut libc::ifaddrs = mem::uninitialized();
+        let mut addrs: *mut libc::ifaddrs = mem::MaybeUninit::<libc::ifaddrs>::uninit().as_mut_ptr();
         if libc::getifaddrs(&mut addrs) != 0 {
             return ifaces;
         }

--- a/pnet_sys/src/lib.rs
+++ b/pnet_sys/src/lib.rs
@@ -142,7 +142,7 @@ fn ntohs(u: u16) -> u16 {
 }
 
 fn make_in6_addr(segments: [u16; 8]) -> In6Addr {
-    let mut val: In6Addr = unsafe { mem::uninitialized() };
+    let mut val: In6Addr = unsafe { mem::MaybeUninit::<In6Addr>::uninit().assume_init() };
     val.s6_addr = unsafe {
         mem::transmute([htons(segments[0]),
                         htons(segments[1]),


### PR DESCRIPTION
mem:uninitialized is deprecated since 1.39.0.  It is recommended to use mem::MaybeUninit instead.