### PR TITLE
Fix unescaped doc links

### DIFF
--- a/pnet_macros/src/decorator.rs
+++ b/pnet_macros/src/decorator.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Implements the #[packet] decorator.
+//! Implements the #\[packet\] decorator.
 
 use crate::util::{
     operations, to_little_endian, to_mutator, Endianness, GetOperation, SetOperation,

--- a/pnet_macros/src/lib.rs
+++ b/pnet_macros/src/lib.rs
@@ -86,7 +86,7 @@
 //!  * \#[length_fn = "function_name"]
 //!
 //!    This attribute is used to enable variable length fields. To specify a variable length field,
-//!    it should have the type `Vec<T>`. It must have the `#[length_fn]` (or #[length]) attribute,
+//!    it should have the type `Vec<T>`. It must have the `#[length_fn]` (or #\[length\]) attribute,
 //!    which specifies a function name to calculate the length of the field. The signature for the
 //!    length function should be
 //!    `fn {function_name}<'a>(example_packet: &ExamplePacket<'a>) -> usize`, substituting
@@ -101,7 +101,7 @@
 //!  * \#[length = "arithmetic expression"]
 //!
 //!    This attribute is used to enable variable length fields. To specify a variable length field,
-//!    it should have the type `Vec<T>`. It must have the `#[length]` (or #[length_fn]) attribute,
+//!    it should have the type `Vec<T>`. It must have the `#[length]` (or #\[length_fn\]) attribute,
 //!    which specifies an arithmetic expression to calculate the length of the field. Only field
 //!    names, constants, integers, basic arithmetic expressions (+ - * / %) and parentheses are
 //!    in the expression. An example would be `#[length = "field_name + CONSTANT - 4]`.
@@ -110,7 +110,7 @@
 //!    `pnet_macros::types`, or another structure marked with #[derive(Packet)], for example
 //!    `Vec<Example>`.
 //!
-//!  * \#[payload]
+//!  * \#\[payload\]
 //!
 //!    This attribute specifies the payload associated with the packet. This should specify the
 //!    data associated with the packet. It may be used in two places:

--- a/pnet_macros_support/src/packet.rs
+++ b/pnet_macros_support/src/packet.rs
@@ -43,12 +43,12 @@ pub trait MutablePacket: Packet {
     }
 }
 
-/// Used to convert on-the-wire packets to their #[packet] equivalent.
+/// Used to convert on-the-wire packets to their #\[packet\] equivalent.
 pub trait FromPacket: Packet {
     /// The type of the packet to convert from.
     type T;
 
-    /// Converts a wire-format packet to #[packet] struct format.
+    /// Converts a wire-format packet to #\[packet\] struct format.
     fn from_packet(&self) -> Self::T;
 }
 

--- a/pnet_macros_support/src/types.rs
+++ b/pnet_macros_support/src/types.rs
@@ -8,7 +8,7 @@
 
 //! Provides type aliases for various primitive integer types
 //!
-//! These types are aliased to the next largest of [`u8`, `u16`, `u32`, `u64`], and purely serve as
+//! These types are aliased to the next largest of \[`u8`, `u16`, `u32`, `u64`\], and purely serve as
 //! hints for the `#[packet]` macro to enable the generation of the correct bit manipulations to
 //! get the value out of a packet.
 //!
@@ -43,451 +43,451 @@ pub type u6 = u8;
 /// Represents an unsigned, 7-bit integer.
 pub type u7 = u8;
 
-/// Represents an unsigned 9-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 9-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u9be = u16;
 
-/// Represents an unsigned 10-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 10-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u10be = u16;
 
-/// Represents an unsigned 11-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 11-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u11be = u16;
 
-/// Represents an unsigned 12-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 12-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u12be = u16;
 
-/// Represents an unsigned 13-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 13-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u13be = u16;
 
-/// Represents an unsigned 14-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 14-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u14be = u16;
 
-/// Represents an unsigned 15-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 15-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u15be = u16;
 
-/// Represents an unsigned 16-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 16-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u16be = u16;
 
-/// Represents an unsigned 17-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 17-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u17be = u32;
 
-/// Represents an unsigned 18-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 18-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u18be = u32;
 
-/// Represents an unsigned 19-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 19-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u19be = u32;
 
-/// Represents an unsigned 20-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 20-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u20be = u32;
 
-/// Represents an unsigned 21-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 21-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u21be = u32;
 
-/// Represents an unsigned 22-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 22-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u22be = u32;
 
-/// Represents an unsigned 23-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 23-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u23be = u32;
 
-/// Represents an unsigned 24-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 24-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u24be = u32;
 
-/// Represents an unsigned 25-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 25-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u25be = u32;
 
-/// Represents an unsigned 26-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 26-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u26be = u32;
 
-/// Represents an unsigned 27-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 27-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u27be = u32;
 
-/// Represents an unsigned 28-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 28-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u28be = u32;
 
-/// Represents an unsigned 29-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 29-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u29be = u32;
 
-/// Represents an unsigned 30-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 30-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u30be = u32;
 
-/// Represents an unsigned 31-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 31-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u31be = u32;
 
-/// Represents an unsigned 32-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 32-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u32be = u32;
 
-/// Represents an unsigned 33-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 33-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u33be = u64;
 
-/// Represents an unsigned 34-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 34-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u34be = u64;
 
-/// Represents an unsigned 35-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 35-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u35be = u64;
 
-/// Represents an unsigned 36-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 36-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u36be = u64;
 
-/// Represents an unsigned 37-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 37-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u37be = u64;
 
-/// Represents an unsigned 38-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 38-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u38be = u64;
 
-/// Represents an unsigned 39-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 39-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u39be = u64;
 
-/// Represents an unsigned 40-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 40-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u40be = u64;
 
-/// Represents an unsigned 41-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 41-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u41be = u64;
 
-/// Represents an unsigned 42-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 42-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u42be = u64;
 
-/// Represents an unsigned 43-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 43-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u43be = u64;
 
-/// Represents an unsigned 44-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 44-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u44be = u64;
 
-/// Represents an unsigned 45-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 45-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u45be = u64;
 
-/// Represents an unsigned 46-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 46-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u46be = u64;
 
-/// Represents an unsigned 47-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 47-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u47be = u64;
 
-/// Represents an unsigned 48-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 48-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u48be = u64;
 
-/// Represents an unsigned 49-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 49-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u49be = u64;
 
-/// Represents an unsigned 50-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 50-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u50be = u64;
 
-/// Represents an unsigned 51-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 51-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u51be = u64;
 
-/// Represents an unsigned 52-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 52-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u52be = u64;
 
-/// Represents an unsigned 53-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 53-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u53be = u64;
 
-/// Represents an unsigned 54-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 54-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u54be = u64;
 
-/// Represents an unsigned 55-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 55-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u55be = u64;
 
-/// Represents an unsigned 56-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 56-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u56be = u64;
 
-/// Represents an unsigned 57-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 57-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u57be = u64;
 
-/// Represents an unsigned 58-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 58-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u58be = u64;
 
-/// Represents an unsigned 59-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 59-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u59be = u64;
 
-/// Represents an unsigned 60-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 60-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u60be = u64;
 
-/// Represents an unsigned 61-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 61-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u61be = u64;
 
-/// Represents an unsigned 62-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 62-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u62be = u64;
 
-/// Represents an unsigned 63-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 63-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u63be = u64;
 
-/// Represents an unsigned 64-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 64-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as big-endian, but accessors/mutators will return/take host-order values.
 pub type u64be = u64;
 
-/// Represents an unsigned 9-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 9-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u9le = u16;
 
-/// Represents an unsigned 10-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 10-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u10le = u16;
 
-/// Represents an unsigned 11-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 11-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u11le = u16;
 
-/// Represents an unsigned 12-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 12-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u12le = u16;
 
-/// Represents an unsigned 13-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 13-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u13le = u16;
 
-/// Represents an unsigned 14-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 14-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u14le = u16;
 
-/// Represents an unsigned 15-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 15-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u15le = u16;
 
-/// Represents an unsigned 16-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 16-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u16le = u16;
 
-/// Represents an unsigned 17-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 17-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u17le = u32;
 
-/// Represents an unsigned 18-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 18-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u18le = u32;
 
-/// Represents an unsigned 19-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 19-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u19le = u32;
 
-/// Represents an unsigned 20-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 20-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u20le = u32;
 
-/// Represents an unsigned 21-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 21-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u21le = u32;
 
-/// Represents an unsigned 22-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 22-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u22le = u32;
 
-/// Represents an unsigned 23-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 23-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u23le = u32;
 
-/// Represents an unsigned 24-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 24-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u24le = u32;
 
-/// Represents an unsigned 25-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 25-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u25le = u32;
 
-/// Represents an unsigned 26-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 26-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u26le = u32;
 
-/// Represents an unsigned 27-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 27-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u27le = u32;
 
-/// Represents an unsigned 28-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 28-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u28le = u32;
 
-/// Represents an unsigned 29-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 29-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u29le = u32;
 
-/// Represents an unsigned 30-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 30-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u30le = u32;
 
-/// Represents an unsigned 31-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 31-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u31le = u32;
 
-/// Represents an unsigned 32-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 32-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u32le = u32;
 
-/// Represents an unsigned 33-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 33-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u33le = u64;
 
-/// Represents an unsigned 34-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 34-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u34le = u64;
 
-/// Represents an unsigned 35-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 35-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u35le = u64;
 
-/// Represents an unsigned 36-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 36-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u36le = u64;
 
-/// Represents an unsigned 37-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 37-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u37le = u64;
 
-/// Represents an unsigned 38-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 38-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u38le = u64;
 
-/// Represents an unsigned 39-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 39-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u39le = u64;
 
-/// Represents an unsigned 40-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 40-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u40le = u64;
 
-/// Represents an unsigned 41-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 41-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u41le = u64;
 
-/// Represents an unsigned 42-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 42-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u42le = u64;
 
-/// Represents an unsigned 43-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 43-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u43le = u64;
 
-/// Represents an unsigned 44-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 44-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u44le = u64;
 
-/// Represents an unsigned 45-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 45-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u45le = u64;
 
-/// Represents an unsigned 46-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 46-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u46le = u64;
 
-/// Represents an unsigned 47-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 47-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u47le = u64;
 
-/// Represents an unsigned 48-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 48-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u48le = u64;
 
-/// Represents an unsigned 49-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 49-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u49le = u64;
 
-/// Represents an unsigned 50-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 50-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u50le = u64;
 
-/// Represents an unsigned 51-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 51-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u51le = u64;
 
-/// Represents an unsigned 52-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 52-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u52le = u64;
 
-/// Represents an unsigned 53-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 53-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u53le = u64;
 
-/// Represents an unsigned 54-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 54-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u54le = u64;
 
-/// Represents an unsigned 55-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 55-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u55le = u64;
 
-/// Represents an unsigned 56-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 56-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u56le = u64;
 
-/// Represents an unsigned 57-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 57-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u57le = u64;
 
-/// Represents an unsigned 58-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 58-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u58le = u64;
 
-/// Represents an unsigned 59-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 59-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u59le = u64;
 
-/// Represents an unsigned 60-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 60-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u60le = u64;
 
-/// Represents an unsigned 61-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 61-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u61le = u64;
 
-/// Represents an unsigned 62-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 62-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u62le = u64;
 
-/// Represents an unsigned 63-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 63-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u63le = u64;
 
-/// Represents an unsigned 64-bit integer. libpnet #[packet]-derived structs using this type will
+/// Represents an unsigned 64-bit integer. libpnet #\[packet\]-derived structs using this type will
 /// hold it in memory as little-endian, but accessors/mutators will return/take host-order values.
 pub type u64le = u64;
 

--- a/pnet_packet/src/ethernet.rs
+++ b/pnet_packet/src/ethernet.rs
@@ -62,51 +62,51 @@ fn ethernet_header_test() {
 pub mod EtherTypes {
     use ethernet::EtherType;
 
-    /// Internet Protocol version 4 (IPv4) [RFC7042].
+    /// Internet Protocol version 4 (IPv4) \[RFC7042\].
     pub const Ipv4: EtherType = EtherType(0x0800);
-    /// Address Resolution Protocol (ARP) [RFC7042].
+    /// Address Resolution Protocol (ARP) \[RFC7042\].
     pub const Arp: EtherType = EtherType(0x0806);
     /// Wake on Lan.
     pub const WakeOnLan: EtherType = EtherType(0x0842);
-    /// IETF TRILL Protocol [IEEE].
+    /// IETF TRILL Protocol \[IEEE\].
     pub const Trill: EtherType = EtherType(0x22F3);
     /// DECnet Phase IV.
     pub const DECnet: EtherType = EtherType(0x6003);
-    /// Reverse Address Resolution Protocol (RARP) [RFC903].
+    /// Reverse Address Resolution Protocol (RARP) \[RFC903\].
     pub const Rarp: EtherType = EtherType(0x8035); 
-    /// AppleTalk - EtherTalk [Apple].
+    /// AppleTalk - EtherTalk \[Apple\].
     pub const AppleTalk: EtherType = EtherType(0x809B);
-    /// AppleTalk Address Resolution Protocol (AARP) [Apple].
+    /// AppleTalk Address Resolution Protocol (AARP) \[Apple\].
     pub const Aarp: EtherType = EtherType(0x80F3);
-    /// IPX [Xerox].
+    /// IPX \[Xerox\].
     pub const Ipx: EtherType = EtherType(0x8137);
-    /// QNX Qnet [QNX Software Systems].
+    /// QNX Qnet \[QNX Software Systems\].
     pub const Qnx: EtherType = EtherType(0x8204);
-    /// Internet Protocol version 6 (IPv6) [RFC7042].
+    /// Internet Protocol version 6 (IPv6) \[RFC7042\].
     pub const Ipv6: EtherType = EtherType(0x86DD);
-    /// Ethernet Flow Control [IEEE 802.3x].
+    /// Ethernet Flow Control \[IEEE 802.3x\].
     pub const FlowControl: EtherType = EtherType(0x8808);
-    /// CobraNet [CobraNet].
+    /// CobraNet \[CobraNet\].
     pub const CobraNet: EtherType = EtherType(0x8819);
-    /// MPLS Unicast [RFC 3032].
+    /// MPLS Unicast \[RFC 3032\].
     pub const Mpls: EtherType = EtherType(0x8847);
-    /// MPLS Multicast [RFC 5332].
+    /// MPLS Multicast \[RFC 5332\].
     pub const MplsMcast: EtherType = EtherType(0x8848);
-    /// PPPOE Discovery Stage [RFC 2516].
+    /// PPPOE Discovery Stage \[RFC 2516\].
     pub const PppoeDiscovery: EtherType = EtherType(0x8863);
-    /// PPPoE Session Stage [RFC 2516].
+    /// PPPoE Session Stage \[RFC 2516\].
     pub const PppoeSession: EtherType = EtherType(0x8864);
     /// VLAN-tagged frame (IEEE 802.1Q).
     pub const Vlan: EtherType = EtherType(0x8100);
-    /// Provider Bridging [IEEE 802.1ad / IEEE 802.1aq].
+    /// Provider Bridging \[IEEE 802.1ad / IEEE 802.1aq\].
     pub const PBridge: EtherType = EtherType(0x88a8);
-    /// Link Layer Discovery Protocol (LLDP) [IEEE 802.1AB].
+    /// Link Layer Discovery Protocol (LLDP) \[IEEE 802.1AB\].
     pub const Lldp: EtherType = EtherType(0x88cc);
-    /// Precision Time Protocol (PTP) over Ethernet [IEEE 1588].
+    /// Precision Time Protocol (PTP) over Ethernet \[IEEE 1588\].
     pub const Ptp: EtherType = EtherType(0x88f7);
-    /// CFM / Y.1731 [IEEE 802.1ag].
+    /// CFM / Y.1731 \[IEEE 802.1ag\].
     pub const Cfm: EtherType = EtherType(0x8902);
-    /// Q-in-Q Vlan Tagging [IEEE 802.1Q].
+    /// Q-in-Q Vlan Tagging \[IEEE 802.1Q\].
     pub const QinQ: EtherType = EtherType(0x9100);
 }
 

--- a/pnet_packet/src/ip.rs
+++ b/pnet_packet/src/ip.rs
@@ -24,31 +24,31 @@ use PrimitiveValues;
 pub mod IpNextHeaderProtocols {
     use super::IpNextHeaderProtocol;
 
-    /// IPv6 Hop-by-Hop Option [RFC2460]
+    /// IPv6 Hop-by-Hop Option \[RFC2460\]
     pub const Hopopt: IpNextHeaderProtocol = IpNextHeaderProtocol(0);
 
-    /// Internet Control Message [RFC792]
+    /// Internet Control Message \[RFC792\]
     pub const Icmp: IpNextHeaderProtocol = IpNextHeaderProtocol(1);
 
-    /// Internet Group Management [RFC1112]
+    /// Internet Group Management \[RFC1112\]
     pub const Igmp: IpNextHeaderProtocol = IpNextHeaderProtocol(2);
 
-    /// Gateway-to-Gateway [RFC823]
+    /// Gateway-to-Gateway \[RFC823\]
     pub const Ggp: IpNextHeaderProtocol = IpNextHeaderProtocol(3);
 
-    /// IPv4 encapsulation [RFC2003]
+    /// IPv4 encapsulation \[RFC2003\]
     pub const Ipv4: IpNextHeaderProtocol = IpNextHeaderProtocol(4);
 
-    /// Stream [RFC1190][RFC1819]
+    /// Stream \[RFC1190\]\[RFC1819\]
     pub const St: IpNextHeaderProtocol = IpNextHeaderProtocol(5);
 
-    /// Transmission Control [RFC793]
+    /// Transmission Control \[RFC793\]
     pub const Tcp: IpNextHeaderProtocol = IpNextHeaderProtocol(6);
 
     /// CBT
     pub const Cbt: IpNextHeaderProtocol = IpNextHeaderProtocol(7);
 
-    /// Exterior Gateway Protocol [RFC888]
+    /// Exterior Gateway Protocol \[RFC888\]
     pub const Egp: IpNextHeaderProtocol = IpNextHeaderProtocol(8);
 
     /// any private interior gateway (used by Cisco for their IGRP)
@@ -57,7 +57,7 @@ pub mod IpNextHeaderProtocols {
     /// BBN RCC Monitoring
     pub const BbnRccMon: IpNextHeaderProtocol = IpNextHeaderProtocol(10);
 
-    /// Network Voice Protocol [RFC741]
+    /// Network Voice Protocol \[RFC741\]
     pub const NvpII: IpNextHeaderProtocol = IpNextHeaderProtocol(11);
 
     /// PUP
@@ -75,7 +75,7 @@ pub mod IpNextHeaderProtocols {
     /// Chaos
     pub const Chaos: IpNextHeaderProtocol = IpNextHeaderProtocol(16);
 
-    /// User Datagram [RFC768]
+    /// User Datagram \[RFC768\]
     pub const Udp: IpNextHeaderProtocol = IpNextHeaderProtocol(17);
 
     /// Multiplexing
@@ -84,7 +84,7 @@ pub mod IpNextHeaderProtocols {
     /// DCN Measurement Subsystems
     pub const DcnMeas: IpNextHeaderProtocol = IpNextHeaderProtocol(19);
 
-    /// Host Monitoring [RFC869]
+    /// Host Monitoring \[RFC869\]
     pub const Hmp: IpNextHeaderProtocol = IpNextHeaderProtocol(20);
 
     /// Packet Radio Measurement
@@ -105,16 +105,16 @@ pub mod IpNextHeaderProtocols {
     /// Leaf-2
     pub const Leaf2: IpNextHeaderProtocol = IpNextHeaderProtocol(26);
 
-    /// Reliable Data Protocol [RFC908]
+    /// Reliable Data Protocol \[RFC908\]
     pub const Rdp: IpNextHeaderProtocol = IpNextHeaderProtocol(27);
 
-    /// Internet Reliable Transaction [RFC938]
+    /// Internet Reliable Transaction \[RFC938\]
     pub const Irtp: IpNextHeaderProtocol = IpNextHeaderProtocol(28);
 
-    /// ISO Transport Protocol Class 4 [RFC905]
+    /// ISO Transport Protocol Class 4 \[RFC905\]
     pub const IsoTp4: IpNextHeaderProtocol = IpNextHeaderProtocol(29);
 
-    /// Bulk Data Transfer Protocol [RFC969]
+    /// Bulk Data Transfer Protocol \[RFC969\]
     pub const Netblt: IpNextHeaderProtocol = IpNextHeaderProtocol(30);
 
     /// MFE Network Services Protocol
@@ -123,7 +123,7 @@ pub mod IpNextHeaderProtocols {
     /// MERIT Internodal Protocol
     pub const MeritInp: IpNextHeaderProtocol = IpNextHeaderProtocol(32);
 
-    /// Datagram Congestion Control Protocol [RFC4340]
+    /// Datagram Congestion Control Protocol \[RFC4340\]
     pub const Dccp: IpNextHeaderProtocol = IpNextHeaderProtocol(33);
 
     /// Third Party Connect Protocol
@@ -147,7 +147,7 @@ pub mod IpNextHeaderProtocols {
     /// IL Transport Protocol
     pub const Il: IpNextHeaderProtocol = IpNextHeaderProtocol(40);
 
-    /// IPv6 encapsulation [RFC2473]
+    /// IPv6 encapsulation \[RFC2473\]
     pub const Ipv6: IpNextHeaderProtocol = IpNextHeaderProtocol(41);
 
     /// Source Demand Routing Protocol
@@ -162,22 +162,22 @@ pub mod IpNextHeaderProtocols {
     /// Inter-Domain Routing Protocol
     pub const Idrp: IpNextHeaderProtocol = IpNextHeaderProtocol(45);
 
-    /// Reservation Protocol [RFC2205][RFC3209]
+    /// Reservation Protocol \[RFC2205\]\[RFC3209\]
     pub const Rsvp: IpNextHeaderProtocol = IpNextHeaderProtocol(46);
 
-    /// Generic Routing Encapsulation [RFC1701]
+    /// Generic Routing Encapsulation \[RFC1701\]
     pub const Gre: IpNextHeaderProtocol = IpNextHeaderProtocol(47);
 
-    /// Dynamic Source Routing Protocol [RFC4728]
+    /// Dynamic Source Routing Protocol \[RFC4728\]
     pub const Dsr: IpNextHeaderProtocol = IpNextHeaderProtocol(48);
 
     /// BNA
     pub const Bna: IpNextHeaderProtocol = IpNextHeaderProtocol(49);
 
-    /// Encap Security Payload [RFC4303]
+    /// Encap Security Payload \[RFC4303\]
     pub const Esp: IpNextHeaderProtocol = IpNextHeaderProtocol(50);
 
-    /// Authentication Header [RFC4302]
+    /// Authentication Header \[RFC4302\]
     pub const Ah: IpNextHeaderProtocol = IpNextHeaderProtocol(51);
 
     /// Integrated Net Layer Security TUBA
@@ -186,7 +186,7 @@ pub mod IpNextHeaderProtocols {
     /// IP with Encryption
     pub const Swipe: IpNextHeaderProtocol = IpNextHeaderProtocol(53);
 
-    /// NBMA Address Resolution Protocol [RFC1735]
+    /// NBMA Address Resolution Protocol \[RFC1735\]
     pub const Narp: IpNextHeaderProtocol = IpNextHeaderProtocol(54);
 
     /// IP Mobility
@@ -201,13 +201,13 @@ pub mod IpNextHeaderProtocols {
     #[deprecated(note = "Please use `IpNextHeaderProtocols::Icmpv6` instead")]
     pub const Ipv6Icmp: IpNextHeaderProtocol = IpNextHeaderProtocol(58);
 
-    /// ICMPv6 [RFC4443]
+    /// ICMPv6 \[RFC4443\]
     pub const Icmpv6: IpNextHeaderProtocol = IpNextHeaderProtocol(58);
 
-    /// No Next Header for IPv6 [RFC2460]
+    /// No Next Header for IPv6 \[RFC2460\]
     pub const Ipv6NoNxt: IpNextHeaderProtocol = IpNextHeaderProtocol(59);
 
-    /// Destination Options for IPv6 [RFC2460]
+    /// Destination Options for IPv6 \[RFC2460\]
     pub const Ipv6Opts: IpNextHeaderProtocol = IpNextHeaderProtocol(60);
 
     /// any host internal protocol
@@ -294,7 +294,7 @@ pub mod IpNextHeaderProtocols {
     /// EIGRP
     pub const Eigrp: IpNextHeaderProtocol = IpNextHeaderProtocol(88);
 
-    /// OSPFIGP [RFC1583][RFC2328][RFC5340]
+    /// OSPFIGP \[RFC1583\]\[RFC2328\]\[RFC5340\]
     pub const OspfigP: IpNextHeaderProtocol = IpNextHeaderProtocol(89);
 
     /// Sprite RPC Protocol
@@ -318,10 +318,10 @@ pub mod IpNextHeaderProtocols {
     /// Semaphore Communications Sec. Pro.
     pub const SccSp: IpNextHeaderProtocol = IpNextHeaderProtocol(96);
 
-    /// Ethernet-within-IP Encapsulation [RFC3378]
+    /// Ethernet-within-IP Encapsulation \[RFC3378\]
     pub const Etherip: IpNextHeaderProtocol = IpNextHeaderProtocol(97);
 
-    /// Encapsulation Header [RFC1241]
+    /// Encapsulation Header \[RFC1241\]
     pub const Encap: IpNextHeaderProtocol = IpNextHeaderProtocol(98);
 
     /// any private encryption scheme
@@ -336,7 +336,7 @@ pub mod IpNextHeaderProtocols {
     /// PNNI over IP
     pub const Pnni: IpNextHeaderProtocol = IpNextHeaderProtocol(102);
 
-    /// Protocol Independent Multicast [RFC4601]
+    /// Protocol Independent Multicast \[RFC4601\]
     pub const Pim: IpNextHeaderProtocol = IpNextHeaderProtocol(103);
 
     /// ARIS
@@ -351,7 +351,7 @@ pub mod IpNextHeaderProtocols {
     /// Active Networks
     pub const AN: IpNextHeaderProtocol = IpNextHeaderProtocol(107);
 
-    /// IP Payload Compression Protocol [RFC2393]
+    /// IP Payload Compression Protocol \[RFC2393\]
     pub const IpComp: IpNextHeaderProtocol = IpNextHeaderProtocol(108);
 
     /// Sitara Networks Protocol
@@ -363,7 +363,7 @@ pub mod IpNextHeaderProtocols {
     /// IPX in IP
     pub const IpxInIp: IpNextHeaderProtocol = IpNextHeaderProtocol(111);
 
-    /// Virtual Router Redundancy Protocol [RFC5798]
+    /// Virtual Router Redundancy Protocol \[RFC5798\]
     pub const Vrrp: IpNextHeaderProtocol = IpNextHeaderProtocol(112);
 
     /// PGM Reliable Transport Protocol
@@ -372,7 +372,7 @@ pub mod IpNextHeaderProtocols {
     /// any 0-hop protocol
     pub const ZeroHop: IpNextHeaderProtocol = IpNextHeaderProtocol(114);
 
-    /// Layer Two Tunneling Protocol [RFC3931]
+    /// Layer Two Tunneling Protocol \[RFC3931\]
     pub const L2tp: IpNextHeaderProtocol = IpNextHeaderProtocol(115);
 
     /// D-II Data Exchange (DDX)
@@ -426,40 +426,40 @@ pub mod IpNextHeaderProtocols {
     /// Stream Control Transmission Protocol
     pub const Sctp: IpNextHeaderProtocol = IpNextHeaderProtocol(132);
 
-    /// Fibre Channel [RFC6172]
+    /// Fibre Channel \[RFC6172\]
     pub const Fc: IpNextHeaderProtocol = IpNextHeaderProtocol(133);
 
-    /// [RFC3175]
+    /// \[RFC3175\]
     pub const RsvpE2eIgnore: IpNextHeaderProtocol = IpNextHeaderProtocol(134);
 
-    /// [RFC6275]
+    /// \[RFC6275\]
     pub const MobilityHeader: IpNextHeaderProtocol = IpNextHeaderProtocol(135);
 
-    /// [RFC3828]
+    /// \[RFC3828\]
     pub const UdpLite: IpNextHeaderProtocol = IpNextHeaderProtocol(136);
 
-    /// [RFC4023]
+    /// \[RFC4023\]
     pub const MplsInIp: IpNextHeaderProtocol = IpNextHeaderProtocol(137);
 
-    /// MANET Protocols [RFC5498]
+    /// MANET Protocols \[RFC5498\]
     pub const Manet: IpNextHeaderProtocol = IpNextHeaderProtocol(138);
 
-    /// Host Identity Protocol [RFC5201]
+    /// Host Identity Protocol \[RFC5201\]
     pub const Hip: IpNextHeaderProtocol = IpNextHeaderProtocol(139);
 
-    /// Shim6 Protocol [RFC5533]
+    /// Shim6 Protocol \[RFC5533\]
     pub const Shim6: IpNextHeaderProtocol = IpNextHeaderProtocol(140);
 
-    /// Wrapped Encapsulating Security Payload [RFC5840]
+    /// Wrapped Encapsulating Security Payload \[RFC5840\]
     pub const Wesp: IpNextHeaderProtocol = IpNextHeaderProtocol(141);
 
-    /// Robust Header Compression [RFC5858]
+    /// Robust Header Compression \[RFC5858\]
     pub const Rohc: IpNextHeaderProtocol = IpNextHeaderProtocol(142);
 
-    /// Use for experimentation and testing [RFC3692]
+    /// Use for experimentation and testing \[RFC3692\]
     pub const Test1: IpNextHeaderProtocol = IpNextHeaderProtocol(253);
 
-    /// Use for experimentation and testing [RFC3692]
+    /// Use for experimentation and testing \[RFC3692\]
     pub const Test2: IpNextHeaderProtocol = IpNextHeaderProtocol(254);
 
     ///

--- a/pnet_packet/src/usbpcap.rs
+++ b/pnet_packet/src/usbpcap.rs
@@ -1,3 +1,4 @@
+//! A USB PCAP packet abstraction.
 use pnet_macros::Packet;
 use pnet_macros_support::types::{u1, u3, u4, u7, u16le, u32le, u64le};
 use pnet_macros_support::packet::PrimitiveValues;


### PR DESCRIPTION
Fixes warnings raised by cargo-doc due to unescaped doc links. Also adds missing doc comment for the usbpcap module.