### PR TITLE
Enable promiscuous capture for pcap

### DIFF
--- a/pnet_datalink/src/pcap.rs
+++ b/pnet_datalink/src/pcap.rs
@@ -63,6 +63,8 @@ pub fn channel(network_interface: &NetworkInterface, config: Config) -> io::Resu
         Some(to) => cap.timeout((to.as_secs() * 1000 + (to.subsec_nanos() / 1000) as u64) as i32),
         None => cap,
     };
+    // Enable promiscuous capture
+    let cap = cap.promisc(true);
     let cap = match cap.open() {
         Ok(cap) => cap,
         Err(e) => return Err(io::Error::new(io::ErrorKind::Other, e)),


### PR DESCRIPTION
Promiscuous mode is activated (not configurable) in the native unix implementation of libpnet, but disabled when using pcap.
I think it would be better to unify behaviour for all platforms/implementations. The easiest way is to activate promiscuous mode in pcap, which done in this pull request.
A more advanced step would be to make it configurable, e.g. via the config object. While I think the former makes sense in any case I'd like to know what others think about the latter.