### PR TITLE
Use `core::net` instead of depending on `no-std-net`

### DIFF
--- a/pnet_base/Cargo.toml
+++ b/pnet_base/Cargo.toml
@@ -12,14 +12,13 @@ categories = ["network-programming"]
 edition = "2021"
 
 [dependencies]
-no-std-net = { version = "0.6.0", default-features = false }
 serde = { version = "1.0.171", optional = true, default-features = false }
 
 [dev-dependencies]
 serde_test = "1.0.171"
 
 [features]
-std = ["no-std-net/std"]
+std = []
 default = ["std"]
 
 [package.metadata.docs.rs]

--- a/pnet_base/src/lib.rs
+++ b/pnet_base/src/lib.rs
@@ -15,5 +15,3 @@ extern crate serde;
 
 mod macaddr;
 pub use crate::macaddr::*;
-
-pub use no_std_net as core_net;

--- a/pnet_macros_support/src/packet.rs
+++ b/pnet_macros_support/src/packet.rs
@@ -11,6 +11,7 @@
 extern crate alloc;
 use alloc::vec;
 
+use core::net::{Ipv4Addr, Ipv6Addr};
 use core::ops::{Deref, DerefMut, Index, IndexMut, Range, RangeFrom, RangeFull, RangeTo};
 use pnet_base;
 
@@ -222,7 +223,7 @@ impl PrimitiveValues for pnet_base::MacAddr {
     }
 }
 
-impl PrimitiveValues for ::pnet_base::core_net::Ipv4Addr {
+impl PrimitiveValues for Ipv4Addr {
     type T = (u8, u8, u8, u8);
     #[inline]
     fn to_primitive_values(&self) -> (u8, u8, u8, u8) {
@@ -232,7 +233,7 @@ impl PrimitiveValues for ::pnet_base::core_net::Ipv4Addr {
     }
 }
 
-impl PrimitiveValues for ::pnet_base::core_net::Ipv6Addr {
+impl PrimitiveValues for Ipv6Addr {
     type T = (u16, u16, u16, u16, u16, u16, u16, u16);
     #[inline]
     fn to_primitive_values(&self) -> (u16, u16, u16, u16, u16, u16, u16, u16) {

--- a/pnet_packet/src/arp.rs
+++ b/pnet_packet/src/arp.rs
@@ -13,7 +13,8 @@ use crate::ethernet::EtherType;
 
 use alloc::vec::Vec;
 
-use pnet_base::core_net::Ipv4Addr;
+use core::net::Ipv4Addr;
+
 use pnet_base::MacAddr;
 use pnet_macros::packet;
 

--- a/pnet_packet/src/dhcp.rs
+++ b/pnet_packet/src/dhcp.rs
@@ -2,7 +2,8 @@ use crate::PrimitiveValues;
 
 use alloc::vec::Vec;
 
-use pnet_base::core_net::Ipv4Addr;
+use core::net::Ipv4Addr;
+
 use pnet_base::MacAddr;
 use pnet_macros::packet;
 use pnet_macros_support::types::*;

--- a/pnet_packet/src/icmpv6.rs
+++ b/pnet_packet/src/icmpv6.rs
@@ -15,7 +15,7 @@ use alloc::vec::Vec;
 
 use pnet_macros::packet;
 use pnet_macros_support::types::*;
-use pnet_base::core_net::Ipv6Addr;
+use core::net::Ipv6Addr;
 
 /// Represents the "ICMPv6 type" header field.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -161,7 +161,7 @@ pub mod ndp {
 
     use pnet_macros::packet;
     use pnet_macros_support::types::*;
-    use pnet_base::core_net::Ipv6Addr;
+    use core::net::Ipv6Addr;
 
     #[allow(non_snake_case)]
     #[allow(non_upper_case_globals)]

--- a/pnet_packet/src/ipv4.rs
+++ b/pnet_packet/src/ipv4.rs
@@ -16,7 +16,7 @@ use alloc::vec::Vec;
 use pnet_macros::packet;
 use pnet_macros_support::types::*;
 
-use pnet_base::core_net::Ipv4Addr;
+use core::net::Ipv4Addr;
 
 /// The IPv4 header flags.
 #[allow(non_snake_case)]

--- a/pnet_packet/src/ipv6.rs
+++ b/pnet_packet/src/ipv6.rs
@@ -15,7 +15,7 @@ use alloc::vec::Vec;
 use pnet_macros::packet;
 use pnet_macros_support::types::*;
 
-use pnet_base::core_net::Ipv6Addr;
+use core::net::Ipv6Addr;
 
 /// Represents an IPv6 Packet.
 #[packet]

--- a/pnet_packet/src/tcp.rs
+++ b/pnet_packet/src/tcp.rs
@@ -17,8 +17,7 @@ use alloc::{vec, vec::Vec};
 use pnet_macros::packet;
 use pnet_macros_support::types::*;
 
-use pnet_base::core_net::Ipv4Addr;
-use pnet_base::core_net::Ipv6Addr;
+use core::net::{Ipv4Addr, Ipv6Addr};
 use crate::util::{self, Octets};
 
 /// The TCP flags.

--- a/pnet_packet/src/udp.rs
+++ b/pnet_packet/src/udp.rs
@@ -16,7 +16,7 @@ use alloc::vec::Vec;
 use pnet_macros::packet;
 use pnet_macros_support::types::*;
 
-use pnet_base::core_net::{Ipv4Addr, Ipv6Addr};
+use core::net::{Ipv4Addr, Ipv6Addr};
 use crate::util;
 
 /// Represents a UDP Packet.

--- a/pnet_packet/src/util.rs
+++ b/pnet_packet/src/util.rs
@@ -12,7 +12,7 @@ use crate::ip::IpNextHeaderProtocol;
 use pnet_macros_support::types::u16be;
 
 use core::convert::TryInto;
-use pnet_base::core_net::{Ipv4Addr, Ipv6Addr};
+use core::net::{Ipv4Addr, Ipv6Addr};
 use core::u16;
 use core::u8;
 

--- a/src/pnettest.rs
+++ b/src/pnettest.rs
@@ -21,7 +21,7 @@ use crate::transport::TransportProtocol::{Ipv4, Ipv6};
 use crate::transport::{
     ipv4_packet_iter, transport_channel, udp_packet_iter, TransportChannelType, TransportProtocol,
 };
-use pnet_base::core_net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::iter::Iterator;
 use std::sync::mpsc::channel;
 use std::thread;

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,5 +8,5 @@
 
 //! Miscellaneous utilities for low-level networking.
 
-pub use pnet_base::{core_net, MacAddr, ParseMacAddrErr};
+pub use pnet_base::{MacAddr, ParseMacAddrErr};
 pub use pnet_packet::util::{checksum, ipv4_checksum, ipv6_checksum, Octets};


### PR DESCRIPTION
As I wrote in a comment a few months ago (https://github.com/libpnet/libpnet/issues/133#issuecomment-2071615766). `core::net` is stable since Rust 1.77. So we can get rid of `no-std-net` here.

According to [this comment](https://github.com/libpnet/libpnet/pull/562#issuecomment-1136129586), it's fine to not support very old Rust versions. And I support that. 1.77 is soon three versions behind already, and not having to use custom IP addr types is really nice.