### PR TITLE
deprecate mac_address() since it uses unwrap().

### DIFF
--- a/pnet_datalink/src/lib.rs
+++ b/pnet_datalink/src/lib.rs
@@ -223,6 +223,10 @@ pub struct NetworkInterface {
 
 impl NetworkInterface {
     /// Retrieve the MAC address associated with the interface.
+    #[deprecated(
+        since = "0.26.0",
+        note = "Please use NetworkInterface's field 'mac' instead."
+    )]
     pub fn mac_address(&self) -> MacAddr {
         self.mac.unwrap()
     }


### PR DESCRIPTION
Suggest to use NetworkInterface's mac field instead.