### PR TITLE
Fix calculation of pcap read timeout

### DIFF
--- a/pnet_datalink/src/pcap.rs
+++ b/pnet_datalink/src/pcap.rs
@@ -59,8 +59,11 @@ pub fn channel(network_interface: &NetworkInterface, config: Config) -> io::Resu
         Err(e) => return Err(io::Error::new(io::ErrorKind::Other, e)),
     }
     .buffer_size(config.read_buffer_size as i32);
+    // Set pcap timeout (in milliseconds).
+    // For conversion .as_millis() method could be used as well, but might have
+    // a small performance impact as it uses u128 as return type
     let cap = match config.read_timeout {
-        Some(to) => cap.timeout((to.as_secs() * 1000 + (to.subsec_nanos() / 1000) as u64) as i32),
+        Some(to) => cap.timeout((to.as_secs() as u32 * 1000 + to.subsec_millis()) as i32),
         None => cap,
     };
     // Enable promiscuous capture


### PR DESCRIPTION
Calculation of pcap timeout is faulty at the moment (as_subsec_nanos / 1000 yields microseconds, not milliseconds as intended). 
This is fixed in this pull request and as_subsec_nanos is replaced with as_subsec_millis method (which didn't exist back then).
As of rust 1.33, an as_millis method exists as well, but it returns u128, so it might have a small performance impact (though we haven't tested it)