### PR TITLE
Add Support for Parsing Profinet Packets

### DIFF
--- a/pnet_packet/src/ethernet.rs
+++ b/pnet_packet/src/ethernet.rs
@@ -161,7 +161,7 @@ impl fmt::Display for EtherType {
                    &EtherTypes::Ptp => "Ptp", //(0x88f7)
                    &EtherTypes::Cfm => "Cfm", //(0x8902)
                    &EtherTypes::QinQ => "QinQ", //(0x9100)
-                   &EtherTypes::Profinet => write!(f, "Profinet"),
+                   &EtherTypes::Profinet => "Profinet", //(0x8892)
                    _ => "unknown",
                })
     }

--- a/pnet_packet/src/ethernet.rs
+++ b/pnet_packet/src/ethernet.rs
@@ -110,6 +110,9 @@ pub mod EtherTypes {
     pub const Cfm: EtherType = EtherType(0x8902);
     /// Q-in-Q Vlan Tagging \[IEEE 802.1Q\].
     pub const QinQ: EtherType = EtherType(0x9100);
+    /// Process Field Network Protocol (Profinet)
+    pub const Profinet: EtherType = EtherType(0x8892);
+
 }
 
 /// Represents the `Ethernet::ethertype` field.
@@ -158,6 +161,7 @@ impl fmt::Display for EtherType {
                    &EtherTypes::Ptp => "Ptp", //(0x88f7)
                    &EtherTypes::Cfm => "Cfm", //(0x8902)
                    &EtherTypes::QinQ => "QinQ", //(0x9100)
+                   &EtherTypes::Profinet => write!(f, "Profinet"),
                    _ => "unknown",
                })
     }
@@ -173,5 +177,7 @@ fn ether_type_to_str() {
     assert_eq!(format!("{}", arp), "Arp");
     let unknown = EtherType(0x0666);
     assert_eq!(format!("{}", unknown), "unknown");
+    let profinet = EtherType(0x8892);
+    assert_eq!(format!("{}", profinet), "Profinet");
 }
 


### PR DESCRIPTION
**Summary:**
This pull request introduces support for parsing Profinet packets by adding the Profinet EtherType (0x8892). Profinet is a widely used industrial Ethernet protocol, and its inclusion will enhance the capability of the library to handle industrial communication standards.

**Details:**
- **New EtherType Constant:** Added a constant for Profinet (0x8892) to the `EtherTypes` module.
- **Display Implementation:** Updated the `fmt::Display` implementation for the `EtherType` struct to recognize and correctly display the Profinet EtherType.
- **Tests:** Added test cases to verify the correct handling and display of the Profinet EtherType.

**Justification:**
Profinet is an essential protocol in industrial automation, providing real-time data exchange capabilities. According to Siemens and Profinet documentation, the EtherType 0x8892 is used for Profinet Real-Time (RT) Ethernet frames to ensure low-latency and deterministic communication. This enhancement aligns the library with industry standards and expands its usability in industrial network applications.

References:
- [Profinet for Network Geeks](https://us.profinet.com/profinet-network-geeks-want/)
- [Profinet RT: Real-Time Performance](https://us.profinet.com/profinet-network-geeks-want/)

Please review the changes and let me know if there are any further improvements needed. Thank you for considering this addition.
