### PR TITLE
Outdated rustfmt config fix.

### DIFF
--- a/examples/arp_packet.rs
+++ b/examples/arp_packet.rs
@@ -106,4 +106,3 @@ fn main() {
 
     println!("Target MAC address: {}", target_mac);
 }
-

--- a/examples/fanout.rs
+++ b/examples/fanout.rs
@@ -95,7 +95,8 @@ fn main() {
                                 io::stdout(),
                                 "Received packet on thread {:?}",
                                 handle.name()
-                            ).unwrap();
+                            )
+                            .unwrap();
                         }
                         Err(e) => panic!("packetdump: unable to receive packet: {}", e),
                     }

--- a/examples/packetdump.rs
+++ b/examples/packetdump.rs
@@ -249,23 +249,23 @@ fn main() {
         match rx.next() {
             Ok(packet) => {
                 let payload_offset;
-                if cfg!(target_os = "macos") && interface.is_up() && !interface.is_broadcast() 
-                    && ((!interface.is_loopback() && interface.is_point_to_point()) 
-                         || interface.is_loopback())
+                if cfg!(target_os = "macos")
+                    && interface.is_up()
+                    && !interface.is_broadcast()
+                    && ((!interface.is_loopback() && interface.is_point_to_point())
+                        || interface.is_loopback())
                 {
-                    if interface.is_loopback()
-                    {
+                    if interface.is_loopback() {
                         // The pnet code for BPF loopback adds a zero'd out Ethernet header
                         payload_offset = 14;
-                    }
-                    else
-                    {
+                    } else {
                         // Maybe is TUN interface
                         payload_offset = 0;
                     }
-                    if packet.len() > payload_offset
-                    {
-                        let version = Ipv4Packet::new(&packet[payload_offset..]).unwrap().get_version();
+                    if packet.len() > payload_offset {
+                        let version = Ipv4Packet::new(&packet[payload_offset..])
+                            .unwrap()
+                            .get_version();
                         if version == 4 {
                             fake_ethernet_frame.set_destination(MacAddr(0, 0, 0, 0, 0, 0));
                             fake_ethernet_frame.set_source(MacAddr(0, 0, 0, 0, 0, 0));

--- a/pnet_datalink/src/bindings/bpf.rs
+++ b/pnet_datalink/src/bindings/bpf.rs
@@ -86,7 +86,11 @@ pub struct sockaddr_dl {
 }
 
 // See man 4 bpf or /usr/include/net/bpf.h [windows: or Common/Packet32.h]
-#[cfg(any(target_os = "freebsd", all(target_os = "macos", target_pointer_width = "32"), windows))]
+#[cfg(any(
+    target_os = "freebsd",
+    all(target_os = "macos", target_pointer_width = "32"),
+    windows
+))]
 pub struct bpf_hdr {
     pub bh_tstamp: libc::timeval,
     pub bh_caplen: u32,
@@ -99,7 +103,10 @@ pub struct timeval32 {
     pub tv_usec: i32,
 }
 
-#[cfg(any(target_os = "openbsd", all(target_os = "macos", target_pointer_width = "64")))]
+#[cfg(any(
+    target_os = "openbsd",
+    all(target_os = "macos", target_pointer_width = "64")
+))]
 pub struct bpf_hdr {
     pub bh_tstamp: timeval32,
     pub bh_caplen: u32,

--- a/pnet_datalink/src/bindings/mod.rs
+++ b/pnet_datalink/src/bindings/mod.rs
@@ -6,7 +6,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[cfg(any(target_os = "freebsd", target_os = "openbsd", target_os = "macos", windows))]
+#[cfg(any(
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "macos",
+    windows
+))]
 pub mod bpf;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/pnet_datalink/src/bindings/winpcap.rs
+++ b/pnet_datalink/src/bindings/winpcap.rs
@@ -64,7 +64,6 @@ pub type PIP_ADDRESS_STRING = *mut _IP_ADDRESS_STRING;
 pub type IP_MASK_STRING = _IP_ADDRESS_STRING;
 pub type PIP_MASK_STRING = *mut _IP_ADDRESS_STRING;
 
-
 #[repr(C)]
 pub struct _IP_ADDR_STRING {
     pub Next: *mut _IP_ADDR_STRING,
@@ -343,26 +342,29 @@ extern "system" {
 
     // from IPHlpApi.h
     pub fn GetAdaptersInfo(pAdapterInfo: PIP_ADAPTER_INFO, pOutBufLen: PULONG) -> win::DWORD;
-    pub fn GetAdaptersAddresses(Family: ULONG,
-                                Flags: ULONG,
-                                Reserved: PVOID,
-                                AdapterAddresses: PIP_ADAPTER_ADDRESSES,
-                                SizePointer: PULONG)
-        -> win::DWORD;
+    pub fn GetAdaptersAddresses(
+        Family: ULONG,
+        Flags: ULONG,
+        Reserved: PVOID,
+        AdapterAddresses: PIP_ADAPTER_ADDRESSES,
+        SizePointer: PULONG,
+    ) -> win::DWORD;
 }
 
 #[link(name = "Packet")]
 #[allow(improper_ctypes)]
 extern "C" {
     // from Packet32.h
-    pub fn PacketSendPacket(AdapterObject: LPADAPTER,
-                            pPacket: LPPACKET,
-                            Sync: win::BOOLEAN)
-        -> win::BOOLEAN;
-    pub fn PacketReceivePacket(AdapterObject: LPADAPTER,
-                               lpPacket: LPPACKET,
-                               Sync: win::BOOLEAN)
-        -> win::BOOLEAN;
+    pub fn PacketSendPacket(
+        AdapterObject: LPADAPTER,
+        pPacket: LPPACKET,
+        Sync: win::BOOLEAN,
+    ) -> win::BOOLEAN;
+    pub fn PacketReceivePacket(
+        AdapterObject: LPADAPTER,
+        lpPacket: LPPACKET,
+        Sync: win::BOOLEAN,
+    ) -> win::BOOLEAN;
     pub fn PacketAllocatePacket() -> LPPACKET;
     pub fn PacketInitPacket(lpPacket: LPPACKET, Buffer: PVOID, Length: UINT);
     pub fn PacketFreePacket(lpPacket: LPPACKET);

--- a/pnet_datalink/src/bpf.rs
+++ b/pnet_datalink/src/bpf.rs
@@ -10,7 +10,6 @@
 
 extern crate libc;
 
-
 use bindings::bpf;
 use {DataLinkReceiver, DataLinkSender, NetworkInterface};
 
@@ -77,15 +76,15 @@ impl Default for Config {
 /// Create a datalink channel using the /dev/bpf device
 // NOTE buffer must be word aligned.
 #[inline]
-pub fn channel(network_interface: &NetworkInterface,
-               config: Config)
-    -> io::Result<super::Channel> {
+pub fn channel(network_interface: &NetworkInterface, config: Config) -> io::Result<super::Channel> {
     #[cfg(target_os = "freebsd")]
     fn get_fd(_attempts: usize) -> libc::c_int {
         unsafe {
-            libc::open(CString::new(&b"/dev/bpf"[..]).unwrap().as_ptr(),
-                       libc::O_RDWR,
-                       0)
+            libc::open(
+                CString::new(&b"/dev/bpf"[..]).unwrap().as_ptr(),
+                libc::O_RDWR,
+                0,
+            )
         }
     }
 
@@ -94,9 +93,11 @@ pub fn channel(network_interface: &NetworkInterface,
         for i in 0..attempts {
             let fd = unsafe {
                 let file_name = format!("/dev/bpf{}", i);
-                libc::open(CString::new(file_name.as_bytes()).unwrap().as_ptr(),
-                           libc::O_RDWR,
-                           0)
+                libc::open(
+                    CString::new(file_name.as_bytes()).unwrap().as_ptr(),
+                    libc::O_RDWR,
+                    0,
+                )
             };
             if fd != -1 {
                 return fd;
@@ -212,7 +213,9 @@ pub fn channel(network_interface: &NetworkInterface,
         fd_set: unsafe { mem::zeroed() },
         write_buffer: vec![0; config.write_buffer_size],
         loopback: loopback,
-        timeout: config.write_timeout.map(|to| pnet_sys::duration_to_timespec(to)),
+        timeout: config
+            .write_timeout
+            .map(|to| pnet_sys::duration_to_timespec(to)),
     });
     unsafe {
         libc::FD_ZERO(&mut sender.fd_set as *mut libc::fd_set);
@@ -223,7 +226,9 @@ pub fn channel(network_interface: &NetworkInterface,
         fd_set: unsafe { mem::zeroed() },
         read_buffer: vec![0; allocated_read_buffer_size],
         loopback: loopback,
-        timeout: config.read_timeout.map(|to| pnet_sys::duration_to_timespec(to)),
+        timeout: config
+            .read_timeout
+            .map(|to| pnet_sys::duration_to_timespec(to)),
         // Enough room for minimally sized packets without reallocating
         packets: VecDeque::with_capacity(allocated_read_buffer_size / 64),
     });
@@ -245,31 +250,38 @@ struct DataLinkSenderImpl {
 
 impl DataLinkSender for DataLinkSenderImpl {
     #[inline]
-    fn build_and_send(&mut self,
-                      num_packets: usize,
-                      packet_size: usize,
-                      func: &mut dyn FnMut(&mut [u8]))
-        -> Option<io::Result<()>> {
+    fn build_and_send(
+        &mut self,
+        num_packets: usize,
+        packet_size: usize,
+        func: &mut dyn FnMut(&mut [u8]),
+    ) -> Option<io::Result<()>> {
         let len = num_packets * packet_size;
         if len >= self.write_buffer.len() {
             None
         } else {
             // If we're sending on the loopback device, discard the ethernet header.
             // The OS will prepend the packet with 4 bytes set to AF_INET.
-            let offset = if self.loopback { ETHERNET_HEADER_SIZE } else { 0 };
+            let offset = if self.loopback {
+                ETHERNET_HEADER_SIZE
+            } else {
+                0
+            };
             for chunk in self.write_buffer[..len].chunks_mut(packet_size) {
                 func(chunk);
                 let ret = unsafe {
                     libc::FD_SET(self.fd.fd, &mut self.fd_set as *mut libc::fd_set);
-                    libc::pselect(self.fd.fd + 1,
-                                  ptr::null_mut(),
-                                  &mut self.fd_set as *mut libc::fd_set,
-                                  ptr::null_mut(),
-                                  self.timeout
-                                      .as_ref()
-                                      .map(|to| to as *const libc::timespec)
-                                      .unwrap_or(ptr::null()),
-                                  ptr::null())
+                    libc::pselect(
+                        self.fd.fd + 1,
+                        ptr::null_mut(),
+                        &mut self.fd_set as *mut libc::fd_set,
+                        ptr::null_mut(),
+                        self.timeout
+                            .as_ref()
+                            .map(|to| to as *const libc::timespec)
+                            .unwrap_or(ptr::null()),
+                        ptr::null(),
+                    )
                 };
                 if ret == -1 {
                     // Error occured!
@@ -278,9 +290,11 @@ impl DataLinkSender for DataLinkSenderImpl {
                     return Some(Err(io::Error::new(io::ErrorKind::TimedOut, "Timed out")));
                 } else {
                     match unsafe {
-                        libc::write(self.fd.fd,
-                                    chunk.as_ptr().offset(offset as isize) as *const libc::c_void,
-                                    (chunk.len() - offset) as libc::size_t)
+                        libc::write(
+                            self.fd.fd,
+                            chunk.as_ptr().offset(offset as isize) as *const libc::c_void,
+                            (chunk.len() - offset) as libc::size_t,
+                        )
                     } {
                         len if len == -1 => return Some(Err(io::Error::last_os_error())),
                         _ => (),
@@ -292,24 +306,27 @@ impl DataLinkSender for DataLinkSenderImpl {
     }
 
     #[inline]
-    fn send_to(&mut self,
-               packet: &[u8],
-               _dst: Option<NetworkInterface>)
-        -> Option<io::Result<()>> {
+    fn send_to(&mut self, packet: &[u8], _dst: Option<NetworkInterface>) -> Option<io::Result<()>> {
         // If we're sending on the loopback device, discard the ethernet header.
         // The OS will prepend the packet with 4 bytes set to AF_INET.
-        let offset = if self.loopback { ETHERNET_HEADER_SIZE } else { 0 };
+        let offset = if self.loopback {
+            ETHERNET_HEADER_SIZE
+        } else {
+            0
+        };
         let ret = unsafe {
             libc::FD_SET(self.fd.fd, &mut self.fd_set as *mut libc::fd_set);
-            libc::pselect(self.fd.fd + 1,
-                          ptr::null_mut(),
-                          &mut self.fd_set as *mut libc::fd_set,
-                          ptr::null_mut(),
-                          self.timeout
-                              .as_ref()
-                              .map(|to| to as *const libc::timespec)
-                              .unwrap_or(ptr::null()),
-                          ptr::null())
+            libc::pselect(
+                self.fd.fd + 1,
+                ptr::null_mut(),
+                &mut self.fd_set as *mut libc::fd_set,
+                ptr::null_mut(),
+                self.timeout
+                    .as_ref()
+                    .map(|to| to as *const libc::timespec)
+                    .unwrap_or(ptr::null()),
+                ptr::null(),
+            )
         };
         if ret == -1 {
             // Error occured!
@@ -318,9 +335,11 @@ impl DataLinkSender for DataLinkSenderImpl {
             return Some(Err(io::Error::new(io::ErrorKind::TimedOut, "Timed out")));
         } else {
             match unsafe {
-                libc::write(self.fd.fd,
-                            packet.as_ptr().offset(offset as isize) as *const libc::c_void,
-                            (packet.len() - offset) as libc::size_t)
+                libc::write(
+                    self.fd.fd,
+                    packet.as_ptr().offset(offset as isize) as *const libc::c_void,
+                    (packet.len() - offset) as libc::size_t,
+                )
             } {
                 len if len == -1 => Some(Err(io::Error::last_os_error())),
                 _ => Some(Ok(())),
@@ -351,16 +370,17 @@ impl DataLinkReceiver for DataLinkReceiverImpl {
             let buffer = &mut self.read_buffer[buffer_offset..];
             let ret = unsafe {
                 libc::FD_SET(self.fd.fd, &mut self.fd_set as *mut libc::fd_set);
-                libc::pselect(self.fd.fd + 1,
-                              &mut self.fd_set as *mut libc::fd_set,
-                              ptr::null_mut(),
-                              ptr::null_mut(),
-                              self
-                                  .timeout
-                                  .as_ref()
-                                  .map(|to| to as *const libc::timespec)
-                                  .unwrap_or(ptr::null()),
-                              ptr::null())
+                libc::pselect(
+                    self.fd.fd + 1,
+                    &mut self.fd_set as *mut libc::fd_set,
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                    self.timeout
+                        .as_ref()
+                        .map(|to| to as *const libc::timespec)
+                        .unwrap_or(ptr::null()),
+                    ptr::null(),
+                )
             };
             if ret == -1 {
                 return Err(io::Error::last_os_error());
@@ -368,9 +388,11 @@ impl DataLinkReceiver for DataLinkReceiverImpl {
                 return Err(io::Error::new(io::ErrorKind::TimedOut, "Timed out"));
             } else {
                 let buflen = match unsafe {
-                    libc::read(self.fd.fd,
-                               buffer.as_ptr() as *mut libc::c_void,
-                               buffer.len() as libc::size_t)
+                    libc::read(
+                        self.fd.fd,
+                        buffer.as_ptr() as *mut libc::c_void,
+                        buffer.len() as libc::size_t,
+                    )
                 } {
                     len if len > 0 => len,
                     _ => return Err(io::Error::last_os_error()),
@@ -380,10 +402,12 @@ impl DataLinkReceiver for DataLinkReceiverImpl {
                 while (ptr as *const u8) < end {
                     unsafe {
                         let packet: *const bpf::bpf_hdr = mem::transmute(ptr);
-                        let start = ptr as isize + (*packet).bh_hdrlen as isize -
-                                    buffer.as_ptr() as isize;
-                        self.packets.push_back((start as usize + header_size,
-                                                (*packet).bh_caplen as usize - header_size));
+                        let start =
+                            ptr as isize + (*packet).bh_hdrlen as isize - buffer.as_ptr() as isize;
+                        self.packets.push_back((
+                            start as usize + header_size,
+                            (*packet).bh_caplen as usize - header_size,
+                        ));
                         let offset = (*packet).bh_hdrlen as isize + (*packet).bh_caplen as isize;
                         ptr = ptr.offset(bpf::BPF_WORDALIGN(offset));
                     }

--- a/pnet_datalink/src/dummy.rs
+++ b/pnet_datalink/src/dummy.rs
@@ -86,26 +86,28 @@ impl Default for Config {
 /// Create a data link channel backed by FIFO queues. Useful for debugging and testing.
 /// See `Config` for how to inject and read packets on this fake network.
 pub fn channel(_: &NetworkInterface, config: Config) -> io::Result<super::Channel> {
-    let sender = Box::new(MockDataLinkSender { sender: config.sender });
+    let sender = Box::new(MockDataLinkSender {
+        sender: config.sender,
+    });
     let receiver = Box::new(MockDataLinkReceiver {
         receiver: config.receiver,
-        used_packets: Vec::new()
+        used_packets: Vec::new(),
     });
 
     Ok(super::Channel::Ethernet(sender, receiver))
 }
-
 
 struct MockDataLinkSender {
     sender: Sender<Box<[u8]>>,
 }
 
 impl DataLinkSender for MockDataLinkSender {
-    fn build_and_send(&mut self,
-                      num_packets: usize,
-                      packet_size: usize,
-                      func: &mut dyn FnMut(&mut [u8]))
-        -> Option<io::Result<()>> {
+    fn build_and_send(
+        &mut self,
+        num_packets: usize,
+        packet_size: usize,
+        func: &mut dyn FnMut(&mut [u8]),
+    ) -> Option<io::Result<()>> {
         for _ in 0..num_packets {
             let mut buffer = vec![0; packet_size];
             func(&mut buffer);
@@ -115,10 +117,7 @@ impl DataLinkSender for MockDataLinkSender {
         Some(Ok(()))
     }
 
-    fn send_to(&mut self,
-               packet: &[u8],
-               _dst: Option<NetworkInterface>)
-        -> Option<io::Result<()>> {
+    fn send_to(&mut self, packet: &[u8], _dst: Option<NetworkInterface>) -> Option<io::Result<()>> {
         let buffer = packet.to_vec();
         self.sender.send(buffer.into_boxed_slice()).unwrap_or(());
         Some(Ok(()))
@@ -205,7 +204,9 @@ mod tests {
             pkg[19] = 201;
         };
         tx.build_and_send(1, 20, &mut builder).unwrap().unwrap();
-        let pkg = read_handle.try_recv().expect("Expected one packet to be sent");
+        let pkg = read_handle
+            .try_recv()
+            .expect("Expected one packet to be sent");
         assert!(read_handle.try_recv().is_err());
         assert_eq!(pkg.len(), 20);
         assert_eq!(pkg[0], 9);
@@ -237,7 +238,9 @@ mod tests {
         buffer[18] = 76;
 
         tx.send_to(&buffer, None).unwrap().unwrap();
-        let pkg = read_handle.try_recv().expect("Expected one packet to be sent");
+        let pkg = read_handle
+            .try_recv()
+            .expect("Expected one packet to be sent");
         assert!(read_handle.try_recv().is_err());
         assert_eq!(pkg.len(), 20);
         assert_eq!(pkg[1], 34);
@@ -294,11 +297,12 @@ mod tests {
         }
     }
 
-    fn create_net()
-        -> (Sender<io::Result<Box<[u8]>>>,
-            Receiver<Box<[u8]>>,
-            Box<DataLinkSender>,
-            Box<DataLinkReceiver>) {
+    fn create_net() -> (
+        Sender<io::Result<Box<[u8]>>>,
+        Receiver<Box<[u8]>>,
+        Box<DataLinkSender>,
+        Box<DataLinkReceiver>,
+    ) {
         let interface = super::dummy_interface(56);
         let mut config = super::Config::default();
         let inject_handle = config.inject_handle().unwrap();

--- a/pnet_datalink/src/lib.rs
+++ b/pnet_datalink/src/lib.rs
@@ -30,24 +30,20 @@ mod backend;
 #[cfg(windows)]
 pub mod winpcap;
 
-#[cfg(all(not(feature = "netmap"),
-          any(target_os = "linux",
-              target_os = "android"
-             )
-         )
-      )]
+#[cfg(all(
+    not(feature = "netmap"),
+    any(target_os = "linux", target_os = "android")
+))]
 #[path = "linux.rs"]
 mod backend;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub mod linux;
 
-#[cfg(all(not(feature = "netmap"),
-          any(target_os = "freebsd",
-              target_os = "openbsd",
-              target_os = "macos")
-             )
-     )]
+#[cfg(all(
+    not(feature = "netmap"),
+    any(target_os = "freebsd", target_os = "openbsd", target_os = "macos")
+))]
 #[path = "bpf.rs"]
 mod backend;
 
@@ -230,7 +226,7 @@ impl NetworkInterface {
     pub fn mac_address(&self) -> MacAddr {
         self.mac.unwrap()
     }
-    
+
     pub fn is_up(&self) -> bool {
         self.flags & (pnet_sys::IFF_UP as u32) != 0
     }
@@ -265,7 +261,7 @@ impl ::std::fmt::Display for NetworkInterface {
                 "{:X}<{}>",
                 self.flags,
                 rets.iter()
-                    .zip(FLAGS.iter()) 
+                    .zip(FLAGS.iter())
                     .filter(|&(ret, _)| ret == &true)
                     .map(|(_, name)| name.to_string())
                     .collect::<Vec<String>>()
@@ -275,7 +271,8 @@ impl ::std::fmt::Display for NetworkInterface {
             format!("{:X}", self.flags)
         };
 
-        let mac = self.mac
+        let mac = self
+            .mac
             .map(|mac| mac.to_string())
             .unwrap_or("N/A".to_owned());
         let ips = if self.ips.len() > 0 {

--- a/pnet_datalink/src/winpcap.rs
+++ b/pnet_datalink/src/winpcap.rs
@@ -79,9 +79,7 @@ impl Default for Config {
 
 /// Create a datalink channel using the WinPcap library.
 #[inline]
-pub fn channel(network_interface: &NetworkInterface,
-               config: Config)
-    -> io::Result<super::Channel> {
+pub fn channel(network_interface: &NetworkInterface, config: Config) -> io::Result<super::Channel> {
     let mut read_buffer = Vec::new();
     read_buffer.resize(config.read_buffer_size, 0u8);
 
@@ -122,9 +120,11 @@ pub fn channel(network_interface: &NetworkInterface,
     }
 
     unsafe {
-        winpcap::PacketInitPacket(read_packet,
-                                  read_buffer.as_mut_ptr() as winpcap::PVOID,
-                                  config.read_buffer_size as winpcap::UINT)
+        winpcap::PacketInitPacket(
+            read_packet,
+            read_buffer.as_mut_ptr() as winpcap::PVOID,
+            config.read_buffer_size as winpcap::UINT,
+        )
     }
 
     let write_packet = unsafe { winpcap::PacketAllocatePacket() };
@@ -137,21 +137,27 @@ pub fn channel(network_interface: &NetworkInterface,
     }
 
     unsafe {
-        winpcap::PacketInitPacket(write_packet,
-                                  write_buffer.as_mut_ptr() as winpcap::PVOID,
-                                  config.write_buffer_size as winpcap::UINT)
+        winpcap::PacketInitPacket(
+            write_packet,
+            write_buffer.as_mut_ptr() as winpcap::PVOID,
+            config.write_buffer_size as winpcap::UINT,
+        )
     }
 
     let adapter = Arc::new(WinPcapAdapter { adapter: adapter });
     let sender = Box::new(DataLinkSenderImpl {
         adapter: adapter.clone(),
         _write_buffer: write_buffer,
-        packet: WinPcapPacket { packet: write_packet },
+        packet: WinPcapPacket {
+            packet: write_packet,
+        },
     });
     let receiver = Box::new(DataLinkReceiverImpl {
         adapter: adapter,
         _read_buffer: read_buffer,
-        packet: WinPcapPacket { packet: read_packet },
+        packet: WinPcapPacket {
+            packet: read_packet,
+        },
         // Enough room for minimally sized packets without reallocating
         packets: VecDeque::with_capacity(unsafe { (*read_packet).Length } as usize / 64),
     });
@@ -166,11 +172,12 @@ struct DataLinkSenderImpl {
 
 impl DataLinkSender for DataLinkSenderImpl {
     #[inline]
-    fn build_and_send(&mut self,
-                      num_packets: usize,
-                      packet_size: usize,
-                      func: &mut FnMut(&mut [u8]))
-        -> Option<io::Result<()>> {
+    fn build_and_send(
+        &mut self,
+        num_packets: usize,
+        packet_size: usize,
+        func: &mut FnMut(&mut [u8]),
+    ) -> Option<io::Result<()>> {
         let len = num_packets * packet_size;
         if len >= unsafe { (*self.packet.packet).Length } as usize {
             None
@@ -204,15 +211,10 @@ impl DataLinkSender for DataLinkSenderImpl {
     }
 
     #[inline]
-    fn send_to(&mut self,
-               packet: &[u8],
-               _dst: Option<NetworkInterface>)
-        -> Option<io::Result<()>> {
-        self.build_and_send(1,
-                            packet.len(),
-                            &mut |eh: &mut [u8]| {
-                                eh.copy_from_slice(packet);
-                            })
+    fn send_to(&mut self, packet: &[u8], _dst: Option<NetworkInterface>) -> Option<io::Result<()>> {
+        self.build_and_send(1, packet.len(), &mut |eh: &mut [u8]| {
+            eh.copy_from_slice(packet);
+        })
     }
 }
 
@@ -245,9 +247,10 @@ impl DataLinkReceiver for DataLinkReceiverImpl {
             while ptr < end {
                 unsafe {
                     let packet: *const bpf::bpf_hdr = mem::transmute(ptr);
-                    let start = ptr as isize + (*packet).bh_hdrlen as isize -
-                                (*self.packet.packet).Buffer as isize;
-                    self.packets.push_back((start as usize, (*packet).bh_caplen as usize));
+                    let start = ptr as isize + (*packet).bh_hdrlen as isize
+                        - (*self.packet.packet).Buffer as isize;
+                    self.packets
+                        .push_back((start as usize, (*packet).bh_caplen as usize));
                     let offset = (*packet).bh_hdrlen as isize + (*packet).bh_caplen as isize;
                     ptr = ptr.offset(bpf::BPF_WORDALIGN(offset));
                 }
@@ -291,12 +294,14 @@ pub fn interfaces() -> Vec<NetworkInterface> {
     let mut all_ifaces = Vec::with_capacity(vec_size as usize);
     while !cursor.is_null() {
         let mac = unsafe {
-            MacAddr((*cursor).Address[0],
-                    (*cursor).Address[1],
-                    (*cursor).Address[2],
-                    (*cursor).Address[3],
-                    (*cursor).Address[4],
-                    (*cursor).Address[5])
+            MacAddr(
+                (*cursor).Address[0],
+                (*cursor).Address[1],
+                (*cursor).Address[2],
+                (*cursor).Address[3],
+                (*cursor).Address[4],
+                (*cursor).Address[5],
+            )
         };
         let mut ip_cursor = unsafe { &mut (*cursor).IpAddressList as winpcap::PIP_ADDR_STRING };
         let mut ips = Vec::new();
@@ -334,11 +339,11 @@ pub fn interfaces() -> Vec<NetworkInterface> {
 
         // Second call should now work with the correct buffer size. If not, this may be
         // due to some privilege or other unforseen issue.
-        if unsafe { winpcap::PacketGetAdapterNames(buf.as_mut_ptr() as *mut i8, &mut buflen) } == 0 {
+        if unsafe { winpcap::PacketGetAdapterNames(buf.as_mut_ptr() as *mut i8, &mut buflen) } == 0
+        {
             panic!("Unable to get interface list despite increasing buffer size");
         }
     }
-
 
     let buf_str = unsafe { from_utf8_unchecked(&buf) };
     let iface_names = buf_str.split("\0\0").next();
@@ -349,7 +354,10 @@ pub fn interfaces() -> Vec<NetworkInterface> {
         Some(iface_names) => {
             for iface in iface_names.split('\0') {
                 let name = iface.to_owned();
-                let next = all_ifaces.iter().filter(|x| name[..].ends_with(&x.name[..])).next();
+                let next = all_ifaces
+                    .iter()
+                    .filter(|x| name[..].ends_with(&x.name[..]))
+                    .next();
                 if next.is_some() {
                     let mut iface = next.unwrap().clone();
                     iface.name = name;

--- a/pnet_macros/src/decorator.rs
+++ b/pnet_macros/src/decorator.rs
@@ -9,8 +9,8 @@
 //! Implements the #[packet] decorator.
 
 use regex::Regex;
-use std::rc::Rc;
 use std::env;
+use std::rc::Rc;
 
 use syntax::ast;
 use syntax::codemap::Span;
@@ -22,7 +22,7 @@ use syntax::ptr::P;
 use syntax::tokenstream::Delimited;
 use syntax::tokenstream::TokenTree::{self, Sequence, Token};
 
-use util::{Endianness, GetOperation, SetOperation, operations, to_little_endian, to_mutator};
+use util::{operations, to_little_endian, to_mutator, Endianness, GetOperation, SetOperation};
 
 /// Lower and upper bounds of a payload.
 /// Represented as strings since they may involve functions.
@@ -75,8 +75,10 @@ fn make_type(ty_str: String, endianness_important: bool) -> Result<Type, String>
             Err("endianness must be specified for types of size >= 8".to_owned())
         }
     } else if ty_str.starts_with("Vec<") {
-        let ty = make_type(String::from(&ty_str[4..ty_str.len() - 1]),
-                           endianness_important);
+        let ty = make_type(
+            String::from(&ty_str[4..ty_str.len() - 1]),
+            endianness_important,
+        );
         match ty {
             Ok(ty) => Ok(Type::Vector(Box::new(ty))),
             Err(e) => Err(e),
@@ -94,11 +96,12 @@ fn multiple_payload_error(ecx: &mut ExtCtxt, field_span: Span, payload_span: Spa
         .emit();
 }
 
-fn make_packet(ecx: &mut ExtCtxt,
-               span: Span,
-               name: String,
-               vd: &ast::VariantData)
-    -> Option<Packet> {
+fn make_packet(
+    ecx: &mut ExtCtxt,
+    span: Span,
+    name: String,
+    vd: &ast::VariantData,
+) -> Option<Packet> {
     let mut payload_span = None;
     let mut fields = Vec::new();
 
@@ -150,8 +153,10 @@ fn make_packet(ecx: &mut ExtCtxt,
                     seen.push(s.to_owned());
                     if &s[..] == "construct_with" {
                         if items.iter().len() == 0 {
-                            ecx.span_err(field.span,
-                                         "#[construct_with] must have at least one argument");
+                            ecx.span_err(
+                                field.span,
+                                "#[construct_with] must have at least one argument",
+                            );
                             return None;
                         }
                         for ty in items.iter() {
@@ -164,9 +169,11 @@ fn make_packet(ecx: &mut ExtCtxt,
                                     }
                                 }
                             } else {
-                                ecx.span_err(field.span,
-                                             "#[construct_with] should be of the form \
-                                              #[construct_with(<types>)]");
+                                ecx.span_err(
+                                    field.span,
+                                    "#[construct_with] should be of the form \
+                                              #[construct_with(<types>)]",
+                                );
                                 return None;
                             }
                         }
@@ -183,22 +190,27 @@ fn make_packet(ecx: &mut ExtCtxt,
                             if let ast::LitKind::Str(ref s, _) = *node {
                                 packet_length = Some(s.to_string() + "(&_self.to_immutable())");
                             } else {
-                                ecx.span_err(field.span,
-                                             "#[length_fn] should be used as #[length_fn = \
-                                              \"name_of_function\"]");
+                                ecx.span_err(
+                                    field.span,
+                                    "#[length_fn] should be used as #[length_fn = \
+                                              \"name_of_function\"]",
+                                );
                                 return None;
                             }
                         }
                         "length" => {
                             let node = &lit.node;
                             if let ast::LitKind::Str(ref s, _) = *node {
-                                let field_names: Vec<String> = sfields.iter()
+                                let field_names: Vec<String> = sfields
+                                    .iter()
                                     .filter_map(|field| {
-                                        field.ident
-                                            .map(|name| name.to_string())
-                                            .and_then(|name| {
-                                                if name == field_name { None } else { Some(name) }
-                                            })
+                                        field.ident.map(|name| name.to_string()).and_then(|name| {
+                                            if name == field_name {
+                                                None
+                                            } else {
+                                                Some(name)
+                                            }
+                                        })
                                     })
                                     .collect();
                                 let tt_tokens = ecx.parse_tts(s.to_string());
@@ -207,9 +219,11 @@ fn make_packet(ecx: &mut ExtCtxt,
                                 let parsed = tts_to_string(&tokens_packet[..]);
                                 packet_length = Some(parsed);
                             } else {
-                                ecx.span_err(field.span,
-                                             "#[length] should be used as #[length = \
-                                              \"field_name and/or arithmetic expression\"]");
+                                ecx.span_err(
+                                    field.span,
+                                    "#[length] should be used as #[length = \
+                                              \"field_name and/or arithmetic expression\"]",
+                                );
                                 return None;
                             }
                         }
@@ -240,16 +254,20 @@ fn make_packet(ecx: &mut ExtCtxt,
             Type::Vector(_) => {
                 struct_length = Some(format!("_packet.{}.len()", field_name).to_owned());
                 if !is_payload && packet_length.is_none() {
-                    ecx.span_err(field.span,
-                                 "variable length field must have #[length = \"\"] or \
-                                  #[length_fn = \"\"] attribute");
+                    ecx.span_err(
+                        field.span,
+                        "variable length field must have #[length = \"\"] or \
+                                  #[length_fn = \"\"] attribute",
+                    );
                     return None;
                 }
             }
             Type::Misc(_) => {
                 if construct_with.is_empty() {
-                    ecx.span_err(field.span,
-                                 "non-primitive field types must specify #[construct_with]");
+                    ecx.span_err(
+                        field.span,
+                        "non-primitive field types must specify #[construct_with]",
+                    );
                     return None;
                 }
             }
@@ -276,7 +294,6 @@ fn make_packet(ecx: &mut ExtCtxt,
         base_name: name,
         fields: fields,
     })
-
 }
 
 fn make_packets(ecx: &mut ExtCtxt, span: Span, item: &Annotatable) -> Option<Vec<Packet>> {
@@ -330,10 +347,11 @@ fn make_packets(ecx: &mut ExtCtxt, span: Span, item: &Annotatable) -> Option<Vec
 }
 
 /// Return the processed length expression for a packet.
-fn parse_length_expr(ecx: &mut ExtCtxt,
-                     tts: &[TokenTree],
-                     field_names: &[String])
-    -> Vec<TokenTree> {
+fn parse_length_expr(
+    ecx: &mut ExtCtxt,
+    tts: &[TokenTree],
+    field_names: &[String],
+) -> Vec<TokenTree> {
     let error_msg = "Only field names, constants, integers, basic arithmetic expressions \
                      (+ - * / %) and parentheses are allowed in the \"length\" attribute";
     let mut needs_constant: Option<Span> = None;
@@ -346,7 +364,7 @@ fn parse_length_expr(ecx: &mut ExtCtxt,
                         let mut modified_packet_tokens =
                             ecx.parse_tts(format!("_self.get_{}() as usize", name).to_owned());
                         acc_packet.append(&mut modified_packet_tokens);
-                    } else  {
+                    } else {
                         if let None = needs_constant {
                             needs_constant = Some(span);
                         }
@@ -399,14 +417,15 @@ fn parse_length_expr(ecx: &mut ExtCtxt,
 
     if let Some(span) = needs_constant {
         if !has_constant {
-            ecx.span_err(span,
-                         "Field name must be a member of the struct and not the field itself");
+            ecx.span_err(
+                span,
+                "Field name must be a member of the struct and not the field itself",
+            );
         }
     }
 
     tokens_packet
 }
-
 
 struct GenContext<'a, 'b: 'a, 'c> {
     ecx: &'a mut ExtCtxt<'b>,
@@ -419,11 +438,13 @@ impl<'a, 'b, 'c> GenContext<'a, 'b, 'c> {
     }
 }
 
-pub fn generate_packet(ecx: &mut ExtCtxt,
-                       span: Span,
-                       _meta_item: &ast::MetaItem,
-                       item: &Annotatable,
-                       push: &mut dyn FnMut(Annotatable)) {
+pub fn generate_packet(
+    ecx: &mut ExtCtxt,
+    span: Span,
+    _meta_item: &ast::MetaItem,
+    item: &Annotatable,
+    push: &mut dyn FnMut(Annotatable),
+) {
     if let Some(packets) = make_packets(ecx, span, item) {
         let mut cx = GenContext {
             ecx: ecx,
@@ -446,26 +467,34 @@ pub fn generate_packet(ecx: &mut ExtCtxt,
 }
 
 fn generate_packet_structs(cx: &mut GenContext, packet: &Packet) {
-    for (name, mutable) in vec![(packet.packet_name(), ""), (packet.packet_name_mut(), "Mut")] {
-        cx.push_item_from_string(format!("
+    for (name, mutable) in vec![
+        (packet.packet_name(), ""),
+        (packet.packet_name_mut(), "Mut"),
+    ] {
+        cx.push_item_from_string(format!(
+            "
             #[derive(PartialEq)]
             /// A structure enabling manipulation of on the wire packets
             pub struct {}<'p> {{
                 packet: ::pnet_macros_support::packet::{}PacketData<'p>,
-            }}", name, mutable));
+            }}",
+            name, mutable
+        ));
     }
 }
 
-fn handle_misc_field(cx: &mut GenContext,
-                     error: &mut bool,
-                     field: &Field,
-                     bit_offset: &mut usize,
-                     offset_fns: &[String],
-                     co: &mut String,
-                     name: &str,
-                     mutators: &mut String,
-                     accessors: &mut String,
-                     ty_str: &str) {
+fn handle_misc_field(
+    cx: &mut GenContext,
+    error: &mut bool,
+    field: &Field,
+    bit_offset: &mut usize,
+    offset_fns: &[String],
+    co: &mut String,
+    name: &str,
+    mutators: &mut String,
+    accessors: &mut String,
+    ty_str: &str,
+) {
     let mut inner_accessors = String::new();
     let mut inner_mutators = String::new();
     let mut get_args = String::new();
@@ -489,32 +518,37 @@ fn handle_misc_field(cx: &mut GenContext,
             }
 
             let arg_name = format!("arg{}", i);
-            inner_accessors =
-                inner_accessors +
-                &generate_accessor_str(&arg_name[..],
-                                       &ty_str[..],
-                                       &co[..],
-                                       &ops[..],
-                                       Some(&name[..]))[..];
-            inner_mutators =
-                inner_mutators +
-                &generate_mutator_str(&arg_name[..],
-                                      &ty_str[..],
-                                      &co[..],
-                                      &to_mutator(&ops[..])[..],
-                                      Some(&name[..]))[..];
+            inner_accessors = inner_accessors
+                + &generate_accessor_str(
+                    &arg_name[..],
+                    &ty_str[..],
+                    &co[..],
+                    &ops[..],
+                    Some(&name[..]),
+                )[..];
+            inner_mutators = inner_mutators
+                + &generate_mutator_str(
+                    &arg_name[..],
+                    &ty_str[..],
+                    &co[..],
+                    &to_mutator(&ops[..])[..],
+                    Some(&name[..]),
+                )[..];
             get_args = format!("{}get_{}(&self), ", get_args, arg_name);
             set_args = format!("{}set_{}(_self, vals.{});\n", set_args, arg_name, i);
             *bit_offset += size;
             // Current offset needs to be recalculated for each arg
             *co = current_offset(*bit_offset, offset_fns);
         } else {
-            cx.ecx.span_err(field.span,
-                            "arguments to #[construct_with] must be primitives");
+            cx.ecx.span_err(
+                field.span,
+                "arguments to #[construct_with] must be primitives",
+            );
             *error = true;
         }
     }
-    *mutators = format!("{mutators}
+    *mutators = format!(
+        "{mutators}
                     /// Set the value of the {name} field.
                     #[inline]
                     #[allow(trivial_numeric_casts)]
@@ -529,23 +563,28 @@ fn handle_misc_field(cx: &mut GenContext,
                         {set_args}
                     }}
                     ",
-                        mutators = &mutators[..],
-                        name = field.name,
-                        ty_str = ty_str,
-                        inner_mutators = inner_mutators,
-                        set_args = set_args);
+        mutators = &mutators[..],
+        name = field.name,
+        ty_str = ty_str,
+        inner_mutators = inner_mutators,
+        set_args = set_args
+    );
     let ctor = if field.construct_with.is_some() {
-        format!("{} {}::new({})",
-                inner_accessors,
-                ty_str,
-                &get_args[..get_args.len() - 2])
+        format!(
+            "{} {}::new({})",
+            inner_accessors,
+            ty_str,
+            &get_args[..get_args.len() - 2]
+        )
     } else {
-        format!("let current_offset = {};
+        format!(
+            "let current_offset = {};
                  {}::new(&_self.packet[current_offset..])",
-                co,
-                ty_str)
+            co, ty_str
+        )
     };
-    *accessors = format!("{accessors}
+    *accessors = format!(
+        "{accessors}
                         /// Get the value of the {name} field
                         #[inline]
                         #[allow(trivial_numeric_casts)]
@@ -554,21 +593,23 @@ fn handle_misc_field(cx: &mut GenContext,
                             {ctor}
                         }}
                         ",
-                         accessors = accessors,
-                         name = field.name,
-                         ty_str = ty_str,
-                         ctor = ctor);
-
+        accessors = accessors,
+        name = field.name,
+        ty_str = ty_str,
+        ctor = ctor
+    );
 }
 
-fn handle_vec_primitive(cx: &mut GenContext,
-                        error: &mut bool,
-                        inner_ty_str: &str,
-                        size: usize,
-                        field: &Field,
-                        accessors: &mut String,
-                        mutators: &mut String,
-                        co: &mut String) {
+fn handle_vec_primitive(
+    cx: &mut GenContext,
+    error: &mut bool,
+    inner_ty_str: &str,
+    size: usize,
+    field: &Field,
+    accessors: &mut String,
+    mutators: &mut String,
+    co: &mut String,
+) {
     if inner_ty_str == "u8" || (size % 8) == 0 {
         let ops = operations(0, size).unwrap();
         if !field.is_payload {
@@ -606,9 +647,11 @@ fn handle_vec_primitive(cx: &mut GenContext,
                                  size = size / 8);
         }
         let check_len = if field.packet_length.is_some() {
-            format!("let len = {packet_length};
+            format!(
+                "let len = {packet_length};
                                              assert!(vals.len() <= len);",
-                    packet_length = field.packet_length.as_ref().unwrap())
+                packet_length = field.packet_length.as_ref().unwrap()
+            )
         } else {
             String::new()
         };
@@ -626,18 +669,21 @@ fn handle_vec_primitive(cx: &mut GenContext,
         } else {
             // e.g. Vec<u16> -> Vec<u8>
             let sop_strings = generate_sop_strings(&to_mutator(&ops));
-            format!("
+            format!(
+                "
                                 let mut co = current_offset;
                                 for i in 0..vals.len() {{
                                     let val = vals[i];
                                     {sop}
                                     co += {size};
                                 }}",
-                    sop = sop_strings,
-                    size = size / 8)
+                sop = sop_strings,
+                size = size / 8
+            )
         };
 
-        *mutators = format!("{mutators}
+        *mutators = format!(
+            "{mutators}
                                 /// Set the value of the {name} field (copies contents)
                                 #[inline]
                                 #[allow(trivial_numeric_casts)]
@@ -651,30 +697,34 @@ fn handle_vec_primitive(cx: &mut GenContext,
 
                                     {copy_vals}
                                }}",
-                            mutators = mutators,
-                            name = field.name,
-                            co = co,
-                            check_len = check_len,
-                            inner_ty_str = inner_ty_str,
-                            copy_vals = copy_vals);
-
+            mutators = mutators,
+            name = field.name,
+            co = co,
+            check_len = check_len,
+            inner_ty_str = inner_ty_str,
+            copy_vals = copy_vals
+        );
     } else {
-
-        cx.ecx.span_err(field.span, "unimplemented variable length field");
+        cx.ecx
+            .span_err(field.span, "unimplemented variable length field");
         *error = true;
     }
 }
 
-fn handle_vector_field(cx: &mut GenContext,
-                       error: &mut bool,
-                       field: &Field,
-                       accessors: &mut String,
-                       mutators: &mut String,
-                       inner_ty: &Box<Type>,
-                       co: &mut String) {
+fn handle_vector_field(
+    cx: &mut GenContext,
+    error: &mut bool,
+    field: &Field,
+    accessors: &mut String,
+    mutators: &mut String,
+    inner_ty: &Box<Type>,
+    co: &mut String,
+) {
     if !field.is_payload && !field.packet_length.is_some() {
-        cx.ecx.span_err(field.span,
-                        "variable length field must have #[length_fn = \"\"] attribute");
+        cx.ecx.span_err(
+            field.span,
+            "variable length field must have #[length_fn = \"\"] attribute",
+        );
         *error = true;
     }
     if !field.is_payload {
@@ -716,18 +766,19 @@ fn handle_vector_field(cx: &mut GenContext,
                             packet_length = field.packet_length.as_ref().unwrap());
     }
     match **inner_ty {
-        Type::Primitive(ref inner_ty_str, _size, _endianness) => {
-            handle_vec_primitive(cx,
-                                 error,
-                                 inner_ty_str,
-                                 _size,
-                                 field,
-                                 accessors,
-                                 mutators,
-                                 co)
-        }
+        Type::Primitive(ref inner_ty_str, _size, _endianness) => handle_vec_primitive(
+            cx,
+            error,
+            inner_ty_str,
+            _size,
+            field,
+            accessors,
+            mutators,
+            co,
+        ),
         Type::Vector(_) => {
-            cx.ecx.span_err(field.span, "variable length fields may not contain vectors");
+            cx.ecx
+                .span_err(field.span, "variable length fields may not contain vectors");
             *error = true;
         }
         Type::Misc(ref inner_ty_str) => {
@@ -796,11 +847,12 @@ fn handle_vector_field(cx: &mut GenContext,
     }
 }
 
-fn generate_packet_impl(cx: &mut GenContext,
-                        packet: &Packet,
-                        mutable: bool,
-                        name: String)
-    -> Option<(PayloadBounds, String)> {
+fn generate_packet_impl(
+    cx: &mut GenContext,
+    packet: &Packet,
+    mutable: bool,
+    name: String,
+) -> Option<(PayloadBounds, String)> {
     let mut bit_offset = 0;
     let mut offset_fns_packet = Vec::new();
     let mut offset_fns_struct = Vec::new();
@@ -818,9 +870,11 @@ fn generate_packet_impl(cx: &mut GenContext,
                     format!("{} + {}", co.clone(), field.packet_length.as_ref().unwrap());
             } else {
                 if idx != packet.fields.len() - 1 {
-                    cx.ecx.span_err(field.span,
-                                    "#[payload] must specify a #[length_fn], unless it is the \
-                                     last field of a packet");
+                    cx.ecx.span_err(
+                        field.span,
+                        "#[payload] must specify a #[length_fn], unless it is the \
+                                     last field of a packet",
+                    );
                     error = true;
                 }
             }
@@ -847,41 +901,40 @@ fn generate_packet_impl(cx: &mut GenContext,
                     ops = to_little_endian(ops);
                 }
 
-                mutators = mutators +
-                           &generate_mutator_str(&field.name[..],
-                                                 &ty_str[..],
-                                                 &co[..],
-                                                 &to_mutator(&ops[..])[..],
-                                                 None)[..];
-                accessors = accessors +
-                            &generate_accessor_str(&field.name[..],
-                                                   &ty_str[..],
-                                                   &co[..],
-                                                   &ops[..],
-                                                   None)[..];
+                mutators = mutators
+                    + &generate_mutator_str(
+                        &field.name[..],
+                        &ty_str[..],
+                        &co[..],
+                        &to_mutator(&ops[..])[..],
+                        None,
+                    )[..];
+                accessors = accessors
+                    + &generate_accessor_str(&field.name[..], &ty_str[..], &co[..], &ops[..], None)
+                        [..];
                 bit_offset += size;
             }
-            Type::Vector(ref inner_ty) => {
-                handle_vector_field(cx,
-                                    &mut error,
-                                    &field,
-                                    &mut accessors,
-                                    &mut mutators,
-                                    inner_ty,
-                                    &mut co)
-            }
-            Type::Misc(ref ty_str) => {
-                handle_misc_field(cx,
-                                  &mut error,
-                                  &field,
-                                  &mut bit_offset,
-                                  &offset_fns_packet[..],
-                                  &mut co,
-                                  &name,
-                                  &mut mutators,
-                                  &mut accessors,
-                                  &ty_str)
-            }
+            Type::Vector(ref inner_ty) => handle_vector_field(
+                cx,
+                &mut error,
+                &field,
+                &mut accessors,
+                &mut mutators,
+                inner_ty,
+                &mut co,
+            ),
+            Type::Misc(ref ty_str) => handle_misc_field(
+                cx,
+                &mut error,
+                &field,
+                &mut bit_offset,
+                &offset_fns_packet[..],
+                &mut co,
+                &name,
+                &mut mutators,
+                &mut accessors,
+                &ty_str,
+            ),
         }
         if field.packet_length.is_some() {
             offset_fns_packet.push(field.packet_length.as_ref().unwrap().clone());
@@ -900,14 +953,12 @@ fn generate_packet_impl(cx: &mut GenContext,
         for field in &packet.fields {
             match field.ty {
                 Type::Vector(_) => {
-                    set_fields = set_fields +
-                                 &format!("_self.set_{field}(&packet.{field});\n",
-                                          field = field.name)[..];
+                    set_fields = set_fields
+                        + &format!("_self.set_{field}(&packet.{field});\n", field = field.name)[..];
                 }
                 _ => {
-                    set_fields = set_fields +
-                                 &format!("_self.set_{field}(packet.{field});\n",
-                                          field = field.name)[..];
+                    set_fields = set_fields
+                        + &format!("_self.set_{field}(packet.{field});\n", field = field.name)[..];
                 }
             }
         }
@@ -918,31 +969,34 @@ fn generate_packet_impl(cx: &mut GenContext,
     let populate = if mutable {
         let set_fields = generate_set_fields(&packet);
         let imm_name = packet.packet_name();
-        format!("/// Populates a {name}Packet using a {name} structure
+        format!(
+            "/// Populates a {name}Packet using a {name} structure
              #[inline]
              #[cfg_attr(feature = \"clippy\", allow(used_underscore_binding))]
              pub fn populate(&mut self, packet: &{name}) {{
                  let _self = self;
                  {set_fields}
              }}",
-                name = &imm_name[..imm_name.len() - 6],
-                set_fields = set_fields)
+            name = &imm_name[..imm_name.len() - 6],
+            set_fields = set_fields
+        )
     } else {
         "".to_owned()
     };
 
     // If there are no variable length fields defined, then `_packet` is not used, hence
     // the leading underscore
-    let packet_size_struct = format!("/// The size (in bytes) of a {base_name} instance when converted into
+    let packet_size_struct = format!(
+        "/// The size (in bytes) of a {base_name} instance when converted into
             /// a byte-array
             #[inline]
             pub fn packet_size(_packet: \
                  &{base_name}) -> usize {{
                 {struct_size}
             }}",
-                                     base_name = packet.base_name,
-                                     struct_size = current_offset(bit_offset,
-                                                                  &offset_fns_struct[..]));
+        base_name = packet.base_name,
+        struct_size = current_offset(bit_offset, &offset_fns_struct[..])
+    );
 
     let byte_size = if bit_offset % 8 == 0 {
         bit_offset / 8
@@ -1013,14 +1067,18 @@ fn generate_packet_impl(cx: &mut GenContext,
     packet_size_struct = packet_size_struct
         ));
 
-    Some((payload_bounds.unwrap(), current_offset(bit_offset, &offset_fns_packet[..])))
+    Some((
+        payload_bounds.unwrap(),
+        current_offset(bit_offset, &offset_fns_packet[..]),
+    ))
 }
-
 
 fn generate_packet_impls(cx: &mut GenContext, packet: &Packet) -> Option<(PayloadBounds, String)> {
     let mut ret = None;
-    for (mutable, name) in vec![(false, packet.packet_name()),
-                                (true, packet.packet_name_mut())] {
+    for (mutable, name) in vec![
+        (false, packet.packet_name()),
+        (true, packet.packet_name_mut()),
+    ] {
         ret = generate_packet_impl(cx, packet, mutable, name);
     }
 
@@ -1029,7 +1087,8 @@ fn generate_packet_impls(cx: &mut GenContext, packet: &Packet) -> Option<(Payloa
 
 fn generate_packet_size_impls(cx: &mut GenContext, packet: &Packet, size: &str) {
     for name in &[packet.packet_name(), packet.packet_name_mut()] {
-        cx.push_item_from_string(format!("
+        cx.push_item_from_string(format!(
+            "
             impl<'a> ::pnet_macros_support::packet::PacketSize for {name}<'a> {{
                 #[cfg_attr(feature = \"clippy\", allow(used_underscore_binding))]
                 fn packet_size(&self) -> usize {{
@@ -1037,17 +1096,22 @@ fn generate_packet_size_impls(cx: &mut GenContext, packet: &Packet, size: &str) 
                     {size}
                 }}
             }}
-        ", name = name, size = size));
+        ",
+            name = name,
+            size = size
+        ));
     }
 }
 
-fn generate_packet_trait_impls(cx: &mut GenContext,
-                               packet: &Packet,
-                               payload_bounds: &PayloadBounds) {
+fn generate_packet_trait_impls(
+    cx: &mut GenContext,
+    packet: &Packet,
+    payload_bounds: &PayloadBounds,
+) {
     for (name, mutable, u_mut, mut_) in vec![
         (packet.packet_name_mut(), "Mutable", "_mut", "mut"),
         (packet.packet_name_mut(), "", "", ""),
-        (packet.packet_name(), "", "", "")
+        (packet.packet_name(), "", "", ""),
     ] {
         let mut pre = "".to_owned();
         let mut start = "".to_owned();
@@ -1057,11 +1121,15 @@ fn generate_packet_trait_impls(cx: &mut GenContext,
             start = "start".to_owned();
         }
         if !payload_bounds.upper.is_empty() {
-            pre = pre + &format!("let end = ::std::cmp::min({}, _self.packet.len());",
-                                    payload_bounds.upper)[..];
+            pre = pre
+                + &format!(
+                    "let end = ::std::cmp::min({}, _self.packet.len());",
+                    payload_bounds.upper
+                )[..];
             end = "end".to_owned();
         }
-        cx.push_item_from_string(format!("impl<'a> ::pnet_macros_support::packet::{mutable}Packet for {name}<'a> {{
+        cx.push_item_from_string(format!(
+            "impl<'a> ::pnet_macros_support::packet::{mutable}Packet for {name}<'a> {{
             #[inline]
             fn packet{u_mut}<'p>(&'p {mut_} self) -> &'p {mut_} [u8] {{ &{mut_} self.packet[..] }}
 
@@ -1075,27 +1143,33 @@ fn generate_packet_trait_impls(cx: &mut GenContext,
                 }}
                 &{mut_} _self.packet[{start}..{end}]
             }}
-        }}", name = name,
-             start = start,
-             end = end,
-             pre = pre,
-             mutable = mutable,
-             u_mut = u_mut,
-             mut_ = mut_));
+        }}",
+            name = name,
+            start = start,
+            end = end,
+            pre = pre,
+            mutable = mutable,
+            u_mut = u_mut,
+            mut_ = mut_
+        ));
     }
 }
 
 fn generate_iterables(cx: &mut GenContext, packet: &Packet) {
     let name = &packet.base_name;
 
-    cx.push_item_from_string(format!("
+    cx.push_item_from_string(format!(
+        "
     /// Used to iterate over a slice of `{name}Packet`s
     pub struct {name}Iterable<'a> {{
         buf: &'a [u8],
     }}
-    ", name = name));
+    ",
+        name = name
+    ));
 
-    cx.push_item_from_string(format!("
+    cx.push_item_from_string(format!(
+        "
     impl<'a> Iterator for {name}Iterable<'a> {{
         type Item = {name}Packet<'a>;
 
@@ -1117,14 +1191,17 @@ fn generate_iterables(cx: &mut GenContext, packet: &Packet) {
             (0, None)
         }}
     }}
-    ", name = name));
+    ",
+        name = name
+    ));
 }
 
 fn generate_converters(cx: &mut GenContext, packet: &Packet) {
     let get_fields = generate_get_fields(packet);
 
     for name in &[packet.packet_name(), packet.packet_name_mut()] {
-        cx.push_item_from_string(format!("
+        cx.push_item_from_string(format!(
+            "
         impl<'p> ::pnet_macros_support::packet::FromPacket for {packet}<'p> {{
             type T = {name};
             #[inline]
@@ -1135,12 +1212,15 @@ fn generate_converters(cx: &mut GenContext, packet: &Packet) {
                     {get_fields}
                 }}
             }}
-        }}", packet = name, name = packet.base_name, get_fields = get_fields));
+        }}",
+            packet = name,
+            name = packet.base_name,
+            get_fields = get_fields
+        ));
     }
 }
 
 fn generate_debug_impls(cx: &mut GenContext, packet: &Packet) {
-
     let mut field_fmt_str = String::new();
     let mut get_fields = String::new();
 
@@ -1152,7 +1232,8 @@ fn generate_debug_impls(cx: &mut GenContext, packet: &Packet) {
     }
 
     for packet in &[packet.packet_name(), packet.packet_name_mut()] {
-        cx.push_item_from_string(format!("
+        cx.push_item_from_string(format!(
+            "
         impl<'p> ::std::fmt::Debug for {packet}<'p> {{
             #[cfg_attr(feature = \"clippy\", allow(used_underscore_binding))]
             fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {{
@@ -1162,7 +1243,11 @@ fn generate_debug_impls(cx: &mut GenContext, packet: &Packet) {
                        {get_fields}
                 )
             }}
-        }}", packet = packet, field_fmt_str = field_fmt_str, get_fields = get_fields));
+        }}",
+            packet = packet,
+            field_fmt_str = field_fmt_str,
+            get_fields = get_fields
+        ));
     }
 }
 
@@ -1209,12 +1294,30 @@ fn parse_ty(ty: &str) -> Option<(usize, Endianness, EndiannessSpecified)> {
 
 #[test]
 fn test_parse_ty() {
-    assert_eq!(parse_ty("u8"), Some((8, Endianness::Big, EndiannessSpecified::No)));
-    assert_eq!(parse_ty("u21be"), Some((21, Endianness::Big, EndiannessSpecified::Yes)));
-    assert_eq!(parse_ty("u21le"), Some((21, Endianness::Little, EndiannessSpecified::Yes)));
-    assert_eq!(parse_ty("u21he"), Some((21, Endianness::Host, EndiannessSpecified::Yes)));
-    assert_eq!(parse_ty("u9"), Some((9, Endianness::Big, EndiannessSpecified::No)));
-    assert_eq!(parse_ty("u16"), Some((16, Endianness::Big, EndiannessSpecified::No)));
+    assert_eq!(
+        parse_ty("u8"),
+        Some((8, Endianness::Big, EndiannessSpecified::No))
+    );
+    assert_eq!(
+        parse_ty("u21be"),
+        Some((21, Endianness::Big, EndiannessSpecified::Yes))
+    );
+    assert_eq!(
+        parse_ty("u21le"),
+        Some((21, Endianness::Little, EndiannessSpecified::Yes))
+    );
+    assert_eq!(
+        parse_ty("u21he"),
+        Some((21, Endianness::Host, EndiannessSpecified::Yes))
+    );
+    assert_eq!(
+        parse_ty("u9"),
+        Some((9, Endianness::Big, EndiannessSpecified::No))
+    );
+    assert_eq!(
+        parse_ty("u16"),
+        Some((16, Endianness::Big, EndiannessSpecified::No))
+    );
     assert_eq!(parse_ty("uable"), None);
     assert_eq!(parse_ty("u21re"), None);
     assert_eq!(parse_ty("i21be"), None);
@@ -1225,59 +1328,85 @@ fn generate_sop_strings(operations: &[SetOperation]) -> String {
     for (idx, sop) in operations.iter().enumerate() {
         let pkt_replace = format!("_self.packet[co + {}]", idx);
         let val_replace = "val";
-        let sop =
-            sop.to_string().replace("{packet}", &pkt_replace[..]).replace("{val}", val_replace);
+        let sop = sop
+            .to_string()
+            .replace("{packet}", &pkt_replace[..])
+            .replace("{val}", val_replace);
         op_strings = op_strings + &sop[..] + ";\n";
     }
 
     op_strings
 }
 
-enum AccessorMutator { Accessor, Mutator }
+enum AccessorMutator {
+    Accessor,
+    Mutator,
+}
 
 fn generate_accessor_or_mutator_comment(name: &str, ty: &str, op_type: AccessorMutator) -> String {
-    let get_or_set = match op_type { AccessorMutator::Accessor => "Get",
-                                     AccessorMutator::Mutator  => "Set" };
+    let get_or_set = match op_type {
+        AccessorMutator::Accessor => "Get",
+        AccessorMutator::Mutator => "Set",
+    };
     if let Some((_, endianness, end_specified)) = parse_ty(ty) {
         if end_specified == EndiannessSpecified::Yes {
-            let return_or_want = match op_type { AccessorMutator::Accessor => "accessor returns",
-                                                 AccessorMutator::Mutator  => "mutator wants" };
+            let return_or_want = match op_type {
+                AccessorMutator::Accessor => "accessor returns",
+                AccessorMutator::Mutator => "mutator wants",
+            };
             let endian_str = match endianness {
-                Endianness::Big => { "big-endian" },
-                Endianness::Little => { "little-endian" },
-                Endianness::Host => { "host-endian" },
+                Endianness::Big => "big-endian",
+                Endianness::Little => "little-endian",
+                Endianness::Host => "host-endian",
             };
 
-            return format!("/// {get_or_set} the {name} field. This field is always stored {endian}
+            return format!(
+                "/// {get_or_set} the {name} field. This field is always stored {endian}
                 /// within the struct, but this {return_or_want} host order.",
-                get_or_set = get_or_set, name = name, endian = endian_str,
-                return_or_want = return_or_want);
+                get_or_set = get_or_set,
+                name = name,
+                endian = endian_str,
+                return_or_want = return_or_want
+            );
         }
     }
-    format!("/// {get_or_set} the {name} field.", get_or_set = get_or_set, name = name)
+    format!(
+        "/// {get_or_set} the {name} field.",
+        get_or_set = get_or_set,
+        name = name
+    )
 }
 
 /// Given the name of a field, and a set of operations required to set that field, return
 /// the Rust code required to set the field
-fn generate_mutator_str(name: &str,
-                        ty: &str,
-                        offset: &str,
-                        operations: &[SetOperation],
-                        inner: Option<&str>)
-    -> String {
+fn generate_mutator_str(
+    name: &str,
+    ty: &str,
+    offset: &str,
+    operations: &[SetOperation],
+    inner: Option<&str>,
+) -> String {
     let op_strings = generate_sop_strings(operations);
 
     let mutator = if let Some(struct_name) = inner {
-        format!("#[inline]
+        format!(
+            "#[inline]
     #[allow(trivial_numeric_casts)]
     #[cfg_attr(feature = \"clippy\", allow(used_underscore_binding))]
     fn set_{name}(_self: &mut {struct_name}, val: {ty}) {{
         let co = {co};
         {operations}
-    }}", struct_name = struct_name, name = name, ty = ty, co = offset, operations = op_strings)
+    }}",
+            struct_name = struct_name,
+            name = name,
+            ty = ty,
+            co = offset,
+            operations = op_strings
+        )
     } else {
         let comment = generate_accessor_or_mutator_comment(name, ty, AccessorMutator::Mutator);
-        format!("{comment}
+        format!(
+            "{comment}
     #[inline]
     #[allow(trivial_numeric_casts)]
     #[cfg_attr(feature = \"clippy\", allow(used_underscore_binding))]
@@ -1285,7 +1414,13 @@ fn generate_mutator_str(name: &str,
         let _self = self;
         let co = {co};
         {operations}
-    }}", comment = comment, name = name, ty = ty, co = offset, operations = op_strings)
+    }}",
+            comment = comment,
+            name = name,
+            ty = ty,
+            co = offset,
+            operations = op_strings
+        )
     };
 
     mutator
@@ -1296,7 +1431,6 @@ fn generate_mutator_str(name: &str,
 ///  let b1 = ((_self.packet[co + 1] as u16be) as u16be;
 ///  b0 | b1"
 fn generate_accessor_op_str(name: &str, ty: &str, operations: &[GetOperation]) -> String {
-
     fn build_return(max: usize) -> String {
         let mut ret = "".to_owned();
         for i in 0..max {
@@ -1310,7 +1444,11 @@ fn generate_accessor_op_str(name: &str, ty: &str, operations: &[GetOperation]) -
 
     let op_strings = if operations.len() == 1 {
         let replacement_str = format!("({}[co] as {})", name, ty);
-        operations.first().unwrap().to_string().replace("{}", &replacement_str[..])
+        operations
+            .first()
+            .unwrap()
+            .to_string()
+            .replace("{}", &replacement_str[..])
     } else {
         let mut op_strings = "".to_owned();
         for (idx, operation) in operations.iter().enumerate() {
@@ -1328,7 +1466,6 @@ fn generate_accessor_op_str(name: &str, ty: &str, operations: &[GetOperation]) -
 
 #[test]
 fn test_generate_accessor_op_str() {
-
     {
         let ops = operations(0, 24).unwrap();
         let result = generate_accessor_op_str("test", "u24be", &ops);
@@ -1359,26 +1496,34 @@ fn test_generate_accessor_op_str() {
 
 /// Given the name of a field, and a set of operations required to get the value of that field,
 /// return the Rust code required to get the field.
-fn generate_accessor_str(name: &str,
-                         ty: &str,
-                         offset: &str,
-                         operations: &[GetOperation],
-                         inner: Option<&str>)
-    -> String {
-
+fn generate_accessor_str(
+    name: &str,
+    ty: &str,
+    offset: &str,
+    operations: &[GetOperation],
+    inner: Option<&str>,
+) -> String {
     let op_strings = generate_accessor_op_str("_self.packet", ty, operations);
 
     let accessor = if let Some(struct_name) = inner {
-        format!("#[inline(always)]
+        format!(
+            "#[inline(always)]
         #[allow(trivial_numeric_casts, unused_parens)]
         #[cfg_attr(feature = \"clippy\", allow(used_underscore_binding))]
         fn get_{name}(_self: &{struct_name}) -> {ty} {{
             let co = {co};
             {operations}
-        }}", struct_name = struct_name, name = name, ty = ty, co = offset, operations = op_strings)
+        }}",
+            struct_name = struct_name,
+            name = name,
+            ty = ty,
+            co = offset,
+            operations = op_strings
+        )
     } else {
         let comment = generate_accessor_or_mutator_comment(name, ty, AccessorMutator::Accessor);
-        format!("{comment}
+        format!(
+            "{comment}
         #[inline]
         #[allow(trivial_numeric_casts, unused_parens)]
         #[cfg_attr(feature = \"clippy\", allow(used_underscore_binding))]
@@ -1386,7 +1531,13 @@ fn generate_accessor_str(name: &str,
             let _self = self;
             let co = {co};
             {operations}
-        }}", comment = comment, name = name, ty = ty, co = offset, operations = op_strings)
+        }}",
+            comment = comment,
+            name = name,
+            ty = ty,
+            co = offset,
+            operations = op_strings
+        )
     };
 
     accessor
@@ -1395,7 +1546,9 @@ fn generate_accessor_str(name: &str,
 fn current_offset(bit_offset: usize, offset_fns: &[String]) -> String {
     let base_offset = bit_offset / 8;
 
-    offset_fns.iter().fold(base_offset.to_string(), |a, b| a + " + " + &b[..])
+    offset_fns
+        .iter()
+        .fold(base_offset.to_string(), |a, b| a + " + " + &b[..])
 }
 
 fn generate_get_fields(packet: &Packet) -> String {
@@ -1403,14 +1556,17 @@ fn generate_get_fields(packet: &Packet) -> String {
 
     for field in &packet.fields {
         if field.is_payload {
-            gets = gets +
-                   &format!("{field} : {{
+            gets = gets
+                + &format!(
+                    "{field} : {{
                                                 let payload = self.payload();
                                                 let mut vec = Vec::with_capacity(payload.len());
                                                 vec.extend_from_slice(payload);
 
                                                 vec
-                                            }},\n", field = field.name)[..]
+                                            }},\n",
+                    field = field.name
+                )[..]
         } else {
             gets = gets + &format!("{field} : _self.get_{field}(),\n", field = field.name)[..]
         }
@@ -1418,7 +1574,6 @@ fn generate_get_fields(packet: &Packet) -> String {
 
     gets
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -1432,13 +1587,17 @@ mod tests {
     fn assert_parse_length_expr(expr: &str, field_names: &[&str], expected: &str) {
         let sess = ParseSess::new();
         let mut dummy_macro_loader = DummyMacroLoader;
-        let mut ecx = ExtCtxt::new(&sess,
-                                   CrateConfig::default(),
-                                   ExpansionConfig::default("parse_length_expr".to_owned()),
-                                   &mut dummy_macro_loader);
+        let mut ecx = ExtCtxt::new(
+            &sess,
+            CrateConfig::default(),
+            ExpansionConfig::default("parse_length_expr".to_owned()),
+            &mut dummy_macro_loader,
+        );
         let expr_tokens = ecx.parse_tts(expr.to_owned());
-        let field_names_vec: Vec<String> =
-            field_names.iter().map(|field_name| (*field_name).to_owned()).collect();
+        let field_names_vec: Vec<String> = field_names
+            .iter()
+            .map(|field_name| (*field_name).to_owned())
+            .collect();
         let parsed = super::parse_length_expr(&mut ecx, &expr_tokens, &field_names_vec);
         let expected_tokens = ecx.parse_tts(expected.to_owned());
         assert_eq!(tts_to_string(&parsed), tts_to_string(&expected_tokens));
@@ -1447,12 +1606,16 @@ mod tests {
     #[test]
     fn test_parse_expr_key() {
         assert_parse_length_expr("key", &["key"], "_self.get_key() as usize");
-        assert_parse_length_expr("another_key",
-                                 &["another_key"],
-                                 "_self.get_another_key() as usize");
-        assert_parse_length_expr("get_something",
-                                 &["get_something"],
-                                 "_self.get_get_something() as usize");
+        assert_parse_length_expr(
+            "another_key",
+            &["another_key"],
+            "_self.get_another_key() as usize",
+        );
+        assert_parse_length_expr(
+            "get_something",
+            &["get_something"],
+            "_self.get_get_something() as usize",
+        );
     }
 
     #[test]
@@ -1471,9 +1634,11 @@ mod tests {
     #[test]
     fn test_parse_expr_key_and_numbers() {
         assert_parse_length_expr("key + 4", &["key"], "_self.get_key() as usize + 4");
-        assert_parse_length_expr("another_key - 7 + 8 * 2 / 1 % 2",
-                                 &["another_key"],
-                                 "_self.get_another_key() as usize - 7 + 8 * 2 / 1 % 2");
+        assert_parse_length_expr(
+            "another_key - 7 + 8 * 2 / 1 % 2",
+            &["another_key"],
+            "_self.get_another_key() as usize - 7 + 8 * 2 / 1 % 2",
+        );
         assert_parse_length_expr("2 * key - 4", &["key"], "2 * _self.get_key() as usize - 4");
     }
 
@@ -1482,10 +1647,12 @@ mod tests {
         assert_parse_length_expr("()", &[], "()");
         assert_parse_length_expr("(key)", &["key"], "(_self.get_key() as usize)");
         assert_parse_length_expr("(key + 5)", &["key"], "(_self.get_key() as usize + 5)");
-        assert_parse_length_expr("key + 5 * (10 - another_key)",
-                                 &["key", "another_key"],
-                                 "_self.get_key() as usize + 5 * (10 - _self.get_another_key() \
-                                  as usize)");
+        assert_parse_length_expr(
+            "key + 5 * (10 - another_key)",
+            &["key", "another_key"],
+            "_self.get_key() as usize + 5 * (10 - _self.get_another_key() \
+                                  as usize)",
+        );
         assert_parse_length_expr("4 + 2 / (3 * (7 - 5))", &[], "4 + 2 / (3 * (7 - 5))");
     }
 
@@ -1493,8 +1660,10 @@ mod tests {
     fn test_parse_expr_constants() {
         assert_parse_length_expr("CONSTANT", &[], "CONSTANT as usize");
         assert_parse_length_expr("std::u32::MIN", &[], "std::u32::MIN as usize");
-        assert_parse_length_expr("key * (4 + std::u32::MIN)",
-                                 &["key"],
-                                 "_self.get_key() as usize * (4 + std::u32::MIN as usize)");
+        assert_parse_length_expr(
+            "key * (4 + std::u32::MIN)",
+            &["key"],
+            "_self.get_key() as usize * (4 + std::u32::MIN as usize)",
+        );
     }
 }

--- a/pnet_macros/src/lib.rs
+++ b/pnet_macros/src/lib.rs
@@ -138,10 +138,9 @@
 //!        `#[construct_with(...)]` attribute, and in the `new` method.
 
 #![deny(missing_docs)]
-
-#![cfg_attr(feature="clippy", feature(plugin))]
-#![cfg_attr(feature="clippy", plugin(clippy))]
-#![cfg_attr(feature="clippy", allow(let_and_return))]
+#![cfg_attr(feature = "clippy", feature(plugin))]
+#![cfg_attr(feature = "clippy", plugin(clippy))]
+#![cfg_attr(feature = "clippy", allow(let_and_return))]
 
 extern crate syntex;
 extern crate syntex_syntax as syntax;
@@ -168,11 +167,12 @@ fn mw(ecx: &mut ExtCtxt, span: Span, word: &'static str) -> P<ast::MetaItem> {
 ///
 /// The #[packet] attribute is consumed, so we replace it with two internal attributes,
 /// #[packet_generator], which is used to generate the packet implementations, and
-fn packet_modifier(ecx: &mut ExtCtxt,
-                   span: Span,
-                   _meta_item: &ast::MetaItem,
-                   item: Annotatable)
-    -> Annotatable {
+fn packet_modifier(
+    ecx: &mut ExtCtxt,
+    span: Span,
+    _meta_item: &ast::MetaItem,
+    item: Annotatable,
+) -> Annotatable {
     let item = item.expect_item();
     let mut new_item = (*item).clone();
 
@@ -182,14 +182,22 @@ fn packet_modifier(ecx: &mut ExtCtxt,
     let unused_attrs = mw(ecx, span, "unused_attributes");
 
     let a1 = ecx.attribute(span, packet_generator);
-    let a2 = ecx.attribute(span,
-                           ecx.meta_list(span,
-                                         token::InternedString::new("derive"),
-                                         vec![clone, debug]));
-    let a3 = ecx.attribute(span,
-                           ecx.meta_list(span,
-                                         token::InternedString::new("allow"),
-                                         vec![unused_attrs]));
+    let a2 = ecx.attribute(
+        span,
+        ecx.meta_list(
+            span,
+            token::InternedString::new("derive"),
+            vec![clone, debug],
+        ),
+    );
+    let a3 = ecx.attribute(
+        span,
+        ecx.meta_list(
+            span,
+            token::InternedString::new("allow"),
+            vec![unused_attrs],
+        ),
+    );
 
     new_item.attrs.push(a1);
     new_item.attrs.push(a2);
@@ -211,12 +219,10 @@ fn variant_data_fields(vd: &mut ast::VariantData) -> &mut [ast::StructField] {
 fn remove_attributes_struct(vd: &mut ast::VariantData) {
     for field in variant_data_fields(vd) {
         let attrs = &mut field.attrs;
-        attrs.retain(|attr| {
-            match attr.node.value.node {
-                ast::MetaItemKind::Word(ref s) => *s != "payload",
-                ast::MetaItemKind::List(ref s, _) => *s != "construct_with",
-                ast::MetaItemKind::NameValue(ref s, _) => !(*s == "length_fn" || *s == "length"),
-            }
+        attrs.retain(|attr| match attr.node.value.node {
+            ast::MetaItemKind::Word(ref s) => *s != "payload",
+            ast::MetaItemKind::List(ref s, _) => *s != "construct_with",
+            ast::MetaItemKind::NameValue(ref s, _) => !(*s == "length_fn" || *s == "length"),
         });
     }
 }
@@ -268,4 +274,3 @@ pub fn register(registry: &mut syntex::Registry) {
     registry.add_decorator("packet_generator", decorator::generate_packet);
     registry.add_post_expansion_pass(remove_attributes);
 }
-

--- a/pnet_macros/src/util.rs
+++ b/pnet_macros/src/util.rs
@@ -49,41 +49,51 @@ impl fmt::Display for GetOperation {
 fn test_display_get_operation() {
     type Op = GetOperation;
 
-    assert_eq!(Op {
-                       mask: 0b00001111,
-                       shiftl: 2,
-                       shiftr: 0,
-                   }
-                   .to_string(),
-               "({} & 0xf) << 2");
-    assert_eq!(Op {
-                       mask: 0b00001111,
-                       shiftl: 2,
-                       shiftr: 2,
-                   }
-                   .to_string(),
-               "({} & 0xf)");
-    assert_eq!(Op {
-                       mask: 0b00001111,
-                       shiftl: 0,
-                       shiftr: 2,
-                   }
-                   .to_string(),
-               "({} & 0xf) >> 2");
-    assert_eq!(Op {
-                       mask: 0b11111111,
-                       shiftl: 0,
-                       shiftr: 2,
-                   }
-                   .to_string(),
-               "{} >> 2");
-    assert_eq!(Op {
-                       mask: 0b11111111,
-                       shiftl: 3,
-                       shiftr: 1,
-                   }
-                   .to_string(),
-               "{} << 2");
+    assert_eq!(
+        Op {
+            mask: 0b00001111,
+            shiftl: 2,
+            shiftr: 0,
+        }
+        .to_string(),
+        "({} & 0xf) << 2"
+    );
+    assert_eq!(
+        Op {
+            mask: 0b00001111,
+            shiftl: 2,
+            shiftr: 2,
+        }
+        .to_string(),
+        "({} & 0xf)"
+    );
+    assert_eq!(
+        Op {
+            mask: 0b00001111,
+            shiftl: 0,
+            shiftr: 2,
+        }
+        .to_string(),
+        "({} & 0xf) >> 2"
+    );
+    assert_eq!(
+        Op {
+            mask: 0b11111111,
+            shiftl: 0,
+            shiftr: 2,
+        }
+        .to_string(),
+        "{} >> 2"
+    );
+    assert_eq!(
+        Op {
+            mask: 0b11111111,
+            shiftl: 3,
+            shiftr: 1,
+        }
+        .to_string(),
+        "{} << 2"
+    );
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -100,8 +110,7 @@ pub struct SetOperation {
 
 macro_rules! radix_fn {
     ($name:ident, $ty:ty) => {
-        fn $name(mut val: $ty) -> String
-        {
+        fn $name(mut val: $ty) -> String {
             let mut ret = String::new();
             let vals = "0123456789abcdef".as_bytes();
             while val > 0 {
@@ -120,7 +129,7 @@ macro_rules! radix_fn {
                 assert_eq!(super::$name(0x1c), "1c".to_owned());
             }
         }
-    }
+    };
 }
 
 radix_fn!(radix16_u8, u8);
@@ -153,10 +162,11 @@ impl fmt::Display for SetOperation {
         };
 
         if should_save {
-            write!(fmt,
-                   "{{packet}} = ({} | ({}) as u8) as u8",
-                   save_str,
-                   shift_str)
+            write!(
+                fmt,
+                "{{packet}} = ({} | ({}) as u8) as u8",
+                save_str, shift_str
+            )
         } else {
             write!(fmt, "{{packet}} = ({}) as u8", shift_str)
         }
@@ -167,46 +177,56 @@ impl fmt::Display for SetOperation {
 fn test_display_set_operation() {
     type Sop = SetOperation;
 
-    assert_eq!(Sop {
-                       save_mask: 0b00000011,
-                       value_mask: 0b00001111,
-                       shiftl: 2,
-                       shiftr: 0,
-                   }
-                   .to_string(),
-               "{packet} = (({packet} & 0x3) | (({val} & 0xf) << 2) as u8) as u8");
-    assert_eq!(Sop {
-                       save_mask: 0b11000000,
-                       value_mask: 0b00001111,
-                       shiftl: 2,
-                       shiftr: 2,
-                   }
-                   .to_string(),
-               "{packet} = (({packet} & 0xc0) | (({val} & 0xf)) as u8) as u8");
-    assert_eq!(Sop {
-                       save_mask: 0b00011100,
-                       value_mask: 0b00001111,
-                       shiftl: 0,
-                       shiftr: 2,
-                   }
-                   .to_string(),
-               "{packet} = (({packet} & 0x1c) | (({val} & 0xf) >> 2) as u8) as u8");
-    assert_eq!(Sop {
-                       save_mask: 0b00000000,
-                       value_mask: 0b11111111,
-                       shiftl: 0,
-                       shiftr: 2,
-                   }
-                   .to_string(),
-               "{packet} = ({val} >> 2) as u8");
-    assert_eq!(Sop {
-                       save_mask: 0b00000011,
-                       value_mask: 0b11111111,
-                       shiftl: 3,
-                       shiftr: 1,
-                   }
-                   .to_string(),
-               "{packet} = (({packet} & 0x3) | ({val} << 2) as u8) as u8");
+    assert_eq!(
+        Sop {
+            save_mask: 0b00000011,
+            value_mask: 0b00001111,
+            shiftl: 2,
+            shiftr: 0,
+        }
+        .to_string(),
+        "{packet} = (({packet} & 0x3) | (({val} & 0xf) << 2) as u8) as u8"
+    );
+    assert_eq!(
+        Sop {
+            save_mask: 0b11000000,
+            value_mask: 0b00001111,
+            shiftl: 2,
+            shiftr: 2,
+        }
+        .to_string(),
+        "{packet} = (({packet} & 0xc0) | (({val} & 0xf)) as u8) as u8"
+    );
+    assert_eq!(
+        Sop {
+            save_mask: 0b00011100,
+            value_mask: 0b00001111,
+            shiftl: 0,
+            shiftr: 2,
+        }
+        .to_string(),
+        "{packet} = (({packet} & 0x1c) | (({val} & 0xf) >> 2) as u8) as u8"
+    );
+    assert_eq!(
+        Sop {
+            save_mask: 0b00000000,
+            value_mask: 0b11111111,
+            shiftl: 0,
+            shiftr: 2,
+        }
+        .to_string(),
+        "{packet} = ({val} >> 2) as u8"
+    );
+    assert_eq!(
+        Sop {
+            save_mask: 0b00000011,
+            value_mask: 0b11111111,
+            shiftl: 3,
+            shiftr: 1,
+        }
+        .to_string(),
+        "{packet} = (({packet} & 0x3) | ({val} << 2) as u8) as u8"
+    );
 }
 
 /// Gets a mask to get bits_remaining bits from offset bits into a byte
@@ -214,7 +234,11 @@ fn test_display_set_operation() {
 fn get_mask(offset: usize, bits_remaining: usize) -> (usize, u8) {
     fn bits_remaining_in_byte(offset: usize, bits_remaining: usize) -> usize {
         fn round_down(max_val: usize, val: usize) -> usize {
-            if val > max_val { max_val } else { val }
+            if val > max_val {
+                max_val
+            } else {
+                val
+            }
         }
         if (bits_remaining / 8) >= 1 {
             8 - offset
@@ -340,7 +364,6 @@ fn test_get_shiftr() {
     assert_eq!(get_shiftr(1, 11, 0, 2), 0);
     assert_eq!(get_shiftr(1, 11, 1, 2), 4);
 
-
     assert_eq!(get_shiftr(0, 35, 0, 5), 0);
     assert_eq!(get_shiftr(0, 35, 1, 5), 0);
     assert_eq!(get_shiftr(0, 35, 2, 5), 0);
@@ -387,172 +410,222 @@ pub fn operations(offset: usize, size: usize) -> Option<Vec<GetOperation>> {
 #[test]
 fn operations_test() {
     type Op = GetOperation;
-    assert_eq!(operations(0, 1).unwrap(),
-               vec![Op {
-                        mask: 0b10000000,
-                        shiftl: 0,
-                        shiftr: 7,
-                    }]);
-    assert_eq!(operations(0, 2).unwrap(),
-               vec![Op {
-                        mask: 0b11000000,
-                        shiftl: 0,
-                        shiftr: 6,
-                    }]);
-    assert_eq!(operations(0, 3).unwrap(),
-               vec![Op {
-                        mask: 0b11100000,
-                        shiftl: 0,
-                        shiftr: 5,
-                    }]);
-    assert_eq!(operations(0, 4).unwrap(),
-               vec![Op {
-                        mask: 0b11110000,
-                        shiftl: 0,
-                        shiftr: 4,
-                    }]);
-    assert_eq!(operations(0, 5).unwrap(),
-               vec![Op {
-                        mask: 0b11111000,
-                        shiftl: 0,
-                        shiftr: 3,
-                    }]);
-    assert_eq!(operations(0, 6).unwrap(),
-               vec![Op {
-                        mask: 0b11111100,
-                        shiftl: 0,
-                        shiftr: 2,
-                    }]);
-    assert_eq!(operations(0, 7).unwrap(),
-               vec![Op {
-                        mask: 0b11111110,
-                        shiftl: 0,
-                        shiftr: 1,
-                    }]);
-    assert_eq!(operations(0, 8).unwrap(),
-               vec![Op {
-                        mask: 0b11111111,
-                        shiftl: 0,
-                        shiftr: 0,
-                    }]);
-    assert_eq!(operations(0, 9).unwrap(),
-               vec![Op {
-                        mask: 0b11111111,
-                        shiftl: 1,
-                        shiftr: 0,
-                    },
-                    Op {
-                        mask: 0b10000000,
-                        shiftl: 0,
-                        shiftr: 7,
-                    }]);
-    assert_eq!(operations(0, 10).unwrap(),
-               vec![Op {
-                        mask: 0b11111111,
-                        shiftl: 2,
-                        shiftr: 0,
-                    },
-                    Op {
-                        mask: 0b11000000,
-                        shiftl: 0,
-                        shiftr: 6,
-                    }]);
+    assert_eq!(
+        operations(0, 1).unwrap(),
+        vec![Op {
+            mask: 0b10000000,
+            shiftl: 0,
+            shiftr: 7,
+        }]
+    );
+    assert_eq!(
+        operations(0, 2).unwrap(),
+        vec![Op {
+            mask: 0b11000000,
+            shiftl: 0,
+            shiftr: 6,
+        }]
+    );
+    assert_eq!(
+        operations(0, 3).unwrap(),
+        vec![Op {
+            mask: 0b11100000,
+            shiftl: 0,
+            shiftr: 5,
+        }]
+    );
+    assert_eq!(
+        operations(0, 4).unwrap(),
+        vec![Op {
+            mask: 0b11110000,
+            shiftl: 0,
+            shiftr: 4,
+        }]
+    );
+    assert_eq!(
+        operations(0, 5).unwrap(),
+        vec![Op {
+            mask: 0b11111000,
+            shiftl: 0,
+            shiftr: 3,
+        }]
+    );
+    assert_eq!(
+        operations(0, 6).unwrap(),
+        vec![Op {
+            mask: 0b11111100,
+            shiftl: 0,
+            shiftr: 2,
+        }]
+    );
+    assert_eq!(
+        operations(0, 7).unwrap(),
+        vec![Op {
+            mask: 0b11111110,
+            shiftl: 0,
+            shiftr: 1,
+        }]
+    );
+    assert_eq!(
+        operations(0, 8).unwrap(),
+        vec![Op {
+            mask: 0b11111111,
+            shiftl: 0,
+            shiftr: 0,
+        }]
+    );
+    assert_eq!(
+        operations(0, 9).unwrap(),
+        vec![
+            Op {
+                mask: 0b11111111,
+                shiftl: 1,
+                shiftr: 0,
+            },
+            Op {
+                mask: 0b10000000,
+                shiftl: 0,
+                shiftr: 7,
+            }
+        ]
+    );
+    assert_eq!(
+        operations(0, 10).unwrap(),
+        vec![
+            Op {
+                mask: 0b11111111,
+                shiftl: 2,
+                shiftr: 0,
+            },
+            Op {
+                mask: 0b11000000,
+                shiftl: 0,
+                shiftr: 6,
+            }
+        ]
+    );
 
-    assert_eq!(operations(1, 1).unwrap(),
-               vec![Op {
-                        mask: 0b01000000,
-                        shiftl: 0,
-                        shiftr: 6,
-                    }]);
-    assert_eq!(operations(1, 2).unwrap(),
-               vec![Op {
-                        mask: 0b01100000,
-                        shiftl: 0,
-                        shiftr: 5,
-                    }]);
-    assert_eq!(operations(1, 3).unwrap(),
-               vec![Op {
-                        mask: 0b01110000,
-                        shiftl: 0,
-                        shiftr: 4,
-                    }]);
-    assert_eq!(operations(1, 4).unwrap(),
-               vec![Op {
-                        mask: 0b01111000,
-                        shiftl: 0,
-                        shiftr: 3,
-                    }]);
-    assert_eq!(operations(1, 5).unwrap(),
-               vec![Op {
-                        mask: 0b01111100,
-                        shiftl: 0,
-                        shiftr: 2,
-                    }]);
-    assert_eq!(operations(1, 6).unwrap(),
-               vec![Op {
-                        mask: 0b01111110,
-                        shiftl: 0,
-                        shiftr: 1,
-                    }]);
-    assert_eq!(operations(1, 7).unwrap(),
-               vec![Op {
-                        mask: 0b01111111,
-                        shiftl: 0,
-                        shiftr: 0,
-                    }]);
-    assert_eq!(operations(1, 8).unwrap(),
-               vec![Op {
-                        mask: 0b01111111,
-                        shiftl: 1,
-                        shiftr: 0,
-                    },
-                    Op {
-                        mask: 0b10000000,
-                        shiftl: 0,
-                        shiftr: 7,
-                    }]);
-    assert_eq!(operations(1, 9).unwrap(),
-               vec![Op {
-                        mask: 0b01111111,
-                        shiftl: 2,
-                        shiftr: 0,
-                    },
-                    Op {
-                        mask: 0b11000000,
-                        shiftl: 0,
-                        shiftr: 6,
-                    }]);
+    assert_eq!(
+        operations(1, 1).unwrap(),
+        vec![Op {
+            mask: 0b01000000,
+            shiftl: 0,
+            shiftr: 6,
+        }]
+    );
+    assert_eq!(
+        operations(1, 2).unwrap(),
+        vec![Op {
+            mask: 0b01100000,
+            shiftl: 0,
+            shiftr: 5,
+        }]
+    );
+    assert_eq!(
+        operations(1, 3).unwrap(),
+        vec![Op {
+            mask: 0b01110000,
+            shiftl: 0,
+            shiftr: 4,
+        }]
+    );
+    assert_eq!(
+        operations(1, 4).unwrap(),
+        vec![Op {
+            mask: 0b01111000,
+            shiftl: 0,
+            shiftr: 3,
+        }]
+    );
+    assert_eq!(
+        operations(1, 5).unwrap(),
+        vec![Op {
+            mask: 0b01111100,
+            shiftl: 0,
+            shiftr: 2,
+        }]
+    );
+    assert_eq!(
+        operations(1, 6).unwrap(),
+        vec![Op {
+            mask: 0b01111110,
+            shiftl: 0,
+            shiftr: 1,
+        }]
+    );
+    assert_eq!(
+        operations(1, 7).unwrap(),
+        vec![Op {
+            mask: 0b01111111,
+            shiftl: 0,
+            shiftr: 0,
+        }]
+    );
+    assert_eq!(
+        operations(1, 8).unwrap(),
+        vec![
+            Op {
+                mask: 0b01111111,
+                shiftl: 1,
+                shiftr: 0,
+            },
+            Op {
+                mask: 0b10000000,
+                shiftl: 0,
+                shiftr: 7,
+            }
+        ]
+    );
+    assert_eq!(
+        operations(1, 9).unwrap(),
+        vec![
+            Op {
+                mask: 0b01111111,
+                shiftl: 2,
+                shiftr: 0,
+            },
+            Op {
+                mask: 0b11000000,
+                shiftl: 0,
+                shiftr: 6,
+            }
+        ]
+    );
 
     assert_eq!(operations(8, 1), None);
     assert_eq!(operations(3, 0), None);
     assert_eq!(operations(3, 65), None);
 
-    assert_eq!(operations(3, 33).unwrap(),
-               vec![Op {
-                        mask: 0b00011111,
-                        shiftl: 28,
-                        shiftr: 0,
-                    },
-                    Op {
-                        mask: 0b11111111,
-                        shiftl: 20,
-                        shiftr: 0,
-                    },
-                    Op {
-                        mask: 0b11111111,
-                        shiftl: 12,
-                        shiftr: 0,
-                    },
-                    Op {
-                        mask: 0b11111111,
-                        shiftl: 4,
-                        shiftr: 0,
-                    },
-                    Op {
-                        mask: 0b11110000,
-                        shiftl: 0,
-                        shiftr: 4,
-                    }]);
+    assert_eq!(
+        operations(3, 33).unwrap(),
+        vec![
+            Op {
+                mask: 0b00011111,
+                shiftl: 28,
+                shiftr: 0,
+            },
+            Op {
+                mask: 0b11111111,
+                shiftl: 20,
+                shiftr: 0,
+            },
+            Op {
+                mask: 0b11111111,
+                shiftl: 12,
+                shiftr: 0,
+            },
+            Op {
+                mask: 0b11111111,
+                shiftl: 4,
+                shiftr: 0,
+            },
+            Op {
+                mask: 0b11110000,
+                shiftl: 0,
+                shiftr: 4,
+            }
+        ]
+    );
 }
 
 /// Mask `bits` bits of a byte. eg. mask_high_bits(2) == 0b00000011
@@ -600,317 +673,377 @@ fn test_to_mutator() {
     type Op = GetOperation;
     type Sop = SetOperation;
 
-    assert_eq!(to_mutator(&[Op {
-                                mask: 0b10000000,
-                                shiftl: 0,
-                                shiftr: 7,
-                            }]),
-               vec![Sop {
-                        save_mask: 0b01111111,
-                        value_mask: 0b00000001,
-                        shiftl: 7,
-                        shiftr: 0,
-                    }]);
-    assert_eq!(to_mutator(&[Op {
-                                mask: 0b11000000,
-                                shiftl: 0,
-                                shiftr: 6,
-                            }]),
-               vec![Sop {
-                        save_mask: 0b00111111,
-                        value_mask: 0b00000011,
-                        shiftl: 6,
-                        shiftr: 0,
-                    }]);
-    assert_eq!(to_mutator(&[Op {
-                                mask: 0b11100000,
-                                shiftl: 0,
-                                shiftr: 5,
-                            }]),
-               vec![Sop {
-                        save_mask: 0b00011111,
-                        value_mask: 0b00000111,
-                        shiftl: 5,
-                        shiftr: 0,
-                    }]);
-    assert_eq!(to_mutator(&[Op {
-                                mask: 0b11110000,
-                                shiftl: 0,
-                                shiftr: 4,
-                            }]),
-               vec![Sop {
-                        save_mask: 0b00001111,
-                        value_mask: 0b00001111,
-                        shiftl: 4,
-                        shiftr: 0,
-                    }]);
-    assert_eq!(to_mutator(&[Op {
-                                mask: 0b11111000,
-                                shiftl: 0,
-                                shiftr: 3,
-                            }]),
-               vec![Sop {
-                        save_mask: 0b00000111,
-                        value_mask: 0b00011111,
-                        shiftl: 3,
-                        shiftr: 0,
-                    }]);
-    assert_eq!(to_mutator(&[Op {
-                                mask: 0b11111100,
-                                shiftl: 0,
-                                shiftr: 2,
-                            }]),
-               vec![Sop {
-                        save_mask: 0b00000011,
-                        value_mask: 0b00111111,
-                        shiftl: 2,
-                        shiftr: 0,
-                    }]);
-    assert_eq!(to_mutator(&[Op {
-                                mask: 0b11111110,
-                                shiftl: 0,
-                                shiftr: 1,
-                            }]),
-               vec![Sop {
-                        save_mask: 0b00000001,
-                        value_mask: 0b01111111,
-                        shiftl: 1,
-                        shiftr: 0,
-                    }]);
-    assert_eq!(to_mutator(&[Op {
-                                mask: 0b11111111,
-                                shiftl: 0,
-                                shiftr: 0,
-                            }]),
-               vec![Sop {
-                        save_mask: 0b00000000,
-                        value_mask: 0b11111111,
-                        shiftl: 0,
-                        shiftr: 0,
-                    }]);
-    assert_eq!(to_mutator(&[Op {
-                                mask: 0b11111111,
-                                shiftl: 1,
-                                shiftr: 0,
-                            },
-                            Op {
-                                mask: 0b10000000,
-                                shiftl: 0,
-                                shiftr: 7,
-                            }]),
-               vec![Sop {
-                        save_mask: 0b00000000,
-                        value_mask: 0b111111110,
-                        shiftl: 0,
-                        shiftr: 1,
-                    },
-                    Sop {
-                        save_mask: 0b01111111,
-                        value_mask: 0b00000001,
-                        shiftl: 7,
-                        shiftr: 0,
-                    }]);
+    assert_eq!(
+        to_mutator(&[Op {
+            mask: 0b10000000,
+            shiftl: 0,
+            shiftr: 7,
+        }]),
+        vec![Sop {
+            save_mask: 0b01111111,
+            value_mask: 0b00000001,
+            shiftl: 7,
+            shiftr: 0,
+        }]
+    );
+    assert_eq!(
+        to_mutator(&[Op {
+            mask: 0b11000000,
+            shiftl: 0,
+            shiftr: 6,
+        }]),
+        vec![Sop {
+            save_mask: 0b00111111,
+            value_mask: 0b00000011,
+            shiftl: 6,
+            shiftr: 0,
+        }]
+    );
+    assert_eq!(
+        to_mutator(&[Op {
+            mask: 0b11100000,
+            shiftl: 0,
+            shiftr: 5,
+        }]),
+        vec![Sop {
+            save_mask: 0b00011111,
+            value_mask: 0b00000111,
+            shiftl: 5,
+            shiftr: 0,
+        }]
+    );
+    assert_eq!(
+        to_mutator(&[Op {
+            mask: 0b11110000,
+            shiftl: 0,
+            shiftr: 4,
+        }]),
+        vec![Sop {
+            save_mask: 0b00001111,
+            value_mask: 0b00001111,
+            shiftl: 4,
+            shiftr: 0,
+        }]
+    );
+    assert_eq!(
+        to_mutator(&[Op {
+            mask: 0b11111000,
+            shiftl: 0,
+            shiftr: 3,
+        }]),
+        vec![Sop {
+            save_mask: 0b00000111,
+            value_mask: 0b00011111,
+            shiftl: 3,
+            shiftr: 0,
+        }]
+    );
+    assert_eq!(
+        to_mutator(&[Op {
+            mask: 0b11111100,
+            shiftl: 0,
+            shiftr: 2,
+        }]),
+        vec![Sop {
+            save_mask: 0b00000011,
+            value_mask: 0b00111111,
+            shiftl: 2,
+            shiftr: 0,
+        }]
+    );
+    assert_eq!(
+        to_mutator(&[Op {
+            mask: 0b11111110,
+            shiftl: 0,
+            shiftr: 1,
+        }]),
+        vec![Sop {
+            save_mask: 0b00000001,
+            value_mask: 0b01111111,
+            shiftl: 1,
+            shiftr: 0,
+        }]
+    );
+    assert_eq!(
+        to_mutator(&[Op {
+            mask: 0b11111111,
+            shiftl: 0,
+            shiftr: 0,
+        }]),
+        vec![Sop {
+            save_mask: 0b00000000,
+            value_mask: 0b11111111,
+            shiftl: 0,
+            shiftr: 0,
+        }]
+    );
+    assert_eq!(
+        to_mutator(&[
+            Op {
+                mask: 0b11111111,
+                shiftl: 1,
+                shiftr: 0,
+            },
+            Op {
+                mask: 0b10000000,
+                shiftl: 0,
+                shiftr: 7,
+            }
+        ]),
+        vec![
+            Sop {
+                save_mask: 0b00000000,
+                value_mask: 0b111111110,
+                shiftl: 0,
+                shiftr: 1,
+            },
+            Sop {
+                save_mask: 0b01111111,
+                value_mask: 0b00000001,
+                shiftl: 7,
+                shiftr: 0,
+            }
+        ]
+    );
 
-    assert_eq!(to_mutator(&[Op {
-                                mask: 0b11111111,
-                                shiftl: 2,
-                                shiftr: 0,
-                            },
-                            Op {
-                                mask: 0b11000000,
-                                shiftl: 0,
-                                shiftr: 6,
-                            }]),
-               vec![Sop {
-                        save_mask: 0b00000000,
-                        value_mask: 0b1111111100,
-                        shiftl: 0,
-                        shiftr: 2,
-                    },
-                    Sop {
-                        save_mask: 0b00111111,
-                        value_mask: 0b00000011,
-                        shiftl: 6,
-                        shiftr: 0,
-                    }]);
+    assert_eq!(
+        to_mutator(&[
+            Op {
+                mask: 0b11111111,
+                shiftl: 2,
+                shiftr: 0,
+            },
+            Op {
+                mask: 0b11000000,
+                shiftl: 0,
+                shiftr: 6,
+            }
+        ]),
+        vec![
+            Sop {
+                save_mask: 0b00000000,
+                value_mask: 0b1111111100,
+                shiftl: 0,
+                shiftr: 2,
+            },
+            Sop {
+                save_mask: 0b00111111,
+                value_mask: 0b00000011,
+                shiftl: 6,
+                shiftr: 0,
+            }
+        ]
+    );
 
-    assert_eq!(to_mutator(&[Op {
-                                mask: 0b01000000,
-                                shiftl: 0,
-                                shiftr: 6,
-                            }]),
-               vec![Sop {
-                        save_mask: 0b10111111,
-                        value_mask: 0b00000001,
-                        shiftl: 6,
-                        shiftr: 0,
-                    }]);
-    assert_eq!(to_mutator(&[Op {
-                                mask: 0b01100000,
-                                shiftl: 0,
-                                shiftr: 5,
-                            }]),
-               vec![Sop {
-                        save_mask: 0b10011111,
-                        value_mask: 0b00000011,
-                        shiftl: 5,
-                        shiftr: 0,
-                    }]);
-    assert_eq!(to_mutator(&[Op {
-                                mask: 0b01110000,
-                                shiftl: 0,
-                                shiftr: 4,
-                            }]),
-               vec![Sop {
-                        save_mask: 0b10001111,
-                        value_mask: 0b00000111,
-                        shiftl: 4,
-                        shiftr: 0,
-                    }]);
-    assert_eq!(to_mutator(&[Op {
-                                mask: 0b01111000,
-                                shiftl: 0,
-                                shiftr: 3,
-                            }]),
-               vec![Sop {
-                        save_mask: 0b10000111,
-                        value_mask: 0b00001111,
-                        shiftl: 3,
-                        shiftr: 0,
-                    }]);
-    assert_eq!(to_mutator(&[Op {
-                                mask: 0b01111100,
-                                shiftl: 0,
-                                shiftr: 2,
-                            }]),
-               vec![Sop {
-                        save_mask: 0b10000011,
-                        value_mask: 0b00011111,
-                        shiftl: 2,
-                        shiftr: 0,
-                    }]);
-    assert_eq!(to_mutator(&[Op {
-                                mask: 0b01111110,
-                                shiftl: 0,
-                                shiftr: 1,
-                            }]),
-               vec![Sop {
-                        save_mask: 0b10000001,
-                        value_mask: 0b00111111,
-                        shiftl: 1,
-                        shiftr: 0,
-                    }]);
-    assert_eq!(to_mutator(&[Op {
-                                mask: 0b01111111,
-                                shiftl: 0,
-                                shiftr: 0,
-                            }]),
-               vec![Sop {
-                        save_mask: 0b10000000,
-                        value_mask: 0b01111111,
-                        shiftl: 0,
-                        shiftr: 0,
-                    }]);
-    assert_eq!(to_mutator(&[Op {
-                                mask: 0b01111111,
-                                shiftl: 1,
-                                shiftr: 0,
-                            },
-                            Op {
-                                mask: 0b10000000,
-                                shiftl: 0,
-                                shiftr: 7,
-                            }]),
-               vec![Sop {
-                        save_mask: 0b10000000,
-                        value_mask: 0b11111110,
-                        shiftl: 0,
-                        shiftr: 1,
-                    },
-                    Sop {
-                        save_mask: 0b01111111,
-                        value_mask: 0b00000001,
-                        shiftl: 7,
-                        shiftr: 0,
-                    }]);
-    assert_eq!(to_mutator(&[Op {
-                                mask: 0b01111111,
-                                shiftl: 2,
-                                shiftr: 0,
-                            },
-                            Op {
-                                mask: 0b11000000,
-                                shiftl: 0,
-                                shiftr: 6,
-                            }]),
-               vec![Sop {
-                        save_mask: 0b10000000,
-                        value_mask: 0b0111111100,
-                        shiftl: 0,
-                        shiftr: 2,
-                    },
-                    Sop {
-                        save_mask: 0b00111111,
-                        value_mask: 0b00000011,
-                        shiftl: 6,
-                        shiftr: 0,
-                    }]);
+    assert_eq!(
+        to_mutator(&[Op {
+            mask: 0b01000000,
+            shiftl: 0,
+            shiftr: 6,
+        }]),
+        vec![Sop {
+            save_mask: 0b10111111,
+            value_mask: 0b00000001,
+            shiftl: 6,
+            shiftr: 0,
+        }]
+    );
+    assert_eq!(
+        to_mutator(&[Op {
+            mask: 0b01100000,
+            shiftl: 0,
+            shiftr: 5,
+        }]),
+        vec![Sop {
+            save_mask: 0b10011111,
+            value_mask: 0b00000011,
+            shiftl: 5,
+            shiftr: 0,
+        }]
+    );
+    assert_eq!(
+        to_mutator(&[Op {
+            mask: 0b01110000,
+            shiftl: 0,
+            shiftr: 4,
+        }]),
+        vec![Sop {
+            save_mask: 0b10001111,
+            value_mask: 0b00000111,
+            shiftl: 4,
+            shiftr: 0,
+        }]
+    );
+    assert_eq!(
+        to_mutator(&[Op {
+            mask: 0b01111000,
+            shiftl: 0,
+            shiftr: 3,
+        }]),
+        vec![Sop {
+            save_mask: 0b10000111,
+            value_mask: 0b00001111,
+            shiftl: 3,
+            shiftr: 0,
+        }]
+    );
+    assert_eq!(
+        to_mutator(&[Op {
+            mask: 0b01111100,
+            shiftl: 0,
+            shiftr: 2,
+        }]),
+        vec![Sop {
+            save_mask: 0b10000011,
+            value_mask: 0b00011111,
+            shiftl: 2,
+            shiftr: 0,
+        }]
+    );
+    assert_eq!(
+        to_mutator(&[Op {
+            mask: 0b01111110,
+            shiftl: 0,
+            shiftr: 1,
+        }]),
+        vec![Sop {
+            save_mask: 0b10000001,
+            value_mask: 0b00111111,
+            shiftl: 1,
+            shiftr: 0,
+        }]
+    );
+    assert_eq!(
+        to_mutator(&[Op {
+            mask: 0b01111111,
+            shiftl: 0,
+            shiftr: 0,
+        }]),
+        vec![Sop {
+            save_mask: 0b10000000,
+            value_mask: 0b01111111,
+            shiftl: 0,
+            shiftr: 0,
+        }]
+    );
+    assert_eq!(
+        to_mutator(&[
+            Op {
+                mask: 0b01111111,
+                shiftl: 1,
+                shiftr: 0,
+            },
+            Op {
+                mask: 0b10000000,
+                shiftl: 0,
+                shiftr: 7,
+            }
+        ]),
+        vec![
+            Sop {
+                save_mask: 0b10000000,
+                value_mask: 0b11111110,
+                shiftl: 0,
+                shiftr: 1,
+            },
+            Sop {
+                save_mask: 0b01111111,
+                value_mask: 0b00000001,
+                shiftl: 7,
+                shiftr: 0,
+            }
+        ]
+    );
+    assert_eq!(
+        to_mutator(&[
+            Op {
+                mask: 0b01111111,
+                shiftl: 2,
+                shiftr: 0,
+            },
+            Op {
+                mask: 0b11000000,
+                shiftl: 0,
+                shiftr: 6,
+            }
+        ]),
+        vec![
+            Sop {
+                save_mask: 0b10000000,
+                value_mask: 0b0111111100,
+                shiftl: 0,
+                shiftr: 2,
+            },
+            Sop {
+                save_mask: 0b00111111,
+                value_mask: 0b00000011,
+                shiftl: 6,
+                shiftr: 0,
+            }
+        ]
+    );
 
-    assert_eq!(to_mutator(&[Op {
-                                mask: 0b00011111,
-                                shiftl: 28,
-                                shiftr: 0,
-                            },
-                            Op {
-                                mask: 0b11111111,
-                                shiftl: 20,
-                                shiftr: 0,
-                            },
-                            Op {
-                                mask: 0b11111111,
-                                shiftl: 12,
-                                shiftr: 0,
-                            },
-                            Op {
-                                mask: 0b11111111,
-                                shiftl: 4,
-                                shiftr: 0,
-                            },
-                            Op {
-                                mask: 0b11110000,
-                                shiftl: 0,
-                                shiftr: 4,
-                            }]),
-               vec![Sop {
-                        save_mask: 0b11100000,
-                        value_mask: 0x1F0000000,
-                        shiftl: 0,
-                        shiftr: 28,
-                    },
-                    Sop {
-                        save_mask: 0b00000000,
-                        value_mask: 0x00FF00000,
-                        shiftl: 0,
-                        shiftr: 20,
-                    },
-                    Sop {
-                        save_mask: 0b00000000,
-                        value_mask: 0x0000FF000,
-                        shiftl: 0,
-                        shiftr: 12,
-                    },
-                    Sop {
-                        save_mask: 0b00000000,
-                        value_mask: 0x000000FF0,
-                        shiftl: 0,
-                        shiftr: 4,
-                    },
-                    Sop {
-                        save_mask: 0b00001111,
-                        value_mask: 0x00000000F,
-                        shiftl: 4,
-                        shiftr: 0,
-                    }]);
+    assert_eq!(
+        to_mutator(&[
+            Op {
+                mask: 0b00011111,
+                shiftl: 28,
+                shiftr: 0,
+            },
+            Op {
+                mask: 0b11111111,
+                shiftl: 20,
+                shiftr: 0,
+            },
+            Op {
+                mask: 0b11111111,
+                shiftl: 12,
+                shiftr: 0,
+            },
+            Op {
+                mask: 0b11111111,
+                shiftl: 4,
+                shiftr: 0,
+            },
+            Op {
+                mask: 0b11110000,
+                shiftl: 0,
+                shiftr: 4,
+            }
+        ]),
+        vec![
+            Sop {
+                save_mask: 0b11100000,
+                value_mask: 0x1F0000000,
+                shiftl: 0,
+                shiftr: 28,
+            },
+            Sop {
+                save_mask: 0b00000000,
+                value_mask: 0x00FF00000,
+                shiftl: 0,
+                shiftr: 20,
+            },
+            Sop {
+                save_mask: 0b00000000,
+                value_mask: 0x0000FF000,
+                shiftl: 0,
+                shiftr: 12,
+            },
+            Sop {
+                save_mask: 0b00000000,
+                value_mask: 0x000000FF0,
+                shiftl: 0,
+                shiftr: 4,
+            },
+            Sop {
+                save_mask: 0b00001111,
+                value_mask: 0x00000000F,
+                shiftl: 4,
+                shiftr: 0,
+            }
+        ]
+    );
 }
 
 /// Takes a set of operations to get a field in big endian, and converts them to get the field in
@@ -918,7 +1051,7 @@ fn test_to_mutator() {
 pub fn to_little_endian(_ops: Vec<GetOperation>) -> Vec<GetOperation> {
     let mut ops = _ops.clone();
     for (op, be_op) in ops.iter_mut().zip(_ops.iter().rev()) {
-	op.shiftl = be_op.shiftl;
+        op.shiftl = be_op.shiftl;
     }
     ops
 }

--- a/pnet_macros/tests/tests.rs
+++ b/pnet_macros/tests/tests.rs
@@ -7,16 +7,23 @@ enum TestType {
 }
 
 fn run_test(name: &str, ty: TestType) {
-    use std::io::prelude::*;
-    use std::fs::File;
     use std::env;
+    use std::fs::File;
+    use std::io::prelude::*;
     use TestType::*;
 
     // Set the required target endian environment variable
-    let target_endian = if cfg!(target_endian = "little") { "little" } else { "big" };
+    let target_endian = if cfg!(target_endian = "little") {
+        "little"
+    } else {
+        "big"
+    };
     env::set_var("CARGO_CFG_TARGET_ENDIAN", target_endian);
 
-    let path = match ty { CompileFail => "compile-fail", RunPass => "run-pass" };
+    let path = match ty {
+        CompileFail => "compile-fail",
+        RunPass => "run-pass",
+    };
     let file_name = format!("tests/{}/{}.rs", path, name);
 
     let mut f = File::open(&file_name).unwrap();
@@ -33,7 +40,7 @@ fn run_test(name: &str, ty: TestType) {
             if res.is_ok() {
                 panic!(format!("unexpected success: {}", file_name));
             }
-        },
+        }
         RunPass => {
             res.unwrap();
         }
@@ -47,8 +54,7 @@ mod run_pass {
             fn $name() {
                 ::run_test(stringify!($name), super::TestType::RunPass);
             }
-
-        }
+        };
     }
 
     run_pass!(length_expr);
@@ -72,23 +78,40 @@ mod compile_fail {
 
                 ::run_test(stringify!($name), super::TestType::CompileFail);
             }
-        }
+        };
     }
 
     compile_fail!(payload_fn2, "unknown attribute: payload");
-    compile_fail!(endianness_not_specified, "endianness must be specified for types of size >= 8");
-    compile_fail!(length_expr, "Only field names, constants, integers, \
+    compile_fail!(
+        endianness_not_specified,
+        "endianness must be specified for types of size >= 8"
+    );
+    compile_fail!(
+        length_expr,
+        "Only field names, constants, integers, \
                                 basic arithmetic expressions (+ - * / %) \
-                                and parentheses are allowed in the \"length\" attribute");
+                                and parentheses are allowed in the \"length\" attribute"
+    );
     compile_fail!(unnamed_field, "all fields in a packet must be named");
     compile_fail!(must_be_pub, "#[packet] structs must be public");
     compile_fail!(no_payload, "#[packet]'s must contain a payload");
-    compile_fail!(invalid_type, "non-primitive field types must specify #[construct_with]");
-    compile_fail!(length_expr_parentheses, "this file contains an un-closed delimiter");
+    compile_fail!(
+        invalid_type,
+        "non-primitive field types must specify #[construct_with]"
+    );
+    compile_fail!(
+        length_expr_parentheses,
+        "this file contains an un-closed delimiter"
+    );
     compile_fail!(multiple_payload, "packet may not have multiple payloads");
-    compile_fail!(variable_length_fields, "variable length field must have #[length = \"\"] or \
-                                           #[length_fn = \"\"] attribute");
-    compile_fail!(length_expr_key, "Field name must be a member of the struct and not the field \
-                                    itself");
+    compile_fail!(
+        variable_length_fields,
+        "variable length field must have #[length = \"\"] or \
+                                           #[length_fn = \"\"] attribute"
+    );
+    compile_fail!(
+        length_expr_key,
+        "Field name must be a member of the struct and not the field \
+                                    itself"
+    );
 }
-

--- a/pnet_macros_support/src/lib.rs
+++ b/pnet_macros_support/src/lib.rs
@@ -14,5 +14,5 @@
 
 extern crate pnet_base;
 
-pub mod types;
 pub mod packet;
+pub mod types;

--- a/pnet_macros_support/src/packet.rs
+++ b/pnet_macros_support/src/packet.rs
@@ -34,9 +34,11 @@ pub trait MutablePacket: Packet {
 
         assert!(self.packet().len() >= other.packet().len());
         unsafe {
-            ptr::copy_nonoverlapping(other.packet().as_ptr(),
-                                     self.packet_mut().as_mut_ptr(),
-                                     other.packet().len());
+            ptr::copy_nonoverlapping(
+                other.packet().as_ptr(),
+                self.packet_mut().as_mut_ptr(),
+                other.packet().len(),
+            );
         }
     }
 }
@@ -166,7 +168,6 @@ impl_index_mut!(MutPacketData, RangeTo<usize>, [u8]);
 impl_index_mut!(MutPacketData, RangeFrom<usize>, [u8]);
 impl_index_mut!(MutPacketData, RangeFull, [u8]);
 
-
 /// Used to convert a type to primitive values representing it.
 pub trait PrimitiveValues {
     /// A tuple of types, to represent the current value.
@@ -175,7 +176,6 @@ pub trait PrimitiveValues {
     /// Convert a value to primitive types representing it.
     fn to_primitive_values(&self) -> Self::T;
 }
-
 
 impl PrimitiveValues for pnet_base::MacAddr {
     type T = (u8, u8, u8, u8, u8, u8);
@@ -198,14 +198,15 @@ impl PrimitiveValues for ::std::net::Ipv6Addr {
     fn to_primitive_values(&self) -> (u16, u16, u16, u16, u16, u16, u16, u16) {
         let segments = self.segments();
 
-        (segments[0],
-         segments[1],
-         segments[2],
-         segments[3],
-         segments[4],
-         segments[5],
-         segments[6],
-         segments[7])
+        (
+            segments[0],
+            segments[1],
+            segments[2],
+            segments[3],
+            segments[4],
+            segments[5],
+            segments[6],
+            segments[7],
+        )
     }
 }
-

--- a/pnet_macros_support/src/types.rs
+++ b/pnet_macros_support/src/types.rs
@@ -43,7 +43,6 @@ pub type u6 = u8;
 /// Represents an unsigned, 7-bit integer.
 pub type u7 = u8;
 
-
 /// Represents an unsigned 9-bit integer. libpnet #[packet]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u9be = u16;
@@ -267,7 +266,6 @@ pub type u63be = u64;
 /// Represents an unsigned 64-bit integer. libpnet #[packet]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u64be = u64;
-
 
 /// Represents an unsigned 9-bit integer. libpnet #[packet]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.

--- a/pnet_packet/build.rs
+++ b/pnet_packet/build.rs
@@ -7,9 +7,9 @@
 // except according to those terms.
 
 mod macros {
+    extern crate glob;
     extern crate pnet_macros;
     extern crate syntex;
-    extern crate glob;
 
     use std::env;
     use std::path::Path;
@@ -17,12 +17,12 @@ mod macros {
     pub fn expand() {
         // globbing for files to pre-process:
         let pattern = "./src/**/*.rs.in";
-        for entry in glob::glob( pattern ).expect("Failed to read glob pattern") {
+        for entry in glob::glob(pattern).expect("Failed to read glob pattern") {
             if let Ok(path) = entry {
-                let src     = Path::new( path.to_str().expect("Invalid src Specified.") );
-                let out_dir = env::var_os( "OUT_DIR" ).expect("Invalid OUT_DIR.");
-                let file    = Path::new( path.file_stem().expect("Invalid file_stem.") );
-                let dst     = Path::new( &out_dir ).join(file);
+                let src = Path::new(path.to_str().expect("Invalid src Specified."));
+                let out_dir = env::var_os("OUT_DIR").expect("Invalid OUT_DIR.");
+                let file = Path::new(path.file_stem().expect("Invalid file_stem."));
+                let dst = Path::new(&out_dir).join(file);
                 let mut registry = syntex::Registry::new();
                 pnet_macros::register(&mut registry);
                 registry.expand("", &src, &dst).unwrap();

--- a/pnet_packet/src/ip.rs
+++ b/pnet_packet/src/ip.rs
@@ -9,8 +9,8 @@
 //! Defines the type and constants for IP next header/next level protocol
 //! fields.
 
-use PrimitiveValues;
 use std::fmt;
+use PrimitiveValues;
 
 /// Protocol numbers as defined at:
 /// http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
@@ -198,7 +198,7 @@ pub mod IpNextHeaderProtocols {
     /// SKIP
     pub const Skip: IpNextHeaderProtocol = IpNextHeaderProtocol(57);
 
-    #[deprecated(note="Please use `IpNextHeaderProtocols::Icmpv6` instead")]
+    #[deprecated(note = "Please use `IpNextHeaderProtocols::Icmpv6` instead")]
     pub const Ipv6Icmp: IpNextHeaderProtocol = IpNextHeaderProtocol(58);
 
     /// ICMPv6 [RFC4443]
@@ -464,7 +464,6 @@ pub mod IpNextHeaderProtocols {
 
     ///
     pub const Reserved: IpNextHeaderProtocol = IpNextHeaderProtocol(255);
-
 }
 
 /// Represents an IPv4 next level protocol, or an IPv6 next header protocol,
@@ -488,157 +487,159 @@ impl PrimitiveValues for IpNextHeaderProtocol {
 
 impl fmt::Display for IpNextHeaderProtocol {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f,
-               "{}",
-               match self {
-                   &IpNextHeaderProtocols::Hopopt => "Hopopt", // 0
-                   &IpNextHeaderProtocols::Icmp => "Icmp", // 1
-                   &IpNextHeaderProtocols::Igmp => "Igmp", // 2
-                   &IpNextHeaderProtocols::Ggp => "Ggp", // 3
-                   &IpNextHeaderProtocols::Ipv4 => "Ipv4", // 4
-                   &IpNextHeaderProtocols::St => "St", // 5
-                   &IpNextHeaderProtocols::Tcp => "Tcp", // 6
-                   &IpNextHeaderProtocols::Cbt => "Cbt", // 7
-                   &IpNextHeaderProtocols::Egp => "Egp", // 8
-                   &IpNextHeaderProtocols::Igp => "Igp", // 9
-                   &IpNextHeaderProtocols::BbnRccMon => "BbnRccMon", // 10
-                   &IpNextHeaderProtocols::NvpII => "NvpII", // 11
-                   &IpNextHeaderProtocols::Pup => "Pup", // 12
-                   &IpNextHeaderProtocols::Argus => "Argus", // 13
-                   &IpNextHeaderProtocols::Emcon => "Emcon", // 14
-                   &IpNextHeaderProtocols::Xnet => "Xnet", // 15
-                   &IpNextHeaderProtocols::Chaos => "Chaos", // 16
-                   &IpNextHeaderProtocols::Udp => "Udp", // 17
-                   &IpNextHeaderProtocols::Mux => "Mux", // 18
-                   &IpNextHeaderProtocols::DcnMeas => "DcnMeas", // 19
-                   &IpNextHeaderProtocols::Hmp => "Hmp", // 20
-                   &IpNextHeaderProtocols::Prm => "Prm", // 21
-                   &IpNextHeaderProtocols::XnsIdp => "XnsIdp", // 22
-                   &IpNextHeaderProtocols::Trunk1 => "Trunk1", // 23
-                   &IpNextHeaderProtocols::Trunk2 => "Trunk2", // 24
-                   &IpNextHeaderProtocols::Leaf1 => "Leaf1", // 25
-                   &IpNextHeaderProtocols::Leaf2 => "Leaf2", // 26
-                   &IpNextHeaderProtocols::Rdp => "Rdp", // 27
-                   &IpNextHeaderProtocols::Irtp => "Irtp", // 28
-                   &IpNextHeaderProtocols::IsoTp4 => "IsoTp4", // 29
-                   &IpNextHeaderProtocols::Netblt => "Netblt", // 30
-                   &IpNextHeaderProtocols::MfeNsp => "MfeNsp", // 31
-                   &IpNextHeaderProtocols::MeritInp => "MeritInp", // 32
-                   &IpNextHeaderProtocols::Dccp => "Dccp", // 33
-                   &IpNextHeaderProtocols::ThreePc => "ThreePc", // 34
-                   &IpNextHeaderProtocols::Idpr => "Idpr", // 35
-                   &IpNextHeaderProtocols::Xtp => "Xtp", // 36
-                   &IpNextHeaderProtocols::Ddp => "Ddp", // 37
-                   &IpNextHeaderProtocols::IdprCmtp => "IdprCmtp", // 38
-                   &IpNextHeaderProtocols::TpPlusPlus => "TpPlusPlus", // 39
-                   &IpNextHeaderProtocols::Il => "Il", // 40
-                   &IpNextHeaderProtocols::Ipv6 => "Ipv6", // 41
-                   &IpNextHeaderProtocols::Sdrp => "Sdrp", // 42
-                   &IpNextHeaderProtocols::Ipv6Route => "Ipv6Route", // 43
-                   &IpNextHeaderProtocols::Ipv6Frag => "Ipv6Frag", // 44
-                   &IpNextHeaderProtocols::Idrp => "Idrp", // 45
-                   &IpNextHeaderProtocols::Rsvp => "Rsvp", // 46
-                   &IpNextHeaderProtocols::Gre => "Gre", // 47
-                   &IpNextHeaderProtocols::Dsr => "Dsr", // 48
-                   &IpNextHeaderProtocols::Bna => "Bna", // 49
-                   &IpNextHeaderProtocols::Esp => "Esp", // 50
-                   &IpNextHeaderProtocols::Ah => "Ah", // 51
-                   &IpNextHeaderProtocols::INlsp => "INlsp", // 52
-                   &IpNextHeaderProtocols::Swipe => "Swipe", // 53
-                   &IpNextHeaderProtocols::Narp => "Narp", // 54
-                   &IpNextHeaderProtocols::Mobile => "Mobile", // 55
-                   &IpNextHeaderProtocols::Tlsp => "Tlsp", // 56
-                   &IpNextHeaderProtocols::Skip => "Skip", // 57
-                   &IpNextHeaderProtocols::Icmpv6 => "Icmpv6", // 58
-                   &IpNextHeaderProtocols::Ipv6NoNxt => "Ipv6NoNxt", // 59
-                   &IpNextHeaderProtocols::Ipv6Opts => "Ipv6Opts", // 60
-                   &IpNextHeaderProtocols::HostInternal => "HostInternal", // 61
-                   &IpNextHeaderProtocols::Cftp => "Cftp", // 62
-                   &IpNextHeaderProtocols::LocalNetwork => "LocalNetwork", // 63
-                   &IpNextHeaderProtocols::SatExpak => "SatExpak", // 64
-                   &IpNextHeaderProtocols::Kryptolan => "Kryptolan", // 65
-                   &IpNextHeaderProtocols::Rvd => "Rvd", // 66
-                   &IpNextHeaderProtocols::Ippc => "Ippc", // 67
-                   &IpNextHeaderProtocols::DistributedFs => "DistributedFs", // 68
-                   &IpNextHeaderProtocols::SatMon => "SatMon", // 69
-                   &IpNextHeaderProtocols::Visa => "Visa", // 70
-                   &IpNextHeaderProtocols::Ipcv => "Ipcv", // 71
-                   &IpNextHeaderProtocols::Cpnx => "Cpnx", // 72
-                   &IpNextHeaderProtocols::Cphb => "Cphb", // 73
-                   &IpNextHeaderProtocols::Wsn => "Wsn", // 74
-                   &IpNextHeaderProtocols::Pvp => "Pvp", // 75
-                   &IpNextHeaderProtocols::BrSatMon => "BrSatMon", // 76
-                   &IpNextHeaderProtocols::SunNd => "SunNd", // 77
-                   &IpNextHeaderProtocols::WbMon => "WbMon", // 78
-                   &IpNextHeaderProtocols::WbExpak => "WbExpak", // 79
-                   &IpNextHeaderProtocols::IsoIp => "IsoIp", // 80
-                   &IpNextHeaderProtocols::Vmtp => "Vmtp", // 81
-                   &IpNextHeaderProtocols::SecureVmtp => "SecureVmtp", // 82
-                   &IpNextHeaderProtocols::Vines => "Vines", // 83
-                   &IpNextHeaderProtocols::TtpOrIptm => "TtpOrIptm", // 84
-                   &IpNextHeaderProtocols::NsfnetIgp => "NsfnetIgp", // 85
-                   &IpNextHeaderProtocols::Dgp => "Dgp", // 86
-                   &IpNextHeaderProtocols::Tcf => "Tcf", // 87
-                   &IpNextHeaderProtocols::Eigrp => "Eigrp", // 88
-                   &IpNextHeaderProtocols::OspfigP => "OspfigP", // 89
-                   &IpNextHeaderProtocols::SpriteRpc => "SpriteRpc", // 90
-                   &IpNextHeaderProtocols::Larp => "Larp", // 91
-                   &IpNextHeaderProtocols::Mtp => "Mtp", // 92
-                   &IpNextHeaderProtocols::Ax25 => "Ax25", // 93
-                   &IpNextHeaderProtocols::IpIp => "IpIp", // 94
-                   &IpNextHeaderProtocols::Micp => "Micp", // 95
-                   &IpNextHeaderProtocols::SccSp => "SccSp", // 96
-                   &IpNextHeaderProtocols::Etherip => "Etherip", // 97
-                   &IpNextHeaderProtocols::Encap => "Encap", // 98
-                   &IpNextHeaderProtocols::PrivEncryption => "PrivEncryption", // 99
-                   &IpNextHeaderProtocols::Gmtp => "Gmtp", // 100
-                   &IpNextHeaderProtocols::Ifmp => "Ifmp", // 101
-                   &IpNextHeaderProtocols::Pnni => "Pnni", // 102
-                   &IpNextHeaderProtocols::Pim => "Pim", // 103
-                   &IpNextHeaderProtocols::Aris => "Aris", // 104
-                   &IpNextHeaderProtocols::Scps => "Scps", // 105
-                   &IpNextHeaderProtocols::Qnx => "Qnx", // 106
-                   &IpNextHeaderProtocols::AN => "AN", // 107
-                   &IpNextHeaderProtocols::IpComp => "IpComp", // 108
-                   &IpNextHeaderProtocols::Snp => "Snp", // 109
-                   &IpNextHeaderProtocols::CompaqPeer => "CompaqPeer", // 110
-                   &IpNextHeaderProtocols::IpxInIp => "IpxInIp", // 111
-                   &IpNextHeaderProtocols::Vrrp => "Vrrp", // 112
-                   &IpNextHeaderProtocols::Pgm => "Pgm", // 113
-                   &IpNextHeaderProtocols::ZeroHop => "ZeroHop", // 114
-                   &IpNextHeaderProtocols::L2tp => "L2tp", // 115
-                   &IpNextHeaderProtocols::Ddx => "Ddx", // 116
-                   &IpNextHeaderProtocols::Iatp => "Iatp", // 117
-                   &IpNextHeaderProtocols::Stp => "Stp", // 118
-                   &IpNextHeaderProtocols::Srp => "Srp", // 119
-                   &IpNextHeaderProtocols::Uti => "Uti", // 120
-                   &IpNextHeaderProtocols::Smp => "Smp", // 121
-                   &IpNextHeaderProtocols::Sm => "Sm", // 122
-                   &IpNextHeaderProtocols::Ptp => "Ptp", // 123
-                   &IpNextHeaderProtocols::IsisOverIpv4 => "IsisOverIpv4", // 124
-                   &IpNextHeaderProtocols::Fire => "Fire", // 125
-                   &IpNextHeaderProtocols::Crtp => "Crtp", // 126
-                   &IpNextHeaderProtocols::Crudp => "Crudp", // 127
-                   &IpNextHeaderProtocols::Sscopmce => "Sscopmce", // 128
-                   &IpNextHeaderProtocols::Iplt => "Iplt", // 129
-                   &IpNextHeaderProtocols::Sps => "Sps", // 130
-                   &IpNextHeaderProtocols::Pipe => "Pipe", // 131
-                   &IpNextHeaderProtocols::Sctp => "Sctp", // 132
-                   &IpNextHeaderProtocols::Fc => "Fc", // 133
-                   &IpNextHeaderProtocols::RsvpE2eIgnore => "RsvpE2eIgnore", // 134
-                   &IpNextHeaderProtocols::MobilityHeader => "MobilityHeader", // 135
-                   &IpNextHeaderProtocols::UdpLite => "UdpLite", // 136
-                   &IpNextHeaderProtocols::MplsInIp => "MplsInIp", // 137
-                   &IpNextHeaderProtocols::Manet => "Manet", // 138
-                   &IpNextHeaderProtocols::Hip => "Hip", // 139
-                   &IpNextHeaderProtocols::Shim6 => "Shim6", // 140
-                   &IpNextHeaderProtocols::Wesp => "Wesp", // 141
-                   &IpNextHeaderProtocols::Rohc => "Rohc", // 142
-                   &IpNextHeaderProtocols::Test1 => "Test1", // 253
-                   &IpNextHeaderProtocols::Test2 => "Test2", // 254*/
-                   &IpNextHeaderProtocols::Reserved => "Reserved", // 255
-                   _ => "unknown",
-               })
+        write!(
+            f,
+            "{}",
+            match self {
+                &IpNextHeaderProtocols::Hopopt => "Hopopt",         // 0
+                &IpNextHeaderProtocols::Icmp => "Icmp",             // 1
+                &IpNextHeaderProtocols::Igmp => "Igmp",             // 2
+                &IpNextHeaderProtocols::Ggp => "Ggp",               // 3
+                &IpNextHeaderProtocols::Ipv4 => "Ipv4",             // 4
+                &IpNextHeaderProtocols::St => "St",                 // 5
+                &IpNextHeaderProtocols::Tcp => "Tcp",               // 6
+                &IpNextHeaderProtocols::Cbt => "Cbt",               // 7
+                &IpNextHeaderProtocols::Egp => "Egp",               // 8
+                &IpNextHeaderProtocols::Igp => "Igp",               // 9
+                &IpNextHeaderProtocols::BbnRccMon => "BbnRccMon",   // 10
+                &IpNextHeaderProtocols::NvpII => "NvpII",           // 11
+                &IpNextHeaderProtocols::Pup => "Pup",               // 12
+                &IpNextHeaderProtocols::Argus => "Argus",           // 13
+                &IpNextHeaderProtocols::Emcon => "Emcon",           // 14
+                &IpNextHeaderProtocols::Xnet => "Xnet",             // 15
+                &IpNextHeaderProtocols::Chaos => "Chaos",           // 16
+                &IpNextHeaderProtocols::Udp => "Udp",               // 17
+                &IpNextHeaderProtocols::Mux => "Mux",               // 18
+                &IpNextHeaderProtocols::DcnMeas => "DcnMeas",       // 19
+                &IpNextHeaderProtocols::Hmp => "Hmp",               // 20
+                &IpNextHeaderProtocols::Prm => "Prm",               // 21
+                &IpNextHeaderProtocols::XnsIdp => "XnsIdp",         // 22
+                &IpNextHeaderProtocols::Trunk1 => "Trunk1",         // 23
+                &IpNextHeaderProtocols::Trunk2 => "Trunk2",         // 24
+                &IpNextHeaderProtocols::Leaf1 => "Leaf1",           // 25
+                &IpNextHeaderProtocols::Leaf2 => "Leaf2",           // 26
+                &IpNextHeaderProtocols::Rdp => "Rdp",               // 27
+                &IpNextHeaderProtocols::Irtp => "Irtp",             // 28
+                &IpNextHeaderProtocols::IsoTp4 => "IsoTp4",         // 29
+                &IpNextHeaderProtocols::Netblt => "Netblt",         // 30
+                &IpNextHeaderProtocols::MfeNsp => "MfeNsp",         // 31
+                &IpNextHeaderProtocols::MeritInp => "MeritInp",     // 32
+                &IpNextHeaderProtocols::Dccp => "Dccp",             // 33
+                &IpNextHeaderProtocols::ThreePc => "ThreePc",       // 34
+                &IpNextHeaderProtocols::Idpr => "Idpr",             // 35
+                &IpNextHeaderProtocols::Xtp => "Xtp",               // 36
+                &IpNextHeaderProtocols::Ddp => "Ddp",               // 37
+                &IpNextHeaderProtocols::IdprCmtp => "IdprCmtp",     // 38
+                &IpNextHeaderProtocols::TpPlusPlus => "TpPlusPlus", // 39
+                &IpNextHeaderProtocols::Il => "Il",                 // 40
+                &IpNextHeaderProtocols::Ipv6 => "Ipv6",             // 41
+                &IpNextHeaderProtocols::Sdrp => "Sdrp",             // 42
+                &IpNextHeaderProtocols::Ipv6Route => "Ipv6Route",   // 43
+                &IpNextHeaderProtocols::Ipv6Frag => "Ipv6Frag",     // 44
+                &IpNextHeaderProtocols::Idrp => "Idrp",             // 45
+                &IpNextHeaderProtocols::Rsvp => "Rsvp",             // 46
+                &IpNextHeaderProtocols::Gre => "Gre",               // 47
+                &IpNextHeaderProtocols::Dsr => "Dsr",               // 48
+                &IpNextHeaderProtocols::Bna => "Bna",               // 49
+                &IpNextHeaderProtocols::Esp => "Esp",               // 50
+                &IpNextHeaderProtocols::Ah => "Ah",                 // 51
+                &IpNextHeaderProtocols::INlsp => "INlsp",           // 52
+                &IpNextHeaderProtocols::Swipe => "Swipe",           // 53
+                &IpNextHeaderProtocols::Narp => "Narp",             // 54
+                &IpNextHeaderProtocols::Mobile => "Mobile",         // 55
+                &IpNextHeaderProtocols::Tlsp => "Tlsp",             // 56
+                &IpNextHeaderProtocols::Skip => "Skip",             // 57
+                &IpNextHeaderProtocols::Icmpv6 => "Icmpv6",         // 58
+                &IpNextHeaderProtocols::Ipv6NoNxt => "Ipv6NoNxt",   // 59
+                &IpNextHeaderProtocols::Ipv6Opts => "Ipv6Opts",     // 60
+                &IpNextHeaderProtocols::HostInternal => "HostInternal", // 61
+                &IpNextHeaderProtocols::Cftp => "Cftp",             // 62
+                &IpNextHeaderProtocols::LocalNetwork => "LocalNetwork", // 63
+                &IpNextHeaderProtocols::SatExpak => "SatExpak",     // 64
+                &IpNextHeaderProtocols::Kryptolan => "Kryptolan",   // 65
+                &IpNextHeaderProtocols::Rvd => "Rvd",               // 66
+                &IpNextHeaderProtocols::Ippc => "Ippc",             // 67
+                &IpNextHeaderProtocols::DistributedFs => "DistributedFs", // 68
+                &IpNextHeaderProtocols::SatMon => "SatMon",         // 69
+                &IpNextHeaderProtocols::Visa => "Visa",             // 70
+                &IpNextHeaderProtocols::Ipcv => "Ipcv",             // 71
+                &IpNextHeaderProtocols::Cpnx => "Cpnx",             // 72
+                &IpNextHeaderProtocols::Cphb => "Cphb",             // 73
+                &IpNextHeaderProtocols::Wsn => "Wsn",               // 74
+                &IpNextHeaderProtocols::Pvp => "Pvp",               // 75
+                &IpNextHeaderProtocols::BrSatMon => "BrSatMon",     // 76
+                &IpNextHeaderProtocols::SunNd => "SunNd",           // 77
+                &IpNextHeaderProtocols::WbMon => "WbMon",           // 78
+                &IpNextHeaderProtocols::WbExpak => "WbExpak",       // 79
+                &IpNextHeaderProtocols::IsoIp => "IsoIp",           // 80
+                &IpNextHeaderProtocols::Vmtp => "Vmtp",             // 81
+                &IpNextHeaderProtocols::SecureVmtp => "SecureVmtp", // 82
+                &IpNextHeaderProtocols::Vines => "Vines",           // 83
+                &IpNextHeaderProtocols::TtpOrIptm => "TtpOrIptm",   // 84
+                &IpNextHeaderProtocols::NsfnetIgp => "NsfnetIgp",   // 85
+                &IpNextHeaderProtocols::Dgp => "Dgp",               // 86
+                &IpNextHeaderProtocols::Tcf => "Tcf",               // 87
+                &IpNextHeaderProtocols::Eigrp => "Eigrp",           // 88
+                &IpNextHeaderProtocols::OspfigP => "OspfigP",       // 89
+                &IpNextHeaderProtocols::SpriteRpc => "SpriteRpc",   // 90
+                &IpNextHeaderProtocols::Larp => "Larp",             // 91
+                &IpNextHeaderProtocols::Mtp => "Mtp",               // 92
+                &IpNextHeaderProtocols::Ax25 => "Ax25",             // 93
+                &IpNextHeaderProtocols::IpIp => "IpIp",             // 94
+                &IpNextHeaderProtocols::Micp => "Micp",             // 95
+                &IpNextHeaderProtocols::SccSp => "SccSp",           // 96
+                &IpNextHeaderProtocols::Etherip => "Etherip",       // 97
+                &IpNextHeaderProtocols::Encap => "Encap",           // 98
+                &IpNextHeaderProtocols::PrivEncryption => "PrivEncryption", // 99
+                &IpNextHeaderProtocols::Gmtp => "Gmtp",             // 100
+                &IpNextHeaderProtocols::Ifmp => "Ifmp",             // 101
+                &IpNextHeaderProtocols::Pnni => "Pnni",             // 102
+                &IpNextHeaderProtocols::Pim => "Pim",               // 103
+                &IpNextHeaderProtocols::Aris => "Aris",             // 104
+                &IpNextHeaderProtocols::Scps => "Scps",             // 105
+                &IpNextHeaderProtocols::Qnx => "Qnx",               // 106
+                &IpNextHeaderProtocols::AN => "AN",                 // 107
+                &IpNextHeaderProtocols::IpComp => "IpComp",         // 108
+                &IpNextHeaderProtocols::Snp => "Snp",               // 109
+                &IpNextHeaderProtocols::CompaqPeer => "CompaqPeer", // 110
+                &IpNextHeaderProtocols::IpxInIp => "IpxInIp",       // 111
+                &IpNextHeaderProtocols::Vrrp => "Vrrp",             // 112
+                &IpNextHeaderProtocols::Pgm => "Pgm",               // 113
+                &IpNextHeaderProtocols::ZeroHop => "ZeroHop",       // 114
+                &IpNextHeaderProtocols::L2tp => "L2tp",             // 115
+                &IpNextHeaderProtocols::Ddx => "Ddx",               // 116
+                &IpNextHeaderProtocols::Iatp => "Iatp",             // 117
+                &IpNextHeaderProtocols::Stp => "Stp",               // 118
+                &IpNextHeaderProtocols::Srp => "Srp",               // 119
+                &IpNextHeaderProtocols::Uti => "Uti",               // 120
+                &IpNextHeaderProtocols::Smp => "Smp",               // 121
+                &IpNextHeaderProtocols::Sm => "Sm",                 // 122
+                &IpNextHeaderProtocols::Ptp => "Ptp",               // 123
+                &IpNextHeaderProtocols::IsisOverIpv4 => "IsisOverIpv4", // 124
+                &IpNextHeaderProtocols::Fire => "Fire",             // 125
+                &IpNextHeaderProtocols::Crtp => "Crtp",             // 126
+                &IpNextHeaderProtocols::Crudp => "Crudp",           // 127
+                &IpNextHeaderProtocols::Sscopmce => "Sscopmce",     // 128
+                &IpNextHeaderProtocols::Iplt => "Iplt",             // 129
+                &IpNextHeaderProtocols::Sps => "Sps",               // 130
+                &IpNextHeaderProtocols::Pipe => "Pipe",             // 131
+                &IpNextHeaderProtocols::Sctp => "Sctp",             // 132
+                &IpNextHeaderProtocols::Fc => "Fc",                 // 133
+                &IpNextHeaderProtocols::RsvpE2eIgnore => "RsvpE2eIgnore", // 134
+                &IpNextHeaderProtocols::MobilityHeader => "MobilityHeader", // 135
+                &IpNextHeaderProtocols::UdpLite => "UdpLite",       // 136
+                &IpNextHeaderProtocols::MplsInIp => "MplsInIp",     // 137
+                &IpNextHeaderProtocols::Manet => "Manet",           // 138
+                &IpNextHeaderProtocols::Hip => "Hip",               // 139
+                &IpNextHeaderProtocols::Shim6 => "Shim6",           // 140
+                &IpNextHeaderProtocols::Wesp => "Wesp",             // 141
+                &IpNextHeaderProtocols::Rohc => "Rohc",             // 142
+                &IpNextHeaderProtocols::Test1 => "Test1",           // 253
+                &IpNextHeaderProtocols::Test2 => "Test2",           // 254*/
+                &IpNextHeaderProtocols::Reserved => "Reserved",     // 255
+                _ => "unknown",
+            }
+        )
     }
 }
 

--- a/pnet_packet/src/lib.rs
+++ b/pnet_packet/src/lib.rs
@@ -15,17 +15,16 @@ extern crate pnet_macros_support;
 
 pub use pnet_macros_support::packet::*;
 
+pub mod arp;
 pub mod ethernet;
 pub mod gre;
+pub mod icmp;
+pub mod icmpv6;
 pub mod ip;
 pub mod ipv4;
 pub mod ipv6;
-pub mod udp;
 pub mod tcp;
-pub mod arp;
-pub mod icmp;
-pub mod icmpv6;
+pub mod udp;
 pub mod vlan;
 
 pub mod util;
-

--- a/pnet_sys/src/lib.rs
+++ b/pnet_sys/src/lib.rs
@@ -23,8 +23,6 @@ mod imp;
 
 pub use self::imp::public::*;
 
-
-
 /// Any file descriptor on unix, only sockets on Windows.
 pub struct FileDesc {
     pub fd: CSocket,
@@ -38,12 +36,12 @@ impl Drop for FileDesc {
     }
 }
 
-pub fn send_to(socket: CSocket,
-               buffer: &[u8],
-               dst: *const SockAddr,
-               slen: SockLen)
-    -> io::Result<usize> {
-
+pub fn send_to(
+    socket: CSocket,
+    buffer: &[u8],
+    dst: *const SockAddr,
+    slen: SockLen,
+) -> io::Result<usize> {
     let send_len = imp::retry(&mut || unsafe {
         imp::sendto(
             socket,
@@ -51,7 +49,7 @@ pub fn send_to(socket: CSocket,
             buffer.len() as BufLen,
             0,
             dst,
-            slen
+            slen,
         )
     });
 
@@ -62,10 +60,11 @@ pub fn send_to(socket: CSocket,
     }
 }
 
-pub fn recv_from(socket: CSocket,
-                 buffer: &mut [u8],
-                 caddr: *mut SockAddrStorage)
-    -> io::Result<usize> {
+pub fn recv_from(
+    socket: CSocket,
+    buffer: &mut [u8],
+    caddr: *mut SockAddrStorage,
+) -> io::Result<usize> {
     let mut caddrlen = mem::size_of::<SockAddrStorage>() as SockLen;
     let len = imp::retry(&mut || unsafe {
         imp::recvfrom(
@@ -74,7 +73,7 @@ pub fn recv_from(socket: CSocket,
             buffer.len() as BufLen,
             0,
             caddr as *mut SockAddr,
-            &mut caddrlen
+            &mut caddrlen,
         )
     });
 
@@ -85,23 +84,27 @@ pub fn recv_from(socket: CSocket,
     }
 }
 
-
 /// Set a timeout for receiving from the socket.
 #[cfg(unix)]
-pub fn set_socket_receive_timeout(socket: CSocket, t: Duration)
-    -> io::Result<()> {
+pub fn set_socket_receive_timeout(socket: CSocket, t: Duration) -> io::Result<()> {
     let ts = duration_to_timeval(t);
     let r = unsafe {
-        setsockopt(socket, SOL_SOCKET, SO_RCVTIMEO,
-                   (&ts as *const libc::timeval) as Buf,
-                   mem::size_of::<libc::timeval>() as SockLen
+        setsockopt(
+            socket,
+            SOL_SOCKET,
+            SO_RCVTIMEO,
+            (&ts as *const libc::timeval) as Buf,
+            mem::size_of::<libc::timeval>() as SockLen,
         )
     };
 
     if r < 0 {
-        Err(io::Error::last_os_error()) 
+        Err(io::Error::last_os_error())
     } else if r > 0 {
-        Err(io::Error::new(io::ErrorKind::Other, format!("Unknown return value from getsockopt(): {}", r)))
+        Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("Unknown return value from getsockopt(): {}", r),
+        ))
     } else {
         Ok(())
     }
@@ -109,28 +112,38 @@ pub fn set_socket_receive_timeout(socket: CSocket, t: Duration)
 
 /// Extracts and returns a timout for reading from the socket.
 #[cfg(unix)]
-pub fn get_socket_receive_timeout(socket: CSocket)
-    -> io::Result<Duration> {
-    let ts = libc::timeval { tv_sec: 0, tv_usec: 0 };
-    let len : SockLen = mem::size_of::<libc::timeval>() as SockLen;
-    let r = unsafe{
-        getsockopt(socket, SOL_SOCKET, SO_RCVTIMEO,
-                   (&ts as *const libc::timeval) as MutBuf,
-                   (&len as *const SockLen) as MutSockLen
+pub fn get_socket_receive_timeout(socket: CSocket) -> io::Result<Duration> {
+    let ts = libc::timeval {
+        tv_sec: 0,
+        tv_usec: 0,
+    };
+    let len: SockLen = mem::size_of::<libc::timeval>() as SockLen;
+    let r = unsafe {
+        getsockopt(
+            socket,
+            SOL_SOCKET,
+            SO_RCVTIMEO,
+            (&ts as *const libc::timeval) as MutBuf,
+            (&len as *const SockLen) as MutSockLen,
         )
     };
-    assert_eq!(len, mem::size_of::<libc::timeval>() as SockLen, "getsockopt did not set size of return value");
-    
+    assert_eq!(
+        len,
+        mem::size_of::<libc::timeval>() as SockLen,
+        "getsockopt did not set size of return value"
+    );
+
     if r < 0 {
-        Err(io::Error::last_os_error()) 
+        Err(io::Error::last_os_error())
     } else if r > 0 {
-        Err(io::Error::new(io::ErrorKind::Other, format!("Unknown return value from getsockopt(): {}", r)))
+        Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("Unknown return value from getsockopt(): {}", r),
+        ))
     } else {
         Ok(timeval_to_duration(ts))
     }
 }
-
-
 
 // These functions are taken/adapted from libnative::io::{mod, net}
 
@@ -144,30 +157,32 @@ fn ntohs(u: u16) -> u16 {
 fn make_in6_addr(segments: [u16; 8]) -> In6Addr {
     let mut val: In6Addr = unsafe { mem::MaybeUninit::<In6Addr>::uninit().assume_init() };
     val.s6_addr = unsafe {
-        mem::transmute([htons(segments[0]),
-                        htons(segments[1]),
-                        htons(segments[2]),
-                        htons(segments[3]),
-                        htons(segments[4]),
-                        htons(segments[5]),
-                        htons(segments[6]),
-                        htons(segments[7])])
+        mem::transmute([
+            htons(segments[0]),
+            htons(segments[1]),
+            htons(segments[2]),
+            htons(segments[3]),
+            htons(segments[4]),
+            htons(segments[5]),
+            htons(segments[6]),
+            htons(segments[7]),
+        ])
     };
     val
 }
 
-pub fn addr_to_sockaddr(addr: SocketAddr,
-                        storage: &mut SockAddrStorage)
-    -> SockLen {
+pub fn addr_to_sockaddr(addr: SocketAddr, storage: &mut SockAddrStorage) -> SockLen {
     unsafe {
         let len = match addr {
             SocketAddr::V4(sa) => {
                 let ip_addr = sa.ip();
                 let octets = ip_addr.octets();
-                let inaddr = imp::mk_inaddr(u32::from_be(((octets[0] as u32) << 24) |
-                                                             ((octets[1] as u32) << 16) |
-                                                             ((octets[2] as u32) << 8) |
-                                                             (octets[3] as u32)));
+                let inaddr = imp::mk_inaddr(u32::from_be(
+                    ((octets[0] as u32) << 24)
+                        | ((octets[1] as u32) << 16)
+                        | ((octets[2] as u32) << 8)
+                        | (octets[3] as u32),
+                ));
                 let storage = storage as *mut _ as *mut SockAddrIn;
                 (*storage).sin_family = AF_INET as SockAddrFamily;
                 (*storage).sin_port = htons(addr.port());
@@ -217,28 +232,33 @@ pub fn sockaddr_to_addr(storage: &SockAddrStorage, len: usize) -> io::Result<Soc
             let g = ntohs(arr[6]);
             let h = ntohs(arr[7]);
             let ip = Ipv6Addr::new(a, b, c, d, e, f, g, h);
-            Ok(SocketAddr::V6(SocketAddrV6::new(ip,
-                                                ntohs(storage.sin6_port),
-                                                u32::from_be(storage.sin6_flowinfo),
-                                                storage.sin6_scope_id)))
+            Ok(SocketAddr::V6(SocketAddrV6::new(
+                ip,
+                ntohs(storage.sin6_port),
+                u32::from_be(storage.sin6_flowinfo),
+                storage.sin6_scope_id,
+            )))
         }
-        _ => Err(io::Error::new(io::ErrorKind::InvalidData, "expected IPv4 or IPv6 socket")),
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "expected IPv4 or IPv6 socket",
+        )),
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::mem;
-    use std::time::{Duration,Instant};
-    use set_socket_receive_timeout;
     use get_socket_receive_timeout;
     use recv_from;
+    use set_socket_receive_timeout;
+    use std::mem;
+    use std::time::{Duration, Instant};
     use CSocket;
     use SockAddrStorage;
 
     fn test_timeout(socket: CSocket) -> Duration {
         let mut buffer = [0u8; 1024];
-        let mut caddr :SockAddrStorage = unsafe { mem::zeroed() };
+        let mut caddr: SockAddrStorage = unsafe { mem::zeroed() };
 
         let t0 = Instant::now();
         let res = recv_from(socket, &mut buffer, &mut caddr);
@@ -249,7 +269,7 @@ mod tests {
     #[test]
     fn test_set_socket_receive_timeout_1s() {
         let socket = unsafe { libc::socket(libc::AF_INET, libc::SOCK_RAW, 1 as libc::c_int) };
-        let d = Duration::new(1,0);
+        let d = Duration::new(1, 0);
         let res = set_socket_receive_timeout(socket, d.clone());
         match res {
             Err(e) => panic!("set_socket_receive_timeout reslted in error: {}", e),
@@ -257,7 +277,7 @@ mod tests {
         };
 
         let t = test_timeout(socket);
-        assert!(t >= Duration::new(1,0));
+        assert!(t >= Duration::new(1, 0));
         assert!(t < Duration::from_millis(1100));
     }
 
@@ -299,7 +319,7 @@ mod tests {
         let g1 = get_socket_receive_timeout(socket);
         match g1 {
             Err(e) => panic!("get_socket_receive_timeout resulted in error: {}", e),
-            Ok(t) => assert_eq!(s1, t, "Expected to receive 1s timeout")
+            Ok(t) => assert_eq!(s1, t, "Expected to receive 1s timeout"),
         }
 
         let s2 = Duration::from_millis(500);
@@ -307,9 +327,7 @@ mod tests {
         let g2 = get_socket_receive_timeout(socket);
         match g2 {
             Err(e) => panic!("get_socket_receive_timeout resulted in error: {}", e),
-            Ok(t) => assert_eq!(s2, t, "Expected to receive 500ms timeout")
+            Ok(t) => assert_eq!(s2, t, "Expected to receive 500ms timeout"),
         }
     }
 }
-
-

--- a/pnet_sys/src/unix.rs
+++ b/pnet_sys/src/unix.rs
@@ -38,10 +38,9 @@ pub mod public {
     pub const IP_HDRINCL: libc::c_int = libc::IP_HDRINCL;
     pub const IP_TTL: libc::c_int = libc::IP_TTL;
 
-    pub use libc::{IFF_UP, IFF_BROADCAST, IFF_LOOPBACK, IFF_POINTOPOINT, IFF_MULTICAST};
+    pub use libc::{IFF_BROADCAST, IFF_LOOPBACK, IFF_MULTICAST, IFF_POINTOPOINT, IFF_UP};
 
     pub const INVALID_SOCKET: CSocket = -1;
-
 
     pub unsafe fn close(sock: CSocket) {
         let _ = libc::close(sock);
@@ -51,21 +50,23 @@ pub mod public {
         libc::socket(af, sock, proto)
     }
 
-    pub unsafe fn getsockopt(socket: CSocket,
-                            level: libc::c_int,
-                            name: libc::c_int,
-                            value: MutBuf,
-                            option_len: MutSockLen)
-        -> libc::c_int {
+    pub unsafe fn getsockopt(
+        socket: CSocket,
+        level: libc::c_int,
+        name: libc::c_int,
+        value: MutBuf,
+        option_len: MutSockLen,
+    ) -> libc::c_int {
         libc::getsockopt(socket, level, name, value, option_len)
     }
 
-    pub unsafe fn setsockopt(socket: CSocket,
-                            level: libc::c_int,
-                            name: libc::c_int,
-                            value: Buf,
-                            option_len: SockLen)
-        -> libc::c_int {
+    pub unsafe fn setsockopt(
+        socket: CSocket,
+        level: libc::c_int,
+        name: libc::c_int,
+        value: Buf,
+        option_len: SockLen,
+    ) -> libc::c_int {
         libc::setsockopt(socket, level, name, value, option_len)
     }
 
@@ -78,7 +79,7 @@ pub mod public {
     pub fn duration_to_timeval(dur: Duration) -> libc::timeval {
         libc::timeval {
             tv_sec: dur.as_secs() as libc::time_t,
-            tv_usec: dur.subsec_micros() as TvUsecType
+            tv_usec: dur.subsec_micros() as TvUsecType,
         }
     }
 
@@ -91,10 +92,9 @@ pub mod public {
     pub fn duration_to_timespec(dur: Duration) -> libc::timespec {
         libc::timespec {
             tv_sec: dur.as_secs() as libc::time_t,
-            tv_nsec: (dur.subsec_nanos() as TvUsecType).into()
+            tv_nsec: (dur.subsec_nanos() as TvUsecType).into(),
         }
     }
-
 }
 
 use self::public::*;
@@ -109,31 +109,32 @@ pub fn mk_inaddr(addr: u32) -> InAddr {
     InAddr { s_addr: addr }
 }
 
-
-pub unsafe fn sendto(socket: CSocket,
-                     buf: Buf,
-                     len: BufLen,
-                     flags: libc::c_int,
-                     addr: *const SockAddr,
-                     addrlen: SockLen)
-    -> CouldFail {
+pub unsafe fn sendto(
+    socket: CSocket,
+    buf: Buf,
+    len: BufLen,
+    flags: libc::c_int,
+    addr: *const SockAddr,
+    addrlen: SockLen,
+) -> CouldFail {
     libc::sendto(socket, buf, len, flags, addr, addrlen)
 }
 
-pub unsafe fn recvfrom(socket: CSocket,
-                       buf: MutBuf,
-                       len: BufLen,
-                       flags: libc::c_int,
-                       addr: *mut SockAddr,
-                       addrlen: *mut SockLen)
-    -> CouldFail {
+pub unsafe fn recvfrom(
+    socket: CSocket,
+    buf: MutBuf,
+    len: BufLen,
+    flags: libc::c_int,
+    addr: *mut SockAddr,
+    addrlen: *mut SockLen,
+) -> CouldFail {
     libc::recvfrom(socket, buf, len, flags, addr, addrlen)
 }
 
-
 #[inline]
 pub fn retry<F>(f: &mut F) -> libc::ssize_t
-    where F: FnMut() -> libc::ssize_t
+where
+    F: FnMut() -> libc::ssize_t,
 {
     loop {
         let ret = f();
@@ -147,17 +148,14 @@ fn errno() -> i32 {
     io::Error::last_os_error().raw_os_error().unwrap()
 }
 
-
-
-
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
     use duration_to_timespec;
+    use std::time::Duration;
     use timespec_to_duration;
 
     #[test]
-    fn test_duration_to_timespec(){
+    fn test_duration_to_timespec() {
         let d1 = Duration::new(1, 0);
         let d2 = Duration::from_millis(500);
 

--- a/pnet_sys/src/windows.rs
+++ b/pnet_sys/src/windows.rs
@@ -5,9 +5,9 @@ use libc;
 use std::io;
 
 pub mod public {
-    use libc;
     use super::winapi;
     use super::ws2_32;
+    use libc;
 
     pub type CSocket = winapi::SOCKET;
     pub type Buf = *const libc::c_char;
@@ -42,7 +42,6 @@ pub mod public {
 
     pub const INVALID_SOCKET: CSocket = winapi::INVALID_SOCKET;
 
-
     pub unsafe fn close(sock: CSocket) {
         let _ = ws2_32::closesocket(sock);
     }
@@ -51,24 +50,25 @@ pub mod public {
         ws2_32::socket(af, sock, proto)
     }
 
-    pub unsafe fn setsockopt(socket: CSocket,
-                            level: libc::c_int,
-                            name: libc::c_int,
-                            value: Buf,
-                            option_len: SockLen)
-        -> libc::c_int {
+    pub unsafe fn setsockopt(
+        socket: CSocket,
+        level: libc::c_int,
+        name: libc::c_int,
+        value: Buf,
+        option_len: SockLen,
+    ) -> libc::c_int {
         ws2_32::setsockopt(socket, level, name, value, option_len)
     }
 
-    pub unsafe fn getsockopt(socket: CSocket,
-                            level: libc::c_int,
-                            name: libc::c_int,
-                            value: MutBuf,
-                            option_len: MutSockLen)
-        -> libc::c_int {
+    pub unsafe fn getsockopt(
+        socket: CSocket,
+        level: libc::c_int,
+        name: libc::c_int,
+        value: MutBuf,
+        option_len: MutSockLen,
+    ) -> libc::c_int {
         ws2_32::getsockopt(socket, level, name, value, option_len)
     }
-
 }
 
 use self::public::*;
@@ -80,34 +80,37 @@ pub fn ipv4_addr(addr: InAddr) -> u32 {
 
 #[inline(always)]
 pub fn mk_inaddr(addr: u32) -> InAddr {
-    InAddr { S_un: addr as winapi::ULONG }
+    InAddr {
+        S_un: addr as winapi::ULONG,
+    }
 }
 
-
-pub unsafe fn sendto(socket: CSocket,
-                     buf: Buf,
-                     len: BufLen,
-                     flags: libc::c_int,
-                     to: *const SockAddr,
-                     tolen: SockLen)
-    -> CouldFail {
+pub unsafe fn sendto(
+    socket: CSocket,
+    buf: Buf,
+    len: BufLen,
+    flags: libc::c_int,
+    to: *const SockAddr,
+    tolen: SockLen,
+) -> CouldFail {
     ws2_32::sendto(socket, buf, len, flags, to, tolen)
 }
 
-pub unsafe fn recvfrom(socket: CSocket,
-                       buf: MutBuf,
-                       len: BufLen,
-                       flags: libc::c_int,
-                       addr: *mut SockAddr,
-                       addrlen: *mut SockLen)
-    -> CouldFail {
+pub unsafe fn recvfrom(
+    socket: CSocket,
+    buf: MutBuf,
+    len: BufLen,
+    flags: libc::c_int,
+    addr: *mut SockAddr,
+    addrlen: *mut SockLen,
+) -> CouldFail {
     ws2_32::recvfrom(socket, buf, len, flags, addr, addrlen)
 }
 
-
 #[inline]
 pub fn retry<F>(f: &mut F) -> libc::c_int
-    where F: FnMut() -> libc::c_int
+where
+    F: FnMut() -> libc::c_int,
 {
     loop {
         let ret = f();
@@ -116,7 +119,6 @@ pub fn retry<F>(f: &mut F) -> libc::c_int
         }
     }
 }
-
 
 fn errno() -> i32 {
     io::Error::last_os_error().raw_os_error().unwrap()

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,2 @@
-required_version = "0.6.1"
 reorder_imports = true
-format_strings = false
+edition = "2018"

--- a/src/pnettest.rs
+++ b/src/pnettest.rs
@@ -111,7 +111,8 @@ fn build_udp4_packet(
     packet[data_start + 3] = msg[3];
 
     let (source, dest) = if let Some(ni) = ni {
-        let ipmask = ni.ips
+        let ipmask = ni
+            .ips
             .iter()
             .filter(|addr| is_ipv4(&addr.ip()))
             .next()
@@ -238,7 +239,10 @@ fn layer4_ipv4() {
 
 // travis does not currently support IPv6
 #[test]
-#[cfg(all(not(feature = "appveyor"), not(all(target_os = "linux", feature = "travis"))))]
+#[cfg(all(
+    not(feature = "appveyor"),
+    not(all(target_os = "linux", feature = "travis"))
+))]
 fn layer4_ipv6() {
     layer4(IpAddr::V6(ipv6_source()), IPV6_HEADER_LEN);
 }
@@ -273,7 +277,8 @@ fn layer3_ipv4() {
                     check_ipv4_header(&packet[..], &header);
                     let udp_header = UdpPacket::new(
                         &header.packet()[(header.get_header_length() as usize * 4usize)..],
-                    ).unwrap();
+                    )
+                    .unwrap();
                     assert_eq!(
                         udp_header,
                         UdpPacket::new(&packet[IPV4_HEADER_LEN..]).unwrap()


### PR DESCRIPTION
Update rustfmt.toml to have only `reorder_imports=true` and `edition="2018"`.
Apply it with `cargo fmt --all`.