### PR TITLE
Remove unnecessary pattern matching in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -123,7 +123,7 @@ run_test() {
         MINGW*|MSYS*)
             PNET_TEST_IFACE=$PNET_TEST_IFACE RUST_TEST_THREADS=1 $TESTER
         ;;
-        FreeBSD|*)
+        *)
             echo "Unsupported testing platform"
         ;;
     esac


### PR DESCRIPTION
case statement in build.sh matches "FreeBSD" twice, and the latter matching is invalid because the former always matches first. 
```sh
    case "$SYSTEM" in
        Linux)
            ...
        ;;
        FreeBSD|Darwin) # Matches FreeBSD here
            ...
        ;;
        MINGW*|MSYS*)
            ...
        ;;
        FreeBSD|*) # And matches again here
            echo "Unsupported testing platform"
        ;;
    esac
```

This commit removes the latter matching that tells FreeBSD as unsupported platform because FreeBSD is now (probably) supported.