### PR TITLE
Remove a few usages of uninitialized, add safety comments

### DIFF
--- a/pnet_sys/src/unix.rs
+++ b/pnet_sys/src/unix.rs
@@ -107,10 +107,10 @@ pub mod public {
     }
 
     fn make_in6_addr(segments: [u16; 8]) -> In6Addr {
-        #[allow(deprecated)]
-        let mut val: In6Addr = unsafe { mem::uninitialized() };
-        val.s6_addr = unsafe {
-            mem::transmute([
+        // Safety: We're transmuting an array of ints to an array of ints.
+        // There is no padding involved, and they must be the same size.
+        let s6_addr = unsafe {
+            mem::transmute::<[u16; 8], [u8; 16]>([
                 htons(segments[0]),
                 htons(segments[1]),
                 htons(segments[2]),
@@ -121,7 +121,8 @@ pub mod public {
                 htons(segments[7]),
             ])
         };
-        val
+
+        In6Addr { s6_addr }
     }
 
     pub fn addr_to_sockaddr(addr: SocketAddr, storage: &mut SockAddrStorage) -> SockLen {


### PR DESCRIPTION
I added some safety comments to the `interfaces` method, and removed some uninitialized (which is UB in basically every situation).

I didn't touch the bits that `cargo check` can't check, and I didn't run tests, I'll leave that up to CI.

One thing I'm concerned about is the `String::from_utf8_unchecked` which implies that all interface names on unix are *always* valid UTF-8. According to https://unix.stackexchange.com/questions/451368/allowed-chars-in-linux-network-interface-names this is incorrect, so what should we do here? Panic? Return an error? Ignore the interface? Use CString in NetworkInterface?

I think using CString in NetworkInterface is the best choice. That would be a breaking change, but it's for the best IMO.