### PR TITLE
Fix unbound variable reference in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -62,6 +62,12 @@ if [[ -z "$PNET_TEST_IFACE" && "$SYSTEM" = "Linux" ]]; then
     done
 fi
 
+# To avoid unbound variable reference, $VERBOSE is explicitly set to
+# zero if $VERBOSE is unbound (or empty)
+if [ -z "$VERBOSE" ]; then
+    VERBOSE="0"
+fi
+
 set -euo pipefail
 
 # FIXME Need to link libraries properly on Windows


### PR DESCRIPTION
This commit fixes build.sh to run properly when environment variable $VERBOSE is not set.

Previously, `set -u` in build.sh caused the script to fail with `build.sh: line 170: $VERBOSE: unbound variable`
when environment variable $VERBOSE is not defined.
This fix introduces a check to set $VERBOSE to 0 if the variable is not set.