### PR TITLE
Draft: fix for musl 1.2.0 time_t change

### DIFF
--- a/pnet_sys/src/unix.rs
+++ b/pnet_sys/src/unix.rs
@@ -105,6 +105,7 @@ pub mod public {
     /// Convert a Duration into a platform specific `timeval`.
     pub fn duration_to_timeval(dur: Duration) -> libc::timeval {
         libc::timeval {
+            #[cfg_attr(target_env = "musl", allow(deprecated))] // FIXME: https://github.com/rust-lang/libc/issues/1848
             tv_sec: dur.as_secs() as libc::time_t,
             tv_usec: dur.subsec_micros() as TvUsecType,
         }
@@ -118,6 +119,7 @@ pub mod public {
     /// Convert a Duration into a platform specific `timespec`.
     pub fn duration_to_timespec(dur: Duration) -> libc::timespec {
         libc::timespec {
+            #[cfg_attr(target_env = "musl", allow(deprecated))] // FIXME: https://github.com/rust-lang/libc/issues/1848
             tv_sec: dur.as_secs() as libc::time_t,
             tv_nsec: (dur.subsec_nanos() as TvUsecType).into(),
         }


### PR DESCRIPTION
https://github.com/rust-lang/libc/issues/1848

This is a work in progress to resolve the time_t definition change in musl 1.2.0, where on 32 bit systems the definition has been changed from 32 bits to 64 bits.