### PR TITLE
Update libc dependency to 0.2.117

### DIFF
--- a/pnet_sys/Cargo.toml
+++ b/pnet_sys/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming"]
 edition = "2021"
 
 [dependencies]
-libc = "0.2.94"
+libc = "0.2.117"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = [ "winsock2", "ws2ipdef" ] }


### PR DESCRIPTION
Updated to 0.2.117 to ensure compatibility of https://github.com/libpnet/libpnet/blob/0d7f3055e588c2739f7a5ba2e6d2dbd09f8654bf/pnet_sys/src/unix.rs#L55-L56 on Android