### PR TITLE
pnet_macros: Fix handle_vec_primitive for multi byte primitives

### DIFF
--- a/pnet_macros/src/decorator.rs
+++ b/pnet_macros/src/decorator.rs
@@ -1019,7 +1019,7 @@ fn handle_vec_primitive(
                                         let end = min(current_offset + {packet_length}, pkt_len);
 
                                         let packet = &_self.packet[current_offset..end];
-                                        let mut vec: Vec<{inner_ty_str}> = Vec::with_capacity(packet.len());
+                                        let mut vec: Vec<{inner_ty_str}> = Vec::with_capacity(packet.len() / {size});
                                         let mut co = 0;
                                         for _ in 0..vec.capacity() {{
                                             vec.push({{

--- a/pnet_macros/tests/tests.rs
+++ b/pnet_macros/tests/tests.rs
@@ -4,3 +4,21 @@ fn compile_test() {
     t.compile_fail("tests/compile-fail/*.rs");
     t.pass("tests/run-pass/*.rs");
 }
+
+#[test]
+fn test_vec_primitive() {
+    use pnet_macros::packet;
+    use pnet_macros_support::types::u32be;
+
+    #[packet]
+    pub struct Test {
+        #[length = "4"]
+        pub v: Vec<u32be>,
+        #[payload]
+        #[length = "0"]
+        pub payload: Vec<u8>,
+    }
+
+    let res = TestPacket::new(&[0x00, 0x00, 0x00, 0x00]).unwrap();
+    assert_eq!(res.get_v(), vec![0]);
+}


### PR DESCRIPTION
Currently `get_*()` will panic for primitives larger than 1 byte with an array out of bounds, e.g. `u32be` because it will try to push for `vec.capacity()` times which is set to the number of bytes in the vec. The correct times to push is the number of elements, which is the number of bytes divided by the size.

