### PR TITLE
Bugfix for DNS response (length calculation) and further decoding of RRs.

### DIFF
--- a/pnet_packet/src/dns.rs
+++ b/pnet_packet/src/dns.rs
@@ -588,24 +588,39 @@ pub struct SrvName {
 impl SrvName {
     pub fn new(name: &str) -> Self {
         let parts: Vec<&str> = name.split('.').collect();
-        let (instance, service, protocol, domain) = match parts.as_slice() {
-            [instance, service, protocol, domain @ ..] if service.starts_with('_') && protocol.starts_with('_') => {
-                (Some(String::from(*instance)), Some(String::from(*service)), Some(String::from(*protocol)), Some(String::from(domain.join("."))))
+        match parts.len() {
+            len if len >4 => {
+                SrvName {
+                    instance: Some(parts[0..len-3].join(".")),
+                    service: Some(String::from(parts[len-3])),
+                    protocol: Some(String::from(parts[len-2])),
+                    domain: Some(String::from(parts[len-1])),
+                }
             },
-            [service, protocol, domain @ ..] if service.starts_with('_') && protocol.starts_with('_') => {
-                (None, Some(String::from(*service)), Some(String::from(*protocol)), Some(String::from(domain.join("."))))
+            4 => {
+                SrvName {
+                    instance: Some(String::from(parts[0])),
+                    service: Some(String::from(parts[1])),
+                    protocol: Some(String::from(parts[2])),
+                    domain: Some(String::from(parts[3])),
+                }
             },
-            [instance, service, protocol, domain @ ..] => {
-                (Some(String::from(*instance)), Some(String::from(*service)), Some(String::from(*protocol)), Some(String::from(domain.join("."))))
+            3 => {
+                SrvName {
+                    instance: None,
+                    service: Some(String::from(parts[0])),
+                    protocol: Some(String::from(parts[1])),
+                    domain: Some(String::from(parts[2])),
+                }
             },
-            _ => (None, None, None, None),
-        };
-
-        SrvName {
-            instance,
-            service,
-            protocol,
-            domain,
+            _ => {
+                SrvName {
+                    instance: None,
+                    service: None,
+                    protocol: None,
+                    domain: None,
+                }
+            },
         }
     }
 }

--- a/pnet_packet/src/dns.rs
+++ b/pnet_packet/src/dns.rs
@@ -425,7 +425,22 @@ pub struct DnsQuery {
 }
 
 fn qname_length(packet: &DnsQueryPacket) -> usize {
-    packet.packet().iter().take_while(|w| *w != &0).count() + 1
+    let mut offset = 0;
+    let mut size = 0;
+    loop {
+        let label_len = packet.packet()[offset] as usize;
+        if label_len == 0 {
+            size += 1;
+            break;
+        }
+        if label_len & 0xC0 == 0xC0 {
+            size += 2;
+            break;
+        }
+        size += label_len + 1;
+        offset += label_len + 1;
+    }
+    size
 }
 
 impl DnsQuery {


### PR DESCRIPTION
1. Fixed bugs in length calculation in fields of DNS responses - answer, authoritative and additional.
2. Added support to decode data for SRV services and put together any string (using C0 construct).
3. Tested against mDNS packets