### PR TITLE
Add NetworkInterface::is_running()

### DIFF
--- a/pnet_datalink/src/lib.rs
+++ b/pnet_datalink/src/lib.rs
@@ -245,6 +245,11 @@ impl NetworkInterface {
     pub fn is_up(&self) -> bool {
         self.flags & (pnet_sys::IFF_UP as u32) != 0
     }
+
+    pub fn is_running(&self) -> bool {
+        self.flags & (pnet_sys::IFF_RUNNING as u32) != 0
+    }
+
     pub fn is_broadcast(&self) -> bool {
         self.flags & (pnet_sys::IFF_BROADCAST as u32) != 0
     }
@@ -262,13 +267,14 @@ impl NetworkInterface {
 
 impl ::std::fmt::Display for NetworkInterface {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        const FLAGS: [&'static str; 5] =
-            ["UP", "BROADCAST", "LOOPBACK", "POINTOPOINT", "MULTICAST"];
+        const FLAGS: [&'static str; 6] =
+            ["UP", "BROADCAST", "LOOPBACK", "RUNNING", "POINTOPOINT", "MULTICAST"];
         let flags = if self.flags > 0 {
             let rets = [
                 self.is_up(),
                 self.is_broadcast(),
                 self.is_loopback(),
+                self.is_running(),
                 self.is_point_to_point(),
                 self.is_multicast(),
             ];

--- a/pnet_sys/src/unix.rs
+++ b/pnet_sys/src/unix.rs
@@ -48,7 +48,7 @@ pub mod public {
     pub const IPPROTO_IPV6: libc::c_int = libc::IPPROTO_IPV6;
     pub const IPV6_UNICAST_HOPS: libc::c_int = libc::IPV6_UNICAST_HOPS;
 
-    pub use super::libc::{IFF_BROADCAST, IFF_LOOPBACK, IFF_MULTICAST, IFF_POINTOPOINT, IFF_UP};
+    pub use super::libc::{IFF_BROADCAST, IFF_LOOPBACK, IFF_RUNNING, IFF_MULTICAST, IFF_POINTOPOINT, IFF_UP};
 
     pub const INVALID_SOCKET: CSocket = -1;
 

--- a/pnet_sys/src/windows.rs
+++ b/pnet_sys/src/windows.rs
@@ -50,6 +50,7 @@ pub mod public {
     pub const IFF_POINTTOPOINT: ctypes::c_int = 0x00000008;
     pub const IFF_POINTOPOINT: ctypes::c_int = IFF_POINTTOPOINT;
     pub const IFF_MULTICAST: ctypes::c_int = 0x00000010;
+    pub const IFF_RUNNING: ctypes::c_int = 0x00000020;
 
     pub const INVALID_SOCKET: CSocket = winsock2::INVALID_SOCKET;
 


### PR DESCRIPTION
This PR adds `is_running` method aimed to detect the state of the network interface link. It was tested on my x86_64 Linux machine by running the `list_interfaces` example and observing its output when the network cable was connected/disconnected.