### PR TITLE
Handle ethernet frame only once on Apple

### DIFF
--- a/examples/packetdump.rs
+++ b/examples/packetdump.rs
@@ -282,8 +282,9 @@ fn main() {
                             continue;
                         }
                     }
+                } else {
+                    handle_ethernet_frame(&interface, &EthernetPacket::new(packet).unwrap());
                 }
-                handle_ethernet_frame(&interface, &EthernetPacket::new(packet).unwrap());
             }
             Err(e) => panic!("packetdump: unable to receive packet: {}", e),
         }


### PR DESCRIPTION
After the "if MacOS or iOS then handle_ethernet_frame()"
there was an unconditional handle_ethernet_frame().

Now we have

   if MacOS or iOS {
       special_actions_for_Apple_OS();
       handle_ethernet_frame();
   } else {
       handle_ethernet_frame();
   }

to prevent triggering  handle_ethernet_frame() on Apple OS
without the special actions.