### PR TITLE
Update license field following SPDX 2.1 license expression standard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pnet"
 version = "0.34.0"
 authors = [ "Robert Clipsham <robert@octarineparrot.com>" ]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"
 repository = "https://github.com/libpnet/libpnet"
 description = "Cross-platform, low level networking using the Rust programming language."

--- a/pnet_base/Cargo.toml
+++ b/pnet_base/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pnet_base"
 version = "0.34.0"
 authors = ["Robert Clipsham <robert@octarineparrot.com>", "Linus Färnstrand <faern@faern.net>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"
 repository = "https://github.com/libpnet/libpnet"
 description = "Fundamental base types and code used by pnet."

--- a/pnet_datalink/Cargo.toml
+++ b/pnet_datalink/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pnet_datalink"
 version = "0.34.0"
 authors = ["Robert Clipsham <robert@octarineparrot.com>", "Linus Färnstrand <faern@faern.net>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"
 repository = "https://github.com/libpnet/libpnet"
 description = "Cross-platform, datalink layer networking."

--- a/pnet_macros/Cargo.toml
+++ b/pnet_macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pnet_macros"
 version = "0.34.0"
 authors = ["Robert Clipsham <robert@octarineparrot.com>", "Pierre Chifflier <chifflier@wzdftpd.net>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"
 repository = "https://github.com/libpnet/libpnet"
 description = "Automatic bit manipulation for binary data formats"

--- a/pnet_macros_support/Cargo.toml
+++ b/pnet_macros_support/Cargo.toml
@@ -3,7 +3,7 @@
 name = "pnet_macros_support"
 version = "0.34.0"
 authors = ["Robert Clipsham <robert@octarineparrot.com>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"
 repository = "https://github.com/libpnet/libpnet"
 description = "Support library for libpnet_macros"

--- a/pnet_packet/Cargo.toml
+++ b/pnet_packet/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pnet_packet"
 version = "0.34.0"
 authors = ["Robert Clipsham <robert@octarineparrot.com>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"
 repository = "https://github.com/libpnet/libpnet"
 description = "Cross-platform, binary packet parsing and manipulation"

--- a/pnet_sys/Cargo.toml
+++ b/pnet_sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pnet_sys"
 version = "0.34.0"
 authors = ["Robert Clipsham <robert@octarineparrot.com>", "Linus Färnstrand <faern@faern.net>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"
 repository = "https://github.com/libpnet/libpnet"
 description = "Access to network related system function and calls."

--- a/pnet_transport/Cargo.toml
+++ b/pnet_transport/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pnet_transport"
 version = "0.34.0"
 authors = ["Robert Clipsham <robert@octarineparrot.com>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 homepage = "https://github.com/libpnet/libpnet"
 repository = "https://github.com/libpnet/libpnet"
 description = "Cross-platform, transport layer networking."


### PR DESCRIPTION
The new recommendation is to follow the SPDX 2.1 standard. This allows automatic license verification software to work properly. Reference: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields