### PR TITLE
Add #[repr(C)] for struct bpf_hdr.

### DIFF
--- a/pnet_datalink/src/bindings/bpf.rs
+++ b/pnet_datalink/src/bindings/bpf.rs
@@ -108,6 +108,7 @@ pub struct timeval32 {
     target_os = "openbsd",
     all(any(target_os = "macos", target_os = "ios"), target_pointer_width = "64")
 ))]
+#[repr(C)]
 pub struct bpf_hdr {
     pub bh_tstamp: timeval32,
     pub bh_caplen: u32,

--- a/pnet_datalink/src/bindings/bpf.rs
+++ b/pnet_datalink/src/bindings/bpf.rs
@@ -91,6 +91,7 @@ pub struct sockaddr_dl {
     all(any(target_os = "macos", target_os = "ios"), target_pointer_width = "32"),
     windows
 ))]
+#[repr(C)]
 pub struct bpf_hdr {
     pub bh_tstamp: libc::timeval,
     pub bh_caplen: u32,


### PR DESCRIPTION
This is a fix for #465 `struct bpf_hdr in pnet_datalink/src/bindings/bpf.rs needs #[repr(C)].`
