### PR TITLE
Mark pnet_datalink::Channel non-exhaustive; remove workaround

### DIFF
--- a/examples/fanout.rs
+++ b/examples/fanout.rs
@@ -82,7 +82,7 @@ fn main() {
                 // Create a channel to receive on
                 let (_, mut rx) = match datalink::channel(&itf, config) {
                     Ok(Ethernet(tx, rx)) => (tx, rx),
-                    Ok(_) => panic!("packetdump: unhandled channel type: {}"),
+                    Ok(_) => panic!("packetdump: unhandled channel type"),
                     Err(e) => panic!("packetdump: unable to create channel: {}", e),
                 };
 

--- a/examples/packetdump.rs
+++ b/examples/packetdump.rs
@@ -239,7 +239,7 @@ fn main() {
     // Create a channel to receive on
     let (_, mut rx) = match datalink::channel(&interface, Default::default()) {
         Ok(Ethernet(tx, rx)) => (tx, rx),
-        Ok(_) => panic!("packetdump: unhandled channel type: {}"),
+        Ok(_) => panic!("packetdump: unhandled channel type"),
         Err(e) => panic!("packetdump: unable to create channel: {}", e),
     };
 

--- a/pnet_datalink/src/lib.rs
+++ b/pnet_datalink/src/lib.rs
@@ -80,24 +80,10 @@ pub enum ChannelType {
 }
 
 /// A channel for sending and receiving at the data link layer.
-///
-/// NOTE: It is important to always include a catch-all variant in match statements using this
-/// enum, since new variants may be added. For example:
-///
-/// ```ignore
-/// match some_channel {
-///     Ethernet(tx, rx) => { /* Handle Ethernet packets */ },
-///     _ => panic!("Unhandled channel type")
-/// }
-/// ```
+#[non_exhaustive]
 pub enum Channel {
     /// A datalink channel which sends and receives Ethernet packets.
     Ethernet(Box<dyn DataLinkSender>, Box<dyn DataLinkReceiver>),
-
-    /// This variant should never be used.
-    ///
-    /// Including it allows new variants to be added to `Channel` without breaking existing code.
-    PleaseIncludeACatchAllVariantWhenMatchingOnThisEnum,
 }
 
 /// Socket fanout type (Linux only).


### PR DESCRIPTION
`pnet_datalink::Channel` has a dummy `PleaseIncludeACatchAllVariantWhenMatchingOnThisEnum` variant, with the stated goal of allowing the library to add more variants in the future without breaking existing code. This is the purpose of Rust's [`non_exhaustive` attribute](https://doc.rust-lang.org/stable/reference/attributes/type_system.html#the-non_exhaustive-attribute), so remove the dummy variant and mark `pnet_datalink::Channel` as non-exhaustive instead.

I also fixed some ill-formed `panic!` invocations in the examples.