### PR TITLE
Bump ipnetwork version for pnet_datalink

### DIFF
--- a/pnet_datalink/Cargo.toml
+++ b/pnet_datalink/Cargo.toml
@@ -15,7 +15,7 @@ netmap = []
 
 [dependencies]
 libc = "0.2.42"
-ipnetwork = "0.17.0"
+ipnetwork = "0.18.0"
 pnet_base = { path = "../pnet_base", version = "0.27.2" }
 pnet_sys = { path = "../pnet_sys", version = "0.27.2" }
 


### PR DESCRIPTION
Closes #494.

Looks like this was missed in #492.