### PR TITLE
Enable pnet to build on Apple iOS target

### DIFF
--- a/examples/packetdump.rs
+++ b/examples/packetdump.rs
@@ -249,7 +249,7 @@ fn main() {
         match rx.next() {
             Ok(packet) => {
                 let payload_offset;
-                if cfg!(target_os = "macos")
+                if cfg!(any(target_os = "macos", target_os = "ios"))
                     && interface.is_up()
                     && !interface.is_broadcast()
                     && ((!interface.is_loopback() && interface.is_point_to_point())

--- a/pnet_datalink/src/bindings/bpf.rs
+++ b/pnet_datalink/src/bindings/bpf.rs
@@ -55,7 +55,7 @@ pub const DLT_NULL: libc::c_uint = 0;
 
 #[cfg(target_os = "freebsd")]
 const BPF_ALIGNMENT: libc::c_int = SIZEOF_C_LONG;
-#[cfg(any(target_os = "openbsd", target_os = "macos", windows))]
+#[cfg(any(target_os = "openbsd", target_os = "macos", target_os = "ios", windows))]
 const BPF_ALIGNMENT: libc::c_int = 4;
 
 pub fn BPF_WORDALIGN(x: isize) -> isize {
@@ -73,7 +73,7 @@ pub struct ifreq {
 // sdl_data does not match if_dl.h on OS X, since the size of 12 is a minimum.
 // Will be unsafe
 // when sdl_nlen > 40.
-#[cfg(any(target_os = "openbsd", target_os = "freebsd", target_os = "macos"))]
+#[cfg(any(target_os = "openbsd", target_os = "freebsd", target_os = "macos", target_os = "ios"))]
 pub struct sockaddr_dl {
     pub sdl_len: libc::c_uchar,
     pub sdl_family: libc::c_uchar,
@@ -88,7 +88,7 @@ pub struct sockaddr_dl {
 // See man 4 bpf or /usr/include/net/bpf.h [windows: or Common/Packet32.h]
 #[cfg(any(
     target_os = "freebsd",
-    all(target_os = "macos", target_pointer_width = "32"),
+    all(any(target_os = "macos", target_os = "ios"), target_pointer_width = "32"),
     windows
 ))]
 pub struct bpf_hdr {
@@ -105,7 +105,7 @@ pub struct timeval32 {
 
 #[cfg(any(
     target_os = "openbsd",
-    all(target_os = "macos", target_pointer_width = "64")
+    all(any(target_os = "macos", target_os = "ios"), target_pointer_width = "64")
 ))]
 pub struct bpf_hdr {
     pub bh_tstamp: timeval32,

--- a/pnet_datalink/src/bindings/mod.rs
+++ b/pnet_datalink/src/bindings/mod.rs
@@ -10,6 +10,7 @@
     target_os = "freebsd",
     target_os = "openbsd",
     target_os = "macos",
+    target_os = "ios",
     windows
 ))]
 pub mod bpf;

--- a/pnet_datalink/src/bpf.rs
+++ b/pnet_datalink/src/bpf.rs
@@ -88,7 +88,7 @@ pub fn channel(network_interface: &NetworkInterface, config: Config) -> io::Resu
         }
     }
 
-    #[cfg(any(target_os = "openbsd", target_os = "macos"))]
+    #[cfg(any(target_os = "openbsd", target_os = "macos", target_os = "ios"))]
     fn get_fd(attempts: usize) -> libc::c_int {
         for i in 0..attempts {
             let fd = unsafe {
@@ -119,7 +119,7 @@ pub fn channel(network_interface: &NetworkInterface, config: Config) -> io::Resu
         Ok(())
     }
 
-    #[cfg(any(target_os = "macos", target_os = "openbsd"))]
+    #[cfg(any(target_os = "macos", target_os = "openbsd", target_os = "ios"))]
     fn set_feedback(_fd: libc::c_int) -> io::Result<()> {
         Ok(())
     }

--- a/pnet_datalink/src/lib.rs
+++ b/pnet_datalink/src/lib.rs
@@ -42,12 +42,12 @@ pub mod linux;
 
 #[cfg(all(
     not(feature = "netmap"),
-    any(target_os = "freebsd", target_os = "openbsd", target_os = "macos")
+    any(target_os = "freebsd", target_os = "openbsd", target_os = "macos", target_os = "ios")
 ))]
 #[path = "bpf.rs"]
 mod backend;
 
-#[cfg(any(target_os = "freebsd", target_os = "macos"))]
+#[cfg(any(target_os = "freebsd", target_os = "macos", target_os = "ios"))]
 pub mod bpf;
 
 #[cfg(feature = "netmap")]

--- a/pnet_datalink/src/unix_interfaces.rs
+++ b/pnet_datalink/src/unix_interfaces.rs
@@ -116,7 +116,7 @@ fn sockaddr_to_network_addr(sa: *const libc::sockaddr) -> (Option<MacAddr>, Opti
     }
 }
 
-#[cfg(any(target_os = "openbsd", target_os = "freebsd", target_os = "macos"))]
+#[cfg(any(target_os = "openbsd", target_os = "freebsd", target_os = "macos", target_os = "ios"))]
 fn sockaddr_to_network_addr(sa: *const libc::sockaddr) -> (Option<MacAddr>, Option<IpAddr>) {
     use bindings::bpf;
     use std::net::SocketAddr;

--- a/pnet_transport/src/lib.rs
+++ b/pnet_transport/src/lib.rs
@@ -218,12 +218,12 @@ impl TransportSender {
         set_socket_ttl(self.socket.clone(), time_to_live)
     }
 
-    #[cfg(all(not(target_os = "freebsd"), not(target_os = "macos")))]
+    #[cfg(all(not(target_os = "freebsd"), not(any(target_os = "macos", target_os = "ios"))))]
     fn send_to_impl<T: Packet>(&mut self, packet: T, dst: IpAddr) -> io::Result<usize> {
         self.send(packet, dst)
     }
 
-    #[cfg(any(target_os = "freebsd", target_os = "macos"))]
+    #[cfg(any(target_os = "freebsd", target_os = "macos", target_os = "ios"))]
     fn send_to_impl<T: Packet>(&mut self, packet: T, dst: IpAddr) -> io::Result<usize> {
         use pnet_packet::ipv4::MutableIpv4Packet;
         use pnet_packet::MutablePacket;
@@ -322,7 +322,7 @@ macro_rules! transport_channel_iterator {
                     Err(e) => Err(e),
                 };
 
-                #[cfg(any(target_os = "freebsd", target_os = "macos"))]
+                #[cfg(any(target_os = "freebsd", target_os = "macos", target_os = "ios"))]
                 fn fixup_packet(buffer: &mut [u8]) {
                     use pnet_packet::ipv4::MutableIpv4Packet;
 
@@ -344,7 +344,7 @@ macro_rules! transport_channel_iterator {
                     new_packet.set_fragment_offset(offset);
                 }
 
-                #[cfg(all(not(target_os = "freebsd"), not(target_os = "macos")))]
+                #[cfg(all(not(target_os = "freebsd"), not(any(target_os = "macos", target_os = "ios"))))]
                 fn fixup_packet(_buffer: &mut [u8]) {}
             }
 


### PR DESCRIPTION
Right now there are various mods that go undefined since it doesn't match any of the existing `target_os` types.

Solution: treat it as equivalent to `macos` in all cases.

Really I'm only using `datalink::interfaces()` but that much is working fine on my iPad.