### PR TITLE
Add ICMP Destination unreachable Next-hop MTU

### DIFF
--- a/pnet_packet/src/icmp.rs
+++ b/pnet_packet/src/icmp.rs
@@ -321,7 +321,7 @@ pub mod destination_unreachable {
     //! +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     //! |     Type      |     Code      |          Checksum             |
     //! +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    //! |                             unused                            |
+    //! |             unused            |        Next-hop MTU           |
     //! +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     //! |      Internet Header + 64 bits of Original Data Datagram      |
     //! +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -381,7 +381,8 @@ pub mod destination_unreachable {
         #[construct_with(u8)]
         pub icmp_code: IcmpCode,
         pub checksum: u16be,
-        pub unused: u32be,
+        pub unused: u16be,
+        pub next_hop_mtu: u16be,
         #[payload]
         pub payload: Vec<u8>,
     }


### PR DESCRIPTION
This commit adds the Next-hop MTU as described in https://en.wikipedia.org/wiki/Internet_Control_Message_Protocol#Destination_unreachable

Fixes #661