### PR TITLE
Add blanket impls of Packet for Box<T> and &T.

### DIFF
--- a/pnet_macros_support/src/packet.rs
+++ b/pnet_macros_support/src/packet.rs
@@ -32,7 +32,7 @@ impl<T: Packet> Packet for alloc::boxed::Box<T> {
 
     /// Retrieve the payload for the packet.
     fn payload(&self) -> &[u8] {
-        self.packet()
+        self.payload()
     }
 }
 
@@ -44,7 +44,7 @@ impl<T: Packet> Packet for &T {
 
     /// Retrieve the payload for the packet.
     fn payload(&self) -> &[u8] {
-        self.packet()
+        self.payload()
     }
 }
 

--- a/pnet_macros_support/src/packet.rs
+++ b/pnet_macros_support/src/packet.rs
@@ -23,6 +23,31 @@ pub trait Packet {
     fn payload(&self) -> &[u8];
 }
 
+/// Blanket impl for Boxed objects
+impl<T: Packet> Packet for alloc::boxed::Box<T> {
+    /// Retrieve the underlying buffer for the packet.
+    fn packet(&self) -> &[u8] {
+        self.packet()
+    }
+
+    /// Retrieve the payload for the packet.
+    fn payload(&self) -> &[u8] {
+        self.packet()
+    }
+}
+
+impl<T: Packet> Packet for &T {
+    /// Retrieve the underlying buffer for the packet.
+    fn packet(&self) -> &[u8] {
+        self.packet()
+    }
+
+    /// Retrieve the payload for the packet.
+    fn payload(&self) -> &[u8] {
+        self.packet()
+    }
+}
+
 /// Represents a generic, mutable, network packet.
 pub trait MutablePacket: Packet {
     /// Retreive the underlying, mutable, buffer for the packet.


### PR DESCRIPTION
This is an ease-of-use improvement. Allowing users to pass boxed objects and references into `send_to` etc.