### PR TITLE
Fix length check in datalink's build_and_send()

### DIFF
--- a/pnet_datalink/src/linux.rs
+++ b/pnet_datalink/src/linux.rs
@@ -242,7 +242,7 @@ impl DataLinkSender for DataLinkSenderImpl {
         func: &mut dyn FnMut(&mut [u8]),
     ) -> Option<io::Result<()>> {
         let len = num_packets * packet_size;
-        if len < self.write_buffer.len() {
+        if len <= self.write_buffer.len() {
             let min = cmp::min(self.write_buffer[..].len(), len);
             let mut_slice = &mut self.write_buffer;
             for chunk in mut_slice[..min].chunks_mut(packet_size) {


### PR DESCRIPTION
This is so build_and_send() can run successfully when num_packets *
packet_size is equal to the write_buffer length.