### PR TITLE
Fix pnet_datalink tests

### DIFF
--- a/pnet_datalink/src/dummy.rs
+++ b/pnet_datalink/src/dummy.rs
@@ -300,8 +300,8 @@ mod tests {
     fn create_net() -> (
         Sender<io::Result<Box<[u8]>>>,
         Receiver<Box<[u8]>>,
-        Box<DataLinkSender>,
-        Box<DataLinkReceiver>,
+        Box<dyn DataLinkSender>,
+        Box<dyn DataLinkReceiver>,
     ) {
         let interface = super::dummy_interface(56);
         let mut config = super::Config::default();

--- a/pnet_datalink/src/lib.rs
+++ b/pnet_datalink/src/lib.rs
@@ -327,7 +327,7 @@ impl ::std::fmt::Display for NetworkInterface {
 /// // up, not loopback and has an IP.
 /// let default_interface = all_interfaces
 ///     .iter()
-///     .find(|e| e.is_up() && !e.is_loopback() && !e.ips.is_empty();
+///     .find(|e| e.is_up() && !e.is_loopback() && !e.ips.is_empty());
 ///
 /// match default_interface {
 ///     Some(interface) => println!("Found default interface with [{}].", interface.name),


### PR DESCRIPTION
There was a doc-test compilation failure in pnet_datalink and two deprecation warnings in a function exclusive to tests...

Thanks!