### PR TITLE
Added support for querying kernel driver flags

### DIFF
--- a/pnet_datalink/src/lib.rs
+++ b/pnet_datalink/src/lib.rs
@@ -245,6 +245,16 @@ impl NetworkInterface {
     pub fn is_up(&self) -> bool {
         self.flags & (pnet_sys::IFF_UP as u32) != 0
     }
+    /// Triggered when the driver has signated netif_carrier_on
+    /// Check https://www.kernel.org/doc/html/latest/networking/operstates.html for more information
+    pub fn is_lower_up(&self) -> bool {
+        self.flags & (pnet_sys::IFF_LOWER_UP as u32) != 0
+    }
+    /// Triggered when the driver has signated netif_dormant_on
+    /// Check https://www.kernel.org/doc/html/latest/networking/operstates.html for more information
+    pub fn is_dormant(&self) -> bool {
+        self.flags & (pnet_sys::IFF_DORMANT as u32) != 0
+    }
     pub fn is_broadcast(&self) -> bool {
         self.flags & (pnet_sys::IFF_BROADCAST as u32) != 0
     }

--- a/pnet_sys/src/unix.rs
+++ b/pnet_sys/src/unix.rs
@@ -48,7 +48,7 @@ pub mod public {
     pub const IPPROTO_IPV6: libc::c_int = libc::IPPROTO_IPV6;
     pub const IPV6_UNICAST_HOPS: libc::c_int = libc::IPV6_UNICAST_HOPS;
 
-    pub use super::libc::{IFF_BROADCAST, IFF_LOOPBACK, IFF_MULTICAST, IFF_POINTOPOINT, IFF_UP};
+    pub use super::libc::{IFF_BROADCAST, IFF_LOOPBACK, IFF_MULTICAST, IFF_POINTOPOINT, IFF_UP, IFF_LOWER_UP, IFF_DORMANT};
 
     pub const INVALID_SOCKET: CSocket = -1;
 


### PR DESCRIPTION
Closes #538

Adds support for the `IFF_LOWER_UP` and `IFF_DORMANT` flags.