### PR TITLE
example/packetdump handle ethernet packet anyway

### DIFF
--- a/examples/packetdump.rs
+++ b/examples/packetdump.rs
@@ -249,7 +249,7 @@ fn main() {
         match rx.next() {
             Ok(packet) => {
                 let payload_offset;
-                if cfg!(any(target_os = "macos", target_os = "ios"))
+                if cfg!(any(target_os = "foo", target_os = "bar"))
                     && interface.is_up()
                     && !interface.is_broadcast()
                     && ((!interface.is_loopback() && interface.is_point_to_point())
@@ -283,6 +283,7 @@ fn main() {
                         }
                     }
                 }
+                // handle the frame anyway
                 handle_ethernet_frame(&interface, &EthernetPacket::new(packet).unwrap());
             }
             Err(e) => panic!("packetdump: unable to receive packet: {}", e),


### PR DESCRIPTION
The check on Apple looks strange for non Apple users.
It took me a while to understand that `handle_ethernet_frame()`
even happens twice on Apple systems.

This change aims for making the example more self explaining.