### PR TITLE
pnet_packet: switch tests to trybuild

### DIFF
--- a/pnet_macros/Cargo.toml
+++ b/pnet_macros/Cargo.toml
@@ -19,8 +19,8 @@ default = []
 travis = []
 
 [dev-dependencies]
-compiletest_rs = "0.6"
 pnet_macros_support = { path = "../pnet_macros_support", version = "0.27.2" }
+trybuild = "1.0"
 
 [dependencies]
 proc-macro2 = "1.0"

--- a/pnet_macros/tests/compile-fail/construct-with-errors.stderr
+++ b/pnet_macros/tests/compile-fail/construct-with-errors.stderr
@@ -1,0 +1,11 @@
+error: #[construct_with] must have at least one argument
+  --> $DIR/construct-with-errors.rs:20:7
+   |
+20 |     #[construct_with()] //~ ERROR #[construct_with] must have at least one argument
+   |       ^^^^^^^^^^^^^^
+
+error: #[construct_with] should be of the form #[construct_with(<types>)]
+  --> $DIR/construct-with-errors.rs:28:22
+   |
+28 |     #[construct_with("test")] //~ ERROR #[construct_with] should be of the form #[construct_with(<types>)]
+   |                      ^^^^^^

--- a/pnet_macros/tests/compile-fail/endianness_not_specified.stderr
+++ b/pnet_macros/tests/compile-fail/endianness_not_specified.stderr
@@ -1,0 +1,5 @@
+error: endianness must be specified for types of size >= 8
+  --> $DIR/endianness_not_specified.rs:15:13
+   |
+15 |     banana: u16,  //~ ERROR endianness must be specified for types of size >= 8
+   |             ^^^

--- a/pnet_macros/tests/compile-fail/invalid_type.stderr
+++ b/pnet_macros/tests/compile-fail/invalid_type.stderr
@@ -1,0 +1,5 @@
+error: non-primitive field types must specify #[construct_with]
+  --> $DIR/invalid_type.rs:15:16
+   |
+15 |     pub field: String, //~ ERROR: non-primitive field types must specify #[construct_with]
+   |                ^^^^^^

--- a/pnet_macros/tests/compile-fail/length_expr.stderr
+++ b/pnet_macros/tests/compile-fail/length_expr.stderr
@@ -1,0 +1,5 @@
+error: Only field names, constants, integers, basic arithmetic expressions (+ - * / %) and parentheses are allowed in the "length" attribute
+  --> $DIR/length_expr.rs:16:16
+   |
+16 |     #[length = "banana + 7.5"] //~ ERROR Only field names, constants, integers, basic arithmetic expressions (+ - * / %) and parentheses ...
+   |                ^^^^^^^^^^^^^^

--- a/pnet_macros/tests/compile-fail/length_expr_key.stderr
+++ b/pnet_macros/tests/compile-fail/length_expr_key.stderr
@@ -1,0 +1,5 @@
+error: Field name must be a member of the struct and not the field itself
+  --> $DIR/length_expr_key.rs:16:16
+   |
+16 |     #[length = "tomato"] //~ ERROR Field name must be a member of the struct and not the field itself
+   |                ^^^^^^^^

--- a/pnet_macros/tests/compile-fail/length_expr_parentheses.stderr
+++ b/pnet_macros/tests/compile-fail/length_expr_parentheses.stderr
@@ -1,0 +1,7 @@
+error: this file contains an unclosed delimiter
+  --> $DIR/length_expr_parentheses.rs:15:1
+   |
+15 | #[packet]
+   | ^^^^^^^^^ unclosed delimiter
+   |
+   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/pnet_macros/tests/compile-fail/multiple_payload.stderr
+++ b/pnet_macros/tests/compile-fail/multiple_payload.stderr
@@ -1,0 +1,5 @@
+error: packet may not have multiple payloads
+  --> $DIR/multiple_payload.rs:18:7
+   |
+18 |     #[payload]  //~ ERROR packet may not have multiple payloads
+   |       ^^^^^^^

--- a/pnet_macros/tests/compile-fail/must_be_pub.stderr
+++ b/pnet_macros/tests/compile-fail/must_be_pub.stderr
@@ -1,0 +1,5 @@
+error: #[packet] structs must be public
+  --> $DIR/must_be_pub.rs:14:8
+   |
+14 | struct MustBePub { //~ ERROR #[packet] structs must be public
+   |        ^^^^^^^^^

--- a/pnet_macros/tests/compile-fail/no_payload.stderr
+++ b/pnet_macros/tests/compile-fail/no_payload.stderr
@@ -1,0 +1,7 @@
+error: #[packet]'s must contain a payload
+  --> $DIR/no_payload.rs:13:1
+   |
+13 | #[packet] //~ ERROR: #[packet]'s must contain a payload
+   | ^^^^^^^^^
+   |
+   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/pnet_macros/tests/compile-fail/non-primitive.stderr
+++ b/pnet_macros/tests/compile-fail/non-primitive.stderr
@@ -1,0 +1,5 @@
+error: non-primitive field types must specify #[construct_with]
+  --> $DIR/non-primitive.rs:20:13
+   |
+20 |     banana: Toto,  //~ ERROR non-primitive field types must specify #[construct_with]
+   |             ^^^^

--- a/pnet_macros/tests/compile-fail/payload_fn2.stderr
+++ b/pnet_macros/tests/compile-fail/payload_fn2.stderr
@@ -1,0 +1,14 @@
+error: unknown attribute: payload
+  --> $DIR/payload_fn2.rs:16:7
+   |
+16 |     #[payload(length_fn = "length_of_payload")] //~ ERROR: unknown attribute: payload
+   |       ^^^^^^^
+
+error[E0412]: cannot find type `PacketWithPayload2Packet` in this scope
+  --> $DIR/payload_fn2.rs:20:26
+   |
+14 | pub struct PacketWithPayload2 {
+   | ----------------------------- similarly named struct `PacketWithPayload2` defined here
+...
+20 | fn length_of_payload(_: &PacketWithPayload2Packet) -> usize { //~ ERROR cannot find type `PacketWithPayload2Packet` in this scope
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `PacketWithPayload2`

--- a/pnet_macros/tests/compile-fail/unnamed_field.stderr
+++ b/pnet_macros/tests/compile-fail/unnamed_field.stderr
@@ -1,0 +1,5 @@
+error: all fields in a packet must be named
+  --> $DIR/unnamed_field.rs:15:20
+   |
+15 |                pub u8); //~ ERROR all fields in a packet must be named
+   |                    ^^

--- a/pnet_macros/tests/compile-fail/variable_length_fields.stderr
+++ b/pnet_macros/tests/compile-fail/variable_length_fields.stderr
@@ -1,0 +1,5 @@
+error: variable length field must have #[length = ""] or #[length_fn = ""] attribute
+  --> $DIR/variable_length_fields.rs:16:17
+   |
+16 |     var_length: Vec<u8>, //~ ERROR: variable length field must have #[length = ""] or #[length_fn = ""] attribute
+   |                 ^^^

--- a/pnet_macros/tests/tests.rs
+++ b/pnet_macros/tests/tests.rs
@@ -1,22 +1,6 @@
-extern crate compiletest_rs as compiletest;
-extern crate pnet_macros;
-
-use compiletest::Config;
-use std::path::PathBuf;
-
-fn run_mode(mode: &'static str) {
-    let mut config = Config::default();
-
-    config.mode = mode.parse().expect("Invalid mode");
-    config.src_base = PathBuf::from(format!("tests/{}", mode));
-    config.link_deps(); // Populate config.target_rustcflags with dependencies on the path
-    config.clean_rmeta(); // If your tests import the parent crate, this helps with E0464
-
-    compiletest::run_tests(&config);
-}
-
 #[test]
 fn compile_test() {
-    run_mode("compile-fail");
-    run_mode("run-pass");
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile-fail/*.rs");
+    t.pass("tests/run-pass/*.rs");
 }


### PR DESCRIPTION
Use `trybuild` instead of `compiletest_rs` for `pnet_macros` compile tests.

The only difference is that the expected errors are now committed to the repository (`trybuild` compares them to the actual output of the compiler).

This fixes the build failure on macos seen in #490 and should make compile tests more reliable on such targets.