### PR TITLE
Re-add serde support to NetworkInterface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ netmap = ["pnet_datalink/netmap_sys", "pnet_datalink/netmap"]
 pcap = ["pnet_datalink/pcap"]
 appveyor = []
 travis = []
-serde = ["pnet_base/serde"]
+serde = ["pnet_base/serde", "pnet_datalink/serde"]
 
 [dependencies]
 ipnetwork = "0.16.0"

--- a/pnet_datalink/Cargo.toml
+++ b/pnet_datalink/Cargo.toml
@@ -22,5 +22,11 @@ pnet_sys = { path = "../pnet_sys", version = "0.26.0" }
 pcap = { version = "0.7", optional = true }
 netmap_sys = { version = ">=0.0", optional = true, features = ["netmap_with_libs"] }
 
+
+serde = { version = "~1", optional = true, default-features = false }
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.8"
+
+[package.metadata.docs.rs]
+# Enable the serde feature when generating docs on docs.rs, so the traits are visible
+features = ["serde"]

--- a/pnet_datalink/Cargo.toml
+++ b/pnet_datalink/Cargo.toml
@@ -21,9 +21,8 @@ pnet_sys = { path = "../pnet_sys", version = "0.26.0" }
 
 pcap = { version = "0.7", optional = true }
 netmap_sys = { version = ">=0.0", optional = true, features = ["netmap_with_libs"] }
+serde = { version = "~1", optional = true, default-features = false, features = [ "derive" ] }
 
-
-serde = { version = "~1", optional = true, default-features = false }
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.8"
 

--- a/pnet_datalink/src/lib.rs
+++ b/pnet_datalink/src/lib.rs
@@ -13,6 +13,11 @@ extern crate libc;
 extern crate pnet_base;
 extern crate pnet_sys;
 
+#[cfg(feature = "serde")]
+extern crate serde;
+#[cfg(feature = "serde")]
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+
 use std::io;
 use std::option::Option;
 use std::time::Duration;
@@ -210,6 +215,7 @@ pub trait DataLinkReceiver: Send {
 }
 
 /// Represents a network interface and its associated addresses.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub struct NetworkInterface {
     /// The name of the interface.

--- a/pnet_datalink/src/lib.rs
+++ b/pnet_datalink/src/lib.rs
@@ -16,7 +16,7 @@ extern crate pnet_sys;
 #[cfg(feature = "serde")]
 extern crate serde;
 #[cfg(feature = "serde")]
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 
 use std::io;
 use std::option::Option;


### PR DESCRIPTION
In #255, the ipnetwork crate was added.
IpNetwork did not yet support Serde, so (de)serialization support using such had to be removed.

As of https://github.com/achanda/ipnetwork/commit/c9e25e15fa0d0be3060bed2e38a86d5717d9c76b, IpNetwork includes feature-gated serde support

This snippet did not function prior to my changes, but seems to function
fine after re-implementing serde support for IpNetwork

```rust
pub fn get_network_interfaces() -> anyhow::Result<Value> {
    let raw_interfaces: Vec<NetworkInterface> = interfaces();
    Ok(json!(raw_interfaces))
}
```
Result:
```json
[{"flags":65609,"index":1,"ips":["127.0.0.1/8","::1/128"],"mac":"00:00:00:00:00:00","name":"lo"},{"flags":69699,"index":2,"ips":["10.10.0.211/24","fe80::a9d:7071:53a:3da1/64"],"mac":"08:62:66:45:70:18","name":"eno1"},{"flags":4099,"index":3,"ips":["172.17.0.1/16"],"mac":"02:42:91:88:fa:1e","name":"docker0"}]
```

I understand there was question as to whether this feature was useful, but it seems appropriate to enable it in this case, especially since it is now supported upstream, and requires minimal effort in terms of maintenance for this repository (as far as I understand).