### PR TITLE
Revert "Add blanket impls of Packet for Box<T> and &T."

### DIFF
--- a/pnet_macros_support/src/packet.rs
+++ b/pnet_macros_support/src/packet.rs
@@ -23,31 +23,6 @@ pub trait Packet {
     fn payload(&self) -> &[u8];
 }
 
-/// Blanket impl for Boxed objects
-impl<T: Packet> Packet for alloc::boxed::Box<T> {
-    /// Retrieve the underlying buffer for the packet.
-    fn packet(&self) -> &[u8] {
-        self.packet()
-    }
-
-    /// Retrieve the payload for the packet.
-    fn payload(&self) -> &[u8] {
-        self.payload()
-    }
-}
-
-impl<T: Packet> Packet for &T {
-    /// Retrieve the underlying buffer for the packet.
-    fn packet(&self) -> &[u8] {
-        self.packet()
-    }
-
-    /// Retrieve the payload for the packet.
-    fn payload(&self) -> &[u8] {
-        self.payload()
-    }
-}
-
 /// Represents a generic, mutable, network packet.
 pub trait MutablePacket: Packet {
     /// Retreive the underlying, mutable, buffer for the packet.


### PR DESCRIPTION
Reverts libpnet/libpnet#599

Looks like the implementation was incorrect, it gives the following warnings:

```
warning: function cannot return without recursing
  --> pnet_macros_support/src/packet.rs:29:5
   |
29 |     fn packet(&self) -> &[u8] {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ cannot return without recursing
30 |         self.packet()
   |         ------------- recursive call site
   |
   = help: a `loop` may express intention better if this is on purpose
   = note: `#[warn(unconditional_recursion)]` on by default

warning: function cannot return without recursing
  --> pnet_macros_support/src/packet.rs:34:5
   |
34 |     fn payload(&self) -> &[u8] {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot return without recursing
35 |         self.payload()
   |         -------------- recursive call site
   |
   = help: a `loop` may express intention better if this is on purpose

warning: function cannot return without recursing
  --> pnet_macros_support/src/packet.rs:41:5
   |
41 |     fn packet(&self) -> &[u8] {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ cannot return without recursing
42 |         self.packet()
   |         ------------- recursive call site
   |
   = help: a `loop` may express intention better if this is on purpose

warning: function cannot return without recursing
  --> pnet_macros_support/src/packet.rs:46:5
   |
46 |     fn payload(&self) -> &[u8] {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot return without recursing
47 |         self.payload()
   |         -------------- recursive call site
   |
   = help: a `loop` may express intention better if this is on purpose

```