### PR TITLE
bump version for ipnetwork in pnet_datalink

### DIFF
--- a/pnet_datalink/Cargo.toml
+++ b/pnet_datalink/Cargo.toml
@@ -18,7 +18,7 @@ default = ["std"]
 
 [dependencies]
 libc = "0.2.97"
-ipnetwork = "0.18.0"
+ipnetwork = "0.19.0"
 pnet_base = { path = "../pnet_base", version = "0.30.0", default-features = false }
 pnet_sys = { path = "../pnet_sys", version = "0.30.0" }
 


### PR DESCRIPTION
Hey, 

small PR to  bump the version of `ipnetwork` in `pnet_datalink`. Since 0.30.0 I have a build error my code :
````
λ ~/dev/nettest(main*) » cargo run
   Compiling nettest v0.1.0 (/home/mathieu/dev/nettest)
error[E0308]: mismatched types
 --> src/main.rs:8:17
  |
7 |             match ip {
  |                   -- this expression has type `ipnetwork::IpNetwork`
8 |                 IpNetwork::V4(ipv4) => {
  |                 ^^^^^^^^^^^^^^^^^^^ expected enum `ipnetwork::IpNetwork`, found enum `IpNetwork`
  |
  = note: perhaps two different versions of crate `ipnetwork` are being used?

error[E0308]: mismatched types
  --> src/main.rs:11:17
   |
7  |             match ip {
   |                   -- this expression has type `ipnetwork::IpNetwork`
...
11 |                 IpNetwork::V6(ipv6) => {
   |                 ^^^^^^^^^^^^^^^^^^^ expected enum `ipnetwork::IpNetwork`, found enum `IpNetwork`
   |
   = note: perhaps two different versions of crate `ipnetwork` are being used?

For more information about this error, try `rustc --explain E0308`.
error: could not compile `nettest` due to 2 previous errors
````

Using the snippet below : 
```Rust
use pnet::datalink;
use pnet::ipnetwork::IpNetwork;

fn main() {
    for iface in datalink::interfaces() {
        for ip in iface.ips {
            match ip {
                IpNetwork::V4(ipv4) => {
                    println!("{:?}", ipv4.ip().to_string());
                }
                IpNetwork::V6(ipv6) => {
                    println!("{:?}", ipv6.ip().to_string());
                }
            }
        }
    }   
}
```

It seems like bumping ipnetwork version fixed it. I noticed it was done in the main `Cargo.toml` but not the one in `pnet_datalink`.