### PR TITLE
Apply dependabot on all subfolders

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,28 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
+- package-ecosystem: cargo
+  directory: "/pnet_base"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+- package-ecosystem: cargo
+  directory: "/pnet_sys"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+- package-ecosystem: cargo
+  directory: "/pnet_datalink"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+- package-ecosystem: cargo
+  directory: "/pnet_transport"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+- package-ecosystem: cargo
+  directory: "/pnet_packet"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Hi !

I noticed #576 doesn't update `ipnetwork ` for  `pnet_datalink/cargo.toml`. That's because dependabot.yml is configured to only  update the cargo.toml in the root directory of the repo.

This PR allows dependabot to update all subprojects of this repo.