### PR TITLE
Move from inline documentation to the rust-enforced equivalent

### DIFF
--- a/pnet_datalink/src/lib.rs
+++ b/pnet_datalink/src/lib.rs
@@ -90,14 +90,10 @@ pub enum ChannelType {
 ///     _ => panic!("Unhandled channel type")
 /// }
 /// ```
+#[non_exhaustive]
 pub enum Channel {
     /// A datalink channel which sends and receives Ethernet packets.
     Ethernet(Box<dyn DataLinkSender>, Box<dyn DataLinkReceiver>),
-
-    /// This variant should never be used.
-    ///
-    /// Including it allows new variants to be added to `Channel` without breaking existing code.
-    PleaseIncludeACatchAllVariantWhenMatchingOnThisEnum,
 }
 
 /// Socket fanout type (Linux only).


### PR DESCRIPTION
Closes #536 

This simplifies the usage of channel. `#[non_exhaustive]` forces clients to include a wildcard in their matching enums. This may break code that ignores the message the enum gave from before.