### PR TITLE
Add setting IPv6 TTL with set_socket_ttl()

### DIFF
--- a/pnet_sys/src/unix.rs
+++ b/pnet_sys/src/unix.rs
@@ -45,6 +45,9 @@ pub mod public {
     pub const IP_HDRINCL: libc::c_int = libc::IP_HDRINCL;
     pub const IP_TTL: libc::c_int = libc::IP_TTL;
 
+    pub const IPPROTO_IPV6: libc::c_int = libc::IPPROTO_IPV6;
+    pub const IPV6_UNICAST_HOPS: libc::c_int = libc::IPV6_UNICAST_HOPS;
+
     pub use super::libc::{IFF_BROADCAST, IFF_LOOPBACK, IFF_MULTICAST, IFF_POINTOPOINT, IFF_UP};
 
     pub const INVALID_SOCKET: CSocket = -1;

--- a/pnet_sys/src/windows.rs
+++ b/pnet_sys/src/windows.rs
@@ -41,6 +41,9 @@ pub mod public {
     pub const IP_HDRINCL: ctypes::c_int = ws2ipdef::IP_HDRINCL;
     pub const IP_TTL: ctypes::c_int = ws2ipdef::IP_TTL;
 
+    pub const IPPROTO_IPV6: ctypes::c_int = ws2def::IPPROTO_IPV6 as ctypes::c_int;
+    pub const IPV6_UNICAST_HOPS: ctypes::c_int = ws2ipdef::IPV6_UNICAST_HOPS;
+
     pub const IFF_UP: ctypes::c_int = 0x00000001;
     pub const IFF_BROADCAST: ctypes::c_int = 0x00000002;
     pub const IFF_LOOPBACK: ctypes::c_int = 0x00000004;


### PR DESCRIPTION
Allow the set_socket_ttl() function to handle setting the TTL for both
IPv4 and IPv6.  For IPv6 the parameter is the "hop limit", but serves
the same purpose as TTL.

Signed-off-by: Curt Brune <curt@brune.net>