### PR TITLE
Add illumos support

### DIFF
--- a/pnet_datalink/src/bindings/bpf.rs
+++ b/pnet_datalink/src/bindings/bpf.rs
@@ -27,7 +27,12 @@ const IOCPARM_MASK: libc::c_ulong = (1 << (IOCPARM_SHIFT as usize)) - 1;
 const SIZEOF_TIMEVAL: libc::c_ulong = 16;
 const SIZEOF_IFREQ: libc::c_ulong = 32;
 const SIZEOF_C_UINT: libc::c_ulong = 4;
-#[cfg(any(target_os = "freebsd", target_os = "netbsd"))]
+#[cfg(any(
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "illumos",
+    target_os = "solaris"
+))]
 const SIZEOF_C_LONG: libc::c_int = 8;
 
 pub const BIOCSETIF: libc::c_ulong =
@@ -46,7 +51,7 @@ pub const BIOCSHDRCMPLT: libc::c_ulong =
 pub const BIOCSRTIMEOUT: libc::c_ulong =
     IOC_IN | ((SIZEOF_TIMEVAL & IOCPARM_MASK) << 16) | (('B' as libc::c_ulong) << 8) | 109;
 
-#[cfg(target_os = "freebsd")]
+#[cfg(any(target_os = "freebsd", target_os = "illumos", target_os = "solaris"))]
 pub const BIOCFEEDBACK: libc::c_ulong =
     IOC_IN | ((SIZEOF_C_UINT & IOCPARM_MASK) << 16) | (('B' as libc::c_ulong) << 8) | 124;
 #[cfg(target_os = "netbsd")]
@@ -56,7 +61,12 @@ pub const BIOCFEEDBACK: libc::c_ulong =
 
 pub const DLT_NULL: libc::c_uint = 0;
 
-#[cfg(any(target_os = "freebsd", target_os = "netbsd"))]
+#[cfg(any(
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "illumos",
+    target_os = "solaris"
+))]
 const BPF_ALIGNMENT: libc::c_int = SIZEOF_C_LONG;
 #[cfg(any(target_os = "openbsd", target_os = "macos", target_os = "ios", windows))]
 const BPF_ALIGNMENT: libc::c_int = 4;
@@ -76,7 +86,15 @@ pub struct ifreq {
 // sdl_data does not match if_dl.h on OS X, since the size of 12 is a minimum.
 // Will be unsafe
 // when sdl_nlen > 40.
-#[cfg(any(target_os = "openbsd", target_os = "freebsd", target_os = "netbsd", target_os = "macos", target_os = "ios"))]
+#[cfg(any(
+    target_os = "openbsd",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "illumos",
+    target_os = "solaris",
+    target_os = "macos",
+    target_os = "ios"
+))]
 pub struct sockaddr_dl {
     pub sdl_len: libc::c_uchar,
     pub sdl_family: libc::c_uchar,
@@ -92,7 +110,12 @@ pub struct sockaddr_dl {
 #[cfg(any(
     target_os = "freebsd",
     target_os = "netbsd",
-    all(any(target_os = "macos", target_os = "ios"), target_pointer_width = "32"),
+    target_os = "illumos",
+    target_os = "solaris",
+    all(
+        any(target_os = "macos", target_os = "ios"),
+        target_pointer_width = "32"
+    ),
     windows
 ))]
 #[repr(C)]

--- a/pnet_datalink/src/bindings/mod.rs
+++ b/pnet_datalink/src/bindings/mod.rs
@@ -10,6 +10,8 @@
     target_os = "freebsd",
     target_os = "openbsd",
     target_os = "netbsd",
+    target_os = "illumos",
+    target_os = "solaris",
     target_os = "macos",
     target_os = "ios",
     windows

--- a/pnet_datalink/src/bpf.rs
+++ b/pnet_datalink/src/bpf.rs
@@ -75,7 +75,12 @@ impl Default for Config {
 // NOTE buffer must be word aligned.
 #[inline]
 pub fn channel(network_interface: &NetworkInterface, config: Config) -> io::Result<super::Channel> {
-    #[cfg(any(target_os = "freebsd", target_os = "netbsd"))]
+    #[cfg(any(
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "illumos",
+        target_os = "solaris"
+    ))]
     fn get_fd(_attempts: usize) -> libc::c_int {
         unsafe {
             libc::open(
@@ -106,7 +111,12 @@ pub fn channel(network_interface: &NetworkInterface, config: Config) -> io::Resu
         -1
     }
 
-    #[cfg(any(target_os = "freebsd", target_os = "netbsd"))]
+    #[cfg(any(
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "illumos",
+        target_os = "solaris"
+    ))]
     fn set_feedback(fd: libc::c_int) -> io::Result<()> {
         if unsafe { bpf::ioctl(fd, bpf::BIOCFEEDBACK, &1) } == -1 {
             let err = io::Error::last_os_error();

--- a/pnet_datalink/src/bpf.rs
+++ b/pnet_datalink/src/bpf.rs
@@ -82,9 +82,10 @@ pub fn channel(network_interface: &NetworkInterface, config: Config) -> io::Resu
         target_os = "solaris"
     ))]
     fn get_fd(_attempts: usize) -> libc::c_int {
+        let c_file_name = CString::new(&b"/dev/bpf"[..]).unwrap();
         unsafe {
             libc::open(
-                CString::new(&b"/dev/bpf"[..]).unwrap().as_ptr(),
+                c_file_name.as_ptr(),
                 libc::O_RDWR,
                 0,
             )

--- a/pnet_datalink/src/lib.rs
+++ b/pnet_datalink/src/lib.rs
@@ -51,6 +51,8 @@ pub mod linux;
         target_os = "freebsd",
         target_os = "openbsd",
         target_os = "netbsd",
+        target_os = "illumos",
+        target_os = "solaris",
         target_os = "macos",
         target_os = "ios"
     )
@@ -61,6 +63,8 @@ mod backend;
 #[cfg(any(
     target_os = "freebsd",
     target_os = "netbsd",
+    target_os = "illumos",
+    target_os = "solaris",
     target_os = "macos",
     target_os = "ios"
 ))]

--- a/pnet_datalink/src/lib.rs
+++ b/pnet_datalink/src/lib.rs
@@ -230,48 +230,57 @@ pub struct NetworkInterface {
     /// IP addresses and netmasks for the interface.
     pub ips: Vec<IpNetwork>,
     /// Operating system specific flags for the interface.
+    #[cfg(not(any(target_os = "illumos", target_os = "solaris")))]
     pub flags: u32,
+    #[cfg(any(target_os = "illumos", target_os = "solaris"))]
+    pub flags: u64,
 }
+
+/// Type alias for an `InterfaceType`.
+#[cfg(not(any(target_os = "illumos", target_os = "solaris")))]
+pub type InterfaceType = u32;
+#[cfg(any(target_os = "illumos", target_os = "solaris"))]
+pub type InterfaceType = u64;
 
 impl NetworkInterface {
     pub fn is_up(&self) -> bool {
-        self.flags & (pnet_sys::IFF_UP as u32) != 0
+        self.flags & (pnet_sys::IFF_UP as InterfaceType) != 0
     }
 
     pub fn is_broadcast(&self) -> bool {
-        self.flags & (pnet_sys::IFF_BROADCAST as u32) != 0
+        self.flags & (pnet_sys::IFF_BROADCAST as InterfaceType) != 0
     }
 
     /// Is the interface a loopback interface?
     pub fn is_loopback(&self) -> bool {
-        self.flags & (pnet_sys::IFF_LOOPBACK as u32) != 0
+        self.flags & (pnet_sys::IFF_LOOPBACK as InterfaceType) != 0
     }
 
     pub fn is_point_to_point(&self) -> bool {
-        self.flags & (pnet_sys::IFF_POINTOPOINT as u32) != 0
+        self.flags & (pnet_sys::IFF_POINTOPOINT as InterfaceType) != 0
     }
 
     pub fn is_multicast(&self) -> bool {
-        self.flags & (pnet_sys::IFF_MULTICAST as u32) != 0
+        self.flags & (pnet_sys::IFF_MULTICAST as InterfaceType) != 0
     }
 
     /// Triggered when the driver has signated netif_carrier_on
     /// Check <https://www.kernel.org/doc/html/latest/networking/operstates.html> for more information
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub fn is_lower_up(&self) -> bool {
-        self.flags & (pnet_sys::IFF_LOWER_UP as u32) != 0
+        self.flags & (pnet_sys::IFF_LOWER_UP as InterfaceType) != 0
     }
 
     /// Triggered when the driver has signated netif_dormant_on
     /// Check <https://www.kernel.org/doc/html/latest/networking/operstates.html> for more information
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub fn is_dormant(&self) -> bool {
-        self.flags & (pnet_sys::IFF_DORMANT as u32) != 0
+        self.flags & (pnet_sys::IFF_DORMANT as InterfaceType) != 0
     }
 
     #[cfg(unix)]
     pub fn is_running(&self) -> bool {
-        self.flags & (pnet_sys::IFF_RUNNING as u32) != 0
+        self.flags & (pnet_sys::IFF_RUNNING as InterfaceType) != 0
     }
 }
 

--- a/pnet_datalink/src/unix_interfaces.rs
+++ b/pnet_datalink/src/unix_interfaces.rs
@@ -142,6 +142,8 @@ fn sockaddr_to_network_addr(sa: *const libc::sockaddr) -> (Option<MacAddr>, Opti
     target_os = "openbsd",
     target_os = "freebsd",
     target_os = "netbsd",
+    target_os = "illumos",
+    target_os = "solaris",
     target_os = "macos",
     target_os = "ios"
 ))]

--- a/pnet_sys/src/unix.rs
+++ b/pnet_sys/src/unix.rs
@@ -30,6 +30,10 @@ pub mod public {
     pub type TvUsecType = libc::c_long;
     #[cfg(any(target_os = "macos", target_os = "ios", target_os = "netbsd"))]
     pub type TvUsecType = libc::c_int;
+    #[cfg(not(any(target_os = "illumos", target_os = "solaris")))]
+    pub type InAddrType = libc::c_uint;
+    #[cfg(any(target_os = "illumos", target_os = "solaris"))]
+    pub type InAddrType = libc::c_ulonglong;
 
     pub const AF_INET: libc::c_int = libc::AF_INET;
     pub const AF_INET6: libc::c_int = libc::AF_INET6;
@@ -206,8 +210,8 @@ pub mod public {
 use self::public::*;
 
 #[inline(always)]
-pub fn ipv4_addr(addr: InAddr) -> u32 {
-    (addr.s_addr as u32).to_be()
+pub fn ipv4_addr(addr: InAddr) -> InAddrType {
+    (addr.s_addr as InAddrType).to_be()
 }
 
 #[inline(always)]


### PR DESCRIPTION
First attempt at adding illumos support.

Rust newcomer here, so any feedback is welcome.

Happy to improve this PR to hopefully get it merged one day.

EDIT:

Testing notes:
- I successfully compiled libpnet with these changes on linux (NixOS) and on illumos as dependency of [garage](https://git.deuxfleurs.fr/Deuxfleurs/garage) and got a working cluster of it running (not 100% sure it's using libpnet for cluster rpc communication)
- Test suite with `cargo test` on linux is green but on illumos it shows this:
```
[root@garage-test ~/work/libpnet]# RUST_BACKTRACE=1 PNET_TEST_IFACE=net1 RUST_TEST_THREADS=1 cargo test
    Finished test [unoptimized + debuginfo] target(s) in 0.06s
     Running unittests (target/debug/deps/pnet-8d719cef29a7e692)

running 5 tests
test pnettest::check_test_environment ... ok
test pnettest::layer2 ... FAILED
test pnettest::layer3_ipv4 ... FAILED
test pnettest::layer4_ipv4 ... FAILED
test pnettest::layer4_ipv6 ... ok

failures:

---- pnettest::layer2 stdout ----
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', src/pnettest.rs:359:50
stack backtrace:
   0: rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::panicking::panic
   3: core::option::Option<T>::unwrap
             at /home/pbulk/build/lang/rust/work/rustc-1.58.1-src/library/core/src/option.rs:746:21
   4: pnet::pnettest::layer2
             at ./src/pnettest.rs:359:36
   5: pnet::pnettest::layer2::{{closure}}
             at ./src/pnettest.rs:346:1
   6: core::ops::function::FnOnce::call_once
             at /home/pbulk/build/lang/rust/work/rustc-1.58.1-src/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

---- pnettest::layer3_ipv4 stdout ----
thread '<unnamed>' panicked at 'assertion failed: `(left == right)`
  left: `0.0.0.0`,
 right: `127.0.0.1`', src/pnettest.rs:276:21
stack backtrace:
   0: rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::panicking::assert_failed_inner
   3: core::panicking::assert_failed
             at /home/pbulk/build/lang/rust/work/rustc-1.58.1-src/library/core/src/panicking.rs:145:5
   4: pnet::pnettest::layer3_ipv4::{{closure}}
             at ./src/pnettest.rs:276:21
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
thread 'main' panicked at 'assertion failed: res.join().is_ok()', src/pnettest.rs:306:5
stack backtrace:
   0: rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::panicking::panic
   3: pnet::pnettest::layer3_ipv4
             at ./src/pnettest.rs:306:5
   4: pnet::pnettest::layer3_ipv4::{{closure}}
             at ./src/pnettest.rs:252:1
   5: core::ops::function::FnOnce::call_once
             at /home/pbulk/build/lang/rust/work/rustc-1.58.1-src/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

---- pnettest::layer4_ipv4 stdout ----
thread '<unnamed>' panicked at 'assertion failed: `(left == right)`
  left: `0.0.0.0`,
 right: `127.0.0.1`', src/pnettest.rs:204:21
stack backtrace:
   0: rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::panicking::assert_failed_inner
   3: core::panicking::assert_failed
             at /home/pbulk/build/lang/rust/work/rustc-1.58.1-src/library/core/src/panicking.rs:145:5
   4: pnet::pnettest::layer4::{{closure}}
             at ./src/pnettest.rs:204:21
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
thread 'main' panicked at 'assertion failed: res.join().is_ok()', src/pnettest.rs:231:5
stack backtrace:
   0: rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::panicking::panic
   3: pnet::pnettest::layer4
             at ./src/pnettest.rs:231:5
   4: pnet::pnettest::layer4_ipv4
             at ./src/pnettest.rs:237:5
   5: pnet::pnettest::layer4_ipv4::{{closure}}
             at ./src/pnettest.rs:236:1
   6: core::ops::function::FnOnce::call_once
             at /home/pbulk/build/lang/rust/work/rustc-1.58.1-src/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.


failures:
    pnettest::layer2
    pnettest::layer3_ipv4
    pnettest::layer4_ipv4

test result: FAILED. 2 passed; 3 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s

error: test failed, to rerun pass '--lib'
```

EDIT2: But `make test` succeeds on both linux and illumos:
```
[root@garage-test ~/work/libpnet]# export VERBOSE=1
[root@garage-test ~/work/libpnet]# make test
bash build.sh test
++ which rustc
+ RUSTC=/opt/local/bin/rustc
++ which rustdoc
+ RUSTDOC=/opt/local/bin/rustdoc
++ which cargo
+ CARGO=/opt/local/bin/cargo
++ which sudo
+ SUDO=/opt/local/bin/sudo
++ uname -s
+ SYSTEM=SunOS
+ TESTER='/opt/local/bin/cargo test'
++ which clang
++ which gcc
+ CC='no clang in /root/go/bin /root/.cargo/bin /usr/local/sbin /usr/local/bin /opt/local/sbin /opt/local/bin /usr/sbin /usr/bin /sbin
/opt/local/bin/gcc'
+ MACROS_WITH_SYNTEX=0
+ [[ -n '' ]]
+ PNET_CARGO_FLAGS=
+ [[ -n '' ]]
+ PNET_MACROS_CARGO_FLAGS=
++ which ifconfig
+ IFCONFIG=/usr/sbin/ifconfig
++ which ip
+ IPROUTE2='no ip in /root/go/bin /root/.cargo/bin /usr/local/sbin /usr/local/bin /opt/local/sbin /opt/local/bin /usr/sbin /usr/bin /sbin'
+ + echo
grep -q with-syntex
+ PNET_TEST_IFACE=
+ [[ -x /usr/sbin/ifconfig ]]
++ ++ ++ /usr/sbin/ifconfig
++ egrep 'UP| active'
perl -pe '/^[A-z0-9]+:([^\n]|\n\t)*status: active/'
++ grep active -B1
++ head -n1
cut -f1 -d:
+ PNET_TEST_IFACE=
+ [[ -z '' ]]
+ [[ -x no ip in /root/go/bin /root/.cargo/bin /usr/local/sbin /usr/local/bin /opt/local/sbin /opt/local/bin /usr/sbin /usr/bin /sbin ]]
+ [[ -z '' ]]
+ [[ SunOS = \L\i\n\u\x ]]
+ set -euo pipefail
+ mkdir -p target/doc
+ mkdir -p target/benches
+ [[ 1 == \1 ]]
+ PNET_CARGO_FLAGS=' --verbose'
+ PNET_MACROS_CARGO_FLAGS=' --verbose'
+ TESTER='/opt/local/bin/cargo test  --verbose'
+ [[ ! -x /opt/local/bin/cargo ]]
+ case "$1" in
+ run_test
+ run_macro_tests
+ cd pnet_macros
+ sh -c '/opt/local/bin/cargo test  --verbose'
    Updating crates.io index
  Downloaded trybuild v1.0.59
  Downloaded 1 crate (36.2 KB) in 3.69s
   Compiling proc-macro2 v1.0.37
   Compiling unicode-xid v0.2.2
   Compiling memchr v2.4.1
   Compiling serde v1.0.136
   Compiling syn v1.0.91
   Compiling serde_json v1.0.79
   Compiling serde_derive v1.0.136
   Compiling ryu v1.0.9
   Compiling trybuild v1.0.59
   Compiling itoa v1.0.1
   Compiling regex-syntax v0.6.25
   Compiling glob v0.3.0
   Compiling termcolor v1.1.3
   Compiling pnet_base v0.29.0 (/root/work/libpnet/pnet_base)
   Compiling once_cell v1.10.0
     Running `rustc --crate-name build_script_build --edition=2018 /root/.cargo/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.37/build.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type bin --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --cfg 'feature="default"' --cfg 'feature="proc-macro"' -C metadata=094c3efe4613fcf4 -C extra-filename=-094c3efe4613fcf4 --out-dir /root/work/libpnet/pnet_macros/target/debug/build/proc-macro2-094c3efe4613fcf4 -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --cap-lints allow`
     Running `rustc --crate-name unicode_xid /root/.cargo/registry/src/github.com-1ecc6299db9ec823/unicode-xid-0.2.2/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --cfg 'feature="default"' -C metadata=0cd80f1ded374c9c -C extra-filename=-0cd80f1ded374c9c --out-dir /root/work/libpnet/pnet_macros/target/debug/deps -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --cap-lints allow`
     Running `rustc --crate-name build_script_build --edition=2018 /root/.cargo/registry/src/github.com-1ecc6299db9ec823/memchr-2.4.1/build.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type bin --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --cfg 'feature="default"' --cfg 'feature="std"' -C metadata=390687abaf38f95b -C extra-filename=-390687abaf38f95b --out-dir /root/work/libpnet/pnet_macros/target/debug/build/memchr-390687abaf38f95b -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --cap-lints allow`
     Running `rustc --crate-name build_script_build /root/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.136/build.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type bin --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --cfg 'feature="default"' --cfg 'feature="std"' -C metadata=b4b46ecaf4aa7302 -C extra-filename=-b4b46ecaf4aa7302 --out-dir /root/work/libpnet/pnet_macros/target/debug/build/serde-b4b46ecaf4aa7302 -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --cap-lints allow`
     Running `rustc --crate-name build_script_build --edition=2018 /root/.cargo/registry/src/github.com-1ecc6299db9ec823/syn-1.0.91/build.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type bin --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --cfg 'feature="clone-impls"' --cfg 'feature="default"' --cfg 'feature="derive"' --cfg 'feature="full"' --cfg 'feature="parsing"' --cfg 'feature="printing"' --cfg 'feature="proc-macro"' --cfg 'feature="quote"' -C metadata=e4635699ed1deccb -C extra-filename=-e4635699ed1deccb --out-dir /root/work/libpnet/pnet_macros/target/debug/build/syn-e4635699ed1deccb -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --cap-lints allow`
     Running `rustc --crate-name build_script_build --edition=2018 /root/.cargo/registry/src/github.com-1ecc6299db9ec823/serde_json-1.0.79/build.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type bin --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --cfg 'feature="default"' --cfg 'feature="std"' -C metadata=c350d1ce2071a666 -C extra-filename=-c350d1ce2071a666 --out-dir /root/work/libpnet/pnet_macros/target/debug/build/serde_json-c350d1ce2071a666 -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --cap-lints allow`
     Running `rustc --crate-name glob /root/.cargo/registry/src/github.com-1ecc6299db9ec823/glob-0.3.0/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 -C metadata=a030302f94138d08 -C extra-filename=-a030302f94138d08 --out-dir /root/work/libpnet/pnet_macros/target/debug/deps -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --cap-lints allow`
     Running `rustc --crate-name itoa --edition=2018 /root/.cargo/registry/src/github.com-1ecc6299db9ec823/itoa-1.0.1/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 -C metadata=8bf3851b1682aa96 -C extra-filename=-8bf3851b1682aa96 --out-dir /root/work/libpnet/pnet_macros/target/debug/deps -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --cap-lints allow`
     Running `rustc --crate-name ryu --edition=2018 /root/.cargo/registry/src/github.com-1ecc6299db9ec823/ryu-1.0.9/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 -C metadata=97e46406aecd2c50 -C extra-filename=-97e46406aecd2c50 --out-dir /root/work/libpnet/pnet_macros/target/debug/deps -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --cap-lints allow`
     Running `rustc --crate-name termcolor --edition=2018 /root/.cargo/registry/src/github.com-1ecc6299db9ec823/termcolor-1.1.3/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 -C metadata=7b889b52f76d0cf2 -C extra-filename=-7b889b52f76d0cf2 --out-dir /root/work/libpnet/pnet_macros/target/debug/deps -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --cap-lints allow`
     Running `rustc --crate-name build_script_build /root/.cargo/registry/src/github.com-1ecc6299db9ec823/serde_derive-1.0.136/build.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type bin --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --cfg 'feature="default"' -C metadata=b83da5d144083adf -C extra-filename=-b83da5d144083adf --out-dir /root/work/libpnet/pnet_macros/target/debug/build/serde_derive-b83da5d144083adf -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --cap-lints allow`
     Running `rustc --crate-name regex_syntax --edition=2018 /root/.cargo/registry/src/github.com-1ecc6299db9ec823/regex-syntax-0.6.25/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --cfg 'feature="default"' --cfg 'feature="unicode"' --cfg 'feature="unicode-age"' --cfg 'feature="unicode-bool"' --cfg 'feature="unicode-case"' --cfg 'feature="unicode-gencat"' --cfg 'feature="unicode-perl"' --cfg 'feature="unicode-script"' --cfg 'feature="unicode-segment"' -C metadata=5bcb329006728441 -C extra-filename=-5bcb329006728441 --out-dir /root/work/libpnet/pnet_macros/target/debug/deps -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --cap-lints allow`
     Running `rustc --crate-name build_script_build --edition=2018 /root/.cargo/registry/src/github.com-1ecc6299db9ec823/trybuild-1.0.59/build.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type bin --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 -C metadata=a9d82db7a7a10b38 -C extra-filename=-a9d82db7a7a10b38 --out-dir /root/work/libpnet/pnet_macros/target/debug/build/trybuild-a9d82db7a7a10b38 -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --cap-lints allow`
     Running `rustc --crate-name pnet_base --edition=2021 /root/work/libpnet/pnet_base/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 -C metadata=4c2e6a1465241add -C extra-filename=-4c2e6a1465241add --out-dir /root/work/libpnet/pnet_macros/target/debug/deps -C incremental=/root/work/libpnet/pnet_macros/target/debug/incremental -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps`
     Running `rustc --crate-name once_cell --edition=2018 /root/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.10.0/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --cfg 'feature="alloc"' --cfg 'feature="default"' --cfg 'feature="race"' --cfg 'feature="std"' -C metadata=3fdf596945f41e51 -C extra-filename=-3fdf596945f41e51 --out-dir /root/work/libpnet/pnet_macros/target/debug/deps -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --cap-lints allow`
   Compiling pnet_macros_support v0.29.0 (/root/work/libpnet/pnet_macros_support)
     Running `rustc --crate-name pnet_macros_support --edition=2021 /root/work/libpnet/pnet_macros_support/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 -C metadata=3cc00d29cfce0b19 -C extra-filename=-3cc00d29cfce0b19 --out-dir /root/work/libpnet/pnet_macros/target/debug/deps -C incremental=/root/work/libpnet/pnet_macros/target/debug/incremental -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --extern pnet_base=/root/work/libpnet/pnet_macros/target/debug/deps/libpnet_base-4c2e6a1465241add.rmeta`
     Running `/root/work/libpnet/pnet_macros/target/debug/build/trybuild-a9d82db7a7a10b38/build-script-build`
     Running `/root/work/libpnet/pnet_macros/target/debug/build/memchr-390687abaf38f95b/build-script-build`
     Running `rustc --crate-name memchr --edition=2018 /root/.cargo/registry/src/github.com-1ecc6299db9ec823/memchr-2.4.1/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --cfg 'feature="default"' --cfg 'feature="std"' -C metadata=a40bff2ba48ac5a0 -C extra-filename=-a40bff2ba48ac5a0 --out-dir /root/work/libpnet/pnet_macros/target/debug/deps -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --cap-lints allow --cfg memchr_runtime_simd --cfg memchr_runtime_sse2 --cfg memchr_runtime_sse42 --cfg memchr_runtime_avx`
     Running `/root/work/libpnet/pnet_macros/target/debug/build/serde_json-c350d1ce2071a666/build-script-build`
     Running `/root/work/libpnet/pnet_macros/target/debug/build/serde-b4b46ecaf4aa7302/build-script-build`
     Running `/root/work/libpnet/pnet_macros/target/debug/build/syn-e4635699ed1deccb/build-script-build`
     Running `/root/work/libpnet/pnet_macros/target/debug/build/serde_derive-b83da5d144083adf/build-script-build`
     Running `/root/work/libpnet/pnet_macros/target/debug/build/proc-macro2-094c3efe4613fcf4/build-script-build`
     Running `rustc --crate-name serde /root/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.136/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --cfg 'feature="default"' --cfg 'feature="std"' -C metadata=4068a22f23551056 -C extra-filename=-4068a22f23551056 --out-dir /root/work/libpnet/pnet_macros/target/debug/deps -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --cap-lints allow`
     Running `rustc --crate-name proc_macro2 --edition=2018 /root/.cargo/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.37/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --cfg 'feature="default"' --cfg 'feature="proc-macro"' -C metadata=c7a0266743c747e3 -C extra-filename=-c7a0266743c747e3 --out-dir /root/work/libpnet/pnet_macros/target/debug/deps -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --extern unicode_xid=/root/work/libpnet/pnet_macros/target/debug/deps/libunicode_xid-0cd80f1ded374c9c.rmeta --cap-lints allow --cfg use_proc_macro --cfg wrap_proc_macro`
   Compiling aho-corasick v0.7.18
     Running `rustc --crate-name aho_corasick --edition=2018 /root/.cargo/registry/src/github.com-1ecc6299db9ec823/aho-corasick-0.7.18/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --cfg 'feature="default"' --cfg 'feature="std"' -C metadata=84701c307285728d -C extra-filename=-84701c307285728d --out-dir /root/work/libpnet/pnet_macros/target/debug/deps -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --extern memchr=/root/work/libpnet/pnet_macros/target/debug/deps/libmemchr-a40bff2ba48ac5a0.rmeta --cap-lints allow`
   Compiling quote v1.0.17
     Running `rustc --crate-name quote --edition=2018 /root/.cargo/registry/src/github.com-1ecc6299db9ec823/quote-1.0.17/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --cfg 'feature="default"' --cfg 'feature="proc-macro"' -C metadata=74821f63340b6c48 -C extra-filename=-74821f63340b6c48 --out-dir /root/work/libpnet/pnet_macros/target/debug/deps -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --extern proc_macro2=/root/work/libpnet/pnet_macros/target/debug/deps/libproc_macro2-c7a0266743c747e3.rmeta --cap-lints allow`
     Running `rustc --crate-name syn --edition=2018 /root/.cargo/registry/src/github.com-1ecc6299db9ec823/syn-1.0.91/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --cfg 'feature="clone-impls"' --cfg 'feature="default"' --cfg 'feature="derive"' --cfg 'feature="full"' --cfg 'feature="parsing"' --cfg 'feature="printing"' --cfg 'feature="proc-macro"' --cfg 'feature="quote"' -C metadata=eaa076982918bc5f -C extra-filename=-eaa076982918bc5f --out-dir /root/work/libpnet/pnet_macros/target/debug/deps -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --extern proc_macro2=/root/work/libpnet/pnet_macros/target/debug/deps/libproc_macro2-c7a0266743c747e3.rmeta --extern quote=/root/work/libpnet/pnet_macros/target/debug/deps/libquote-74821f63340b6c48.rmeta --extern unicode_xid=/root/work/libpnet/pnet_macros/target/debug/deps/libunicode_xid-0cd80f1ded374c9c.rmeta --cap-lints allow --cfg syn_disable_nightly_tests`
   Compiling regex v1.5.5
     Running `rustc --crate-name regex --edition=2018 /root/.cargo/registry/src/github.com-1ecc6299db9ec823/regex-1.5.5/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --cfg 'feature="aho-corasick"' --cfg 'feature="default"' --cfg 'feature="memchr"' --cfg 'feature="perf"' --cfg 'feature="perf-cache"' --cfg 'feature="perf-dfa"' --cfg 'feature="perf-inline"' --cfg 'feature="perf-literal"' --cfg 'feature="std"' --cfg 'feature="unicode"' --cfg 'feature="unicode-age"' --cfg 'feature="unicode-bool"' --cfg 'feature="unicode-case"' --cfg 'feature="unicode-gencat"' --cfg 'feature="unicode-perl"' --cfg 'feature="unicode-script"' --cfg 'feature="unicode-segment"' -C metadata=3b38ba035ec50a14 -C extra-filename=-3b38ba035ec50a14 --out-dir /root/work/libpnet/pnet_macros/target/debug/deps -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --extern aho_corasick=/root/work/libpnet/pnet_macros/target/debug/deps/libaho_corasick-84701c307285728d.rmeta --extern memchr=/root/work/libpnet/pnet_macros/target/debug/deps/libmemchr-a40bff2ba48ac5a0.rmeta --extern regex_syntax=/root/work/libpnet/pnet_macros/target/debug/deps/libregex_syntax-5bcb329006728441.rmeta --cap-lints allow`
   Compiling toml v0.5.8
     Running `rustc --crate-name serde_json --edition=2018 /root/.cargo/registry/src/github.com-1ecc6299db9ec823/serde_json-1.0.79/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --cfg 'feature="default"' --cfg 'feature="std"' -C metadata=8f8d0d25fda9bb2e -C extra-filename=-8f8d0d25fda9bb2e --out-dir /root/work/libpnet/pnet_macros/target/debug/deps -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --extern itoa=/root/work/libpnet/pnet_macros/target/debug/deps/libitoa-8bf3851b1682aa96.rmeta --extern ryu=/root/work/libpnet/pnet_macros/target/debug/deps/libryu-97e46406aecd2c50.rmeta --extern serde=/root/work/libpnet/pnet_macros/target/debug/deps/libserde-4068a22f23551056.rmeta --cap-lints allow --cfg limb_width_64`
     Running `rustc --crate-name toml --edition=2018 /root/.cargo/registry/src/github.com-1ecc6299db9ec823/toml-0.5.8/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --cfg 'feature="default"' -C metadata=f3a7ace3ee973cf9 -C extra-filename=-f3a7ace3ee973cf9 --out-dir /root/work/libpnet/pnet_macros/target/debug/deps -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --extern serde=/root/work/libpnet/pnet_macros/target/debug/deps/libserde-4068a22f23551056.rmeta --cap-lints allow`
   Compiling pnet_macros v0.29.0 (/root/work/libpnet/pnet_macros)
     Running `rustc --crate-name serde_derive /root/.cargo/registry/src/github.com-1ecc6299db9ec823/serde_derive-1.0.136/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type proc-macro --emit=dep-info,link -C prefer-dynamic -C embed-bitcode=no -C debuginfo=2 --cfg 'feature="default"' -C metadata=4e38bf31bc611ea7 -C extra-filename=-4e38bf31bc611ea7 --out-dir /root/work/libpnet/pnet_macros/target/debug/deps -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --extern proc_macro2=/root/work/libpnet/pnet_macros/target/debug/deps/libproc_macro2-c7a0266743c747e3.rlib --extern quote=/root/work/libpnet/pnet_macros/target/debug/deps/libquote-74821f63340b6c48.rlib --extern syn=/root/work/libpnet/pnet_macros/target/debug/deps/libsyn-eaa076982918bc5f.rlib --extern proc_macro --cap-lints allow --cfg underscore_consts --cfg ptr_addr_of`
     Running `rustc --crate-name pnet_macros --edition=2021 src/lib.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type proc-macro --emit=dep-info,link -C prefer-dynamic -C embed-bitcode=no -C debuginfo=2 --cfg 'feature="default"' -C metadata=6bb70d9bff3c27ed -C extra-filename=-6bb70d9bff3c27ed --out-dir /root/work/libpnet/pnet_macros/target/debug/deps -C incremental=/root/work/libpnet/pnet_macros/target/debug/incremental -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --extern proc_macro2=/root/work/libpnet/pnet_macros/target/debug/deps/libproc_macro2-c7a0266743c747e3.rlib --extern quote=/root/work/libpnet/pnet_macros/target/debug/deps/libquote-74821f63340b6c48.rlib --extern regex=/root/work/libpnet/pnet_macros/target/debug/deps/libregex-3b38ba035ec50a14.rlib --extern syn=/root/work/libpnet/pnet_macros/target/debug/deps/libsyn-eaa076982918bc5f.rlib --extern proc_macro`
     Running `rustc --crate-name trybuild --edition=2018 /root/.cargo/registry/src/github.com-1ecc6299db9ec823/trybuild-1.0.59/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 -C metadata=c94a3b442cb4def8 -C extra-filename=-c94a3b442cb4def8 --out-dir /root/work/libpnet/pnet_macros/target/debug/deps -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --extern glob=/root/work/libpnet/pnet_macros/target/debug/deps/libglob-a030302f94138d08.rmeta --extern once_cell=/root/work/libpnet/pnet_macros/target/debug/deps/libonce_cell-3fdf596945f41e51.rmeta --extern serde=/root/work/libpnet/pnet_macros/target/debug/deps/libserde-4068a22f23551056.rmeta --extern serde_derive=/root/work/libpnet/pnet_macros/target/debug/deps/libserde_derive-4e38bf31bc611ea7.so --extern serde_json=/root/work/libpnet/pnet_macros/target/debug/deps/libserde_json-8f8d0d25fda9bb2e.rmeta --extern termcolor=/root/work/libpnet/pnet_macros/target/debug/deps/libtermcolor-7b889b52f76d0cf2.rmeta --extern toml=/root/work/libpnet/pnet_macros/target/debug/deps/libtoml-f3a7ace3ee973cf9.rmeta --cap-lints allow`
     Running `rustc --crate-name tests --edition=2021 tests/tests.rs --error-format=json --json=diagnostic-rendered-ansi --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --test --cfg 'feature="default"' -C metadata=54bcf580bb93b2be -C extra-filename=-54bcf580bb93b2be --out-dir /root/work/libpnet/pnet_macros/target/debug/deps -C incremental=/root/work/libpnet/pnet_macros/target/debug/incremental -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --extern pnet_macros=/root/work/libpnet/pnet_macros/target/debug/deps/libpnet_macros-6bb70d9bff3c27ed.so --extern pnet_macros_support=/root/work/libpnet/pnet_macros/target/debug/deps/libpnet_macros_support-3cc00d29cfce0b19.rlib --extern proc_macro2=/root/work/libpnet/pnet_macros/target/debug/deps/libproc_macro2-c7a0266743c747e3.rlib --extern quote=/root/work/libpnet/pnet_macros/target/debug/deps/libquote-74821f63340b6c48.rlib --extern regex=/root/work/libpnet/pnet_macros/target/debug/deps/libregex-3b38ba035ec50a14.rlib --extern syn=/root/work/libpnet/pnet_macros/target/debug/deps/libsyn-eaa076982918bc5f.rlib --extern trybuild=/root/work/libpnet/pnet_macros/target/debug/deps/libtrybuild-c94a3b442cb4def8.rlib`
     Running `rustc --crate-name pnet_macros --edition=2021 src/lib.rs --error-format=json --json=diagnostic-rendered-ansi --emit=dep-info,link -C prefer-dynamic -C embed-bitcode=no -C debuginfo=2 --test --cfg 'feature="default"' -C metadata=826bf7e4105c5920 -C extra-filename=-826bf7e4105c5920 --out-dir /root/work/libpnet/pnet_macros/target/debug/deps -C incremental=/root/work/libpnet/pnet_macros/target/debug/incremental -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --extern pnet_macros_support=/root/work/libpnet/pnet_macros/target/debug/deps/libpnet_macros_support-3cc00d29cfce0b19.rlib --extern proc_macro2=/root/work/libpnet/pnet_macros/target/debug/deps/libproc_macro2-c7a0266743c747e3.rlib --extern quote=/root/work/libpnet/pnet_macros/target/debug/deps/libquote-74821f63340b6c48.rlib --extern regex=/root/work/libpnet/pnet_macros/target/debug/deps/libregex-3b38ba035ec50a14.rlib --extern syn=/root/work/libpnet/pnet_macros/target/debug/deps/libsyn-eaa076982918bc5f.rlib --extern trybuild=/root/work/libpnet/pnet_macros/target/debug/deps/libtrybuild-c94a3b442cb4def8.rlib --extern proc_macro`
    Finished test [unoptimized + debuginfo] target(s) in 48.16s
     Running `/root/work/libpnet/pnet_macros/target/debug/deps/pnet_macros-826bf7e4105c5920`

running 11 tests
test util::radix16_u64::test ... ok
test util::operations_test ... ok
test util::test_display_get_operation ... ok
test util::radix16_u8::test ... ok
test util::test_get_mask ... ok
test util::test_get_shiftl ... ok
test util::test_get_shiftr ... ok
test decorator::test_generate_accessor_op_str ... ok
test util::test_to_mutator ... ok
test util::test_display_set_operation ... ok
test decorator::test_parse_ty ... ok

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s

     Running `/root/work/libpnet/pnet_macros/target/debug/deps/tests-54bcf580bb93b2be`

running 1 test
   Compiling memchr v2.4.1
   Compiling proc-macro2 v1.0.37
   Compiling syn v1.0.91
   Compiling unicode-xid v0.2.2
   Compiling regex-syntax v0.6.25
   Compiling pnet_base v0.29.0 (/root/work/libpnet/pnet_base)
   Compiling pnet_macros_support v0.29.0 (/root/work/libpnet/pnet_macros_support)
   Compiling aho-corasick v0.7.18
   Compiling quote v1.0.17
   Compiling regex v1.5.5
   Compiling pnet_macros v0.29.0 (/root/work/libpnet/pnet_macros)
   Compiling pnet_macros-tests v0.0.0 (/root/work/libpnet/pnet_macros/target/tests/pnet_macros)
    Finished dev [unoptimized + debuginfo] target(s) in 27.13s


test tests/compile-fail/construct-with-errors.rs [should fail to compile] ... ok
test tests/compile-fail/endianness_not_specified.rs [should fail to compile] ... ok
test tests/compile-fail/invalid_type.rs [should fail to compile] ... ok
test tests/compile-fail/length_expr.rs [should fail to compile] ... ok
test tests/compile-fail/length_expr_key.rs [should fail to compile] ... ok
test tests/compile-fail/length_expr_parentheses.rs [should fail to compile] ... ok
test tests/compile-fail/multiple_payload.rs [should fail to compile] ... ok
test tests/compile-fail/must_be_pub.rs [should fail to compile] ... ok
test tests/compile-fail/no_payload.rs [should fail to compile] ... ok
test tests/compile-fail/non-primitive.rs [should fail to compile] ... ok
test tests/compile-fail/payload_fn2.rs [should fail to compile] ... ok
test tests/compile-fail/unnamed_field.rs [should fail to compile] ... ok
test tests/compile-fail/variable_length_fields.rs [should fail to compile] ... ok
test tests/run-pass/construct_with.rs [should pass] ... ok
test tests/run-pass/get_variable_length_field.rs [should pass] ... ok
test tests/run-pass/length_expr.rs [should pass] ... ok
test tests/run-pass/min_packet_size.rs [should pass] ... ok
test tests/run-pass/mqtt.rs [should pass] ... ok
test tests/run-pass/packet_in_packet.rs [should pass] ... ok
test tests/run-pass/packet_size.rs [should pass] ... ok
test tests/run-pass/payload_fn.rs [should pass] ... ok
test tests/run-pass/variable_length_fields.rs [should pass] ... ok
test tests/run-pass/weird_field_pos.rs [should pass] ... ok


test compile_test ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 48.20s

   Doc-tests pnet_macros
     Running `rustdoc --edition=2021 --crate-type proc-macro --crate-name pnet_macros --test /root/work/libpnet/pnet_macros/src/lib.rs -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps -L dependency=/root/work/libpnet/pnet_macros/target/debug/deps --extern pnet_macros=/root/work/libpnet/pnet_macros/target/debug/deps/libpnet_macros-6bb70d9bff3c27ed.so --extern pnet_macros_support=/root/work/libpnet/pnet_macros/target/debug/deps/libpnet_macros_support-3cc00d29cfce0b19.rlib --extern proc_macro2=/root/work/libpnet/pnet_macros/target/debug/deps/libproc_macro2-c7a0266743c747e3.rlib --extern quote=/root/work/libpnet/pnet_macros/target/debug/deps/libquote-74821f63340b6c48.rlib --extern regex=/root/work/libpnet/pnet_macros/target/debug/deps/libregex-3b38ba035ec50a14.rlib --extern syn=/root/work/libpnet/pnet_macros/target/debug/deps/libsyn-eaa076982918bc5f.rlib --extern trybuild=/root/work/libpnet/pnet_macros/target/debug/deps/libtrybuild-c94a3b442cb4def8.rlib --extern proc_macro -C embed-bitcode=no --cfg 'feature="default"' --error-format human`

running 1 test
test src/lib.rs - (line 14) ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.77s

+ cd ..
+ run_packet_tests
+ cd pnet_packet
+ sh -c '/opt/local/bin/cargo test'
    Updating crates.io index
   Compiling proc-macro2 v1.0.37
   Compiling memchr v2.4.1
   Compiling unicode-xid v0.2.2
   Compiling syn v1.0.91
   Compiling regex-syntax v0.6.25
   Compiling pnet_base v0.29.0 (/root/work/libpnet/pnet_base)
   Compiling pnet_macros_support v0.29.0 (/root/work/libpnet/pnet_macros_support)
   Compiling aho-corasick v0.7.18
   Compiling quote v1.0.17
   Compiling regex v1.5.5
   Compiling pnet_macros v0.29.0 (/root/work/libpnet/pnet_macros)
   Compiling pnet_packet v0.29.0 (/root/work/libpnet/pnet_packet)
    Finished test [unoptimized + debuginfo] target(s) in 33.01s
     Running unittests (target/debug/deps/pnet_packet-bd3dbf8c26e3bae5)

running 45 tests
test ethernet::ether_type_to_str ... ok
test gre::gre_packet_test ... ok
test ethernet::ethernet_header_test ... ok
test gre::gre_checksum_test ... ok
test icmp::checksum_tests::checksum_nonzero ... ok
test icmp::checksum_tests::checksum_odd_bytes ... ok
test icmp::checksum_tests::checksum_zeros ... ok
test icmpv6::checksum_tests::checksum_echo_request ... ok
test icmpv6::ndp::ndp_tests::basic_na_parse ... ok
test icmpv6::ndp::ndp_tests::basic_na_create ... ok
test icmpv6::ndp::ndp_tests::basic_option_parsing ... ok
test icmpv6::ndp::ndp_tests::basic_ns_parse ... ok
test icmpv6::ndp::ndp_tests::basic_ra_create ... ok
test icmpv6::ndp::ndp_tests::basic_ns_create ... ok
test icmpv6::ndp::ndp_tests::basic_ra_parse ... ok
test icmpv6::ndp::ndp_tests::basic_redirect_parse ... ok
test icmpv6::ndp::ndp_tests::basic_redirect_create ... ok
test icmpv6::ndp::ndp_tests::basic_rs_create ... ok
test icmpv6::ndp::ndp_tests::basic_rs_parse ... ok
test ip::ip_next_header_protocol_to_str ... ok
test ipv4::checksum_tests::checksum_nonzero ... ok
test ipv4::checksum_tests::checksum_too_large_header_length ... ok
test ipv4::checksum_tests::checksum_too_small_header_length ... ok
test ipv4::checksum_tests::checksum_zeros ... ok
test ipv4::ipv4_options_length_test ... ok
test ipv4::ipv4_packet_set_payload_test ... ok
test ipv4::ipv4_packet_option_test ... ok
test ipv4::ipv4_packet_test ... ok
test ipv4::ipv4_payload_length_test ... ok
test ipv6::ipv6_header_test ... ok
test tcp::tcp_test_options_invalid_offset ... ok
test tcp::tcp_header_ipv4_test ... ok
test tcp::tcp_test_options_slice_invalid_offset ... ok
test tcp::tcp_test_option_invalid_len ... ok
test tcp::tcp_test_options_vec_invalid_offset ... ok
test tcp::tcp_test_payload_slice_invalid_offset ... ok
test udp::udp_header_ipv4_test ... ok
test udp::udp_header_ipv6_test ... ok
test usbpcap::tests::usbpcap_packet_test ... ok
test util::tests::sum_be_words_different_skipwords ... ok
test usbpcap::tests::usbpcap_packet_test_variable_header ... ok
test util::tests::sum_be_words_misaligned_ptr ... ok
test util::tests::sum_be_words_small_sizes ... ok
test vlan::tests::vlan_packet_test ... ok
test ipv4::ipv4_packet_set_payload_test_panic - should panic ... ok

test result: ok. 45 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests pnet_packet

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

+ cd ..
+ export RUST_TEST_THREADS=1
+ RUST_TEST_THREADS=1
+ case "$SYSTEM" in
+ echo 'Unsupported testing platform'
```