### PR TITLE
Add a next_with_timeout method to DataLinkReciever

### DIFF
--- a/pnet_datalink/src/lib.rs
+++ b/pnet_datalink/src/lib.rs
@@ -215,6 +215,8 @@ pub trait DataLinkSender: Send {
 pub trait DataLinkReceiver: Send {
     /// Get the next ethernet frame in the channel.
     fn next(&mut self) -> io::Result<&[u8]>;
+    /// Get the next ethernet frame in the channel within the specified timeout.
+    fn next_with_timeout(&mut self, t: Duration) -> io::Result<&[u8]>;
 }
 
 /// Represents a network interface and its associated addresses.

--- a/pnet_datalink/src/linux.rs
+++ b/pnet_datalink/src/linux.rs
@@ -367,7 +367,7 @@ impl DataLinkReceiver for DataLinkReceiverImpl {
         }
     }
 
-    fn next_with_timeout<'a>(&'a mut self, t: Duration) -> io::Result<&[u8]> {
+    fn next_with_timeout(&mut self, t: Duration) -> io::Result<&[u8]> {
         let timeout = Some(pnet_sys::duration_to_timespec(t));
         let mut caddr: libc::sockaddr_storage = unsafe { mem::zeroed() };
         unsafe {

--- a/pnet_datalink/src/pcap.rs
+++ b/pnet_datalink/src/pcap.rs
@@ -177,6 +177,10 @@ impl<T: Activated + Send + Sync> DataLinkReceiver for DataLinkReceiverImpl<T> {
         };
         Ok(&self.read_buffer)
     }
+
+    fn next_with_timeout<'a>(&'a mut self, t: Duration) -> io::Result<&[u8]> {
+        unimplemented!()
+    }
 }
 
 /// Get a list of available network interfaces for the current machine.

--- a/pnet_datalink/src/winpcap.rs
+++ b/pnet_datalink/src/winpcap.rs
@@ -263,6 +263,10 @@ impl DataLinkReceiver for DataLinkReceiverImpl {
         };
         Ok(slice)
     }
+
+    fn next_with_timeout<'a>(&'a mut self, t: Duration) -> io::Result<&[u8]> {
+        unimplemented!()
+    }
 }
 
 /// Get a list of available network interfaces for the current machine.


### PR DESCRIPTION
One attempt at adding a way to do per-call timeouts on `DataLinkReciever`.
I added it this way for symmetry with the similarly-named `TransportChannel` methods, though I'm not sure if this is really the best way to do this; perhaps it would be better to just add a `set_timeout` method?