### PR TITLE
Fix undefined behavior in non-English Windows locales

### DIFF
--- a/pnet_datalink/src/winpcap.rs
+++ b/pnet_datalink/src/winpcap.rs
@@ -314,13 +314,12 @@ pub fn interfaces() -> Vec<NetworkInterface> {
 
         unsafe {
             let name_str_ptr = (*cursor).AdapterName.as_ptr() as *const i8;
-
-            let bytes = CStr::from_ptr(name_str_ptr).to_bytes();
-            let name_str = from_utf8_unchecked(bytes).to_owned();
+            let name_str_bytes = CStr::from_ptr(name_str_ptr).to_bytes();
+            let name_str = String::from_utf8_lossy(name_str_bytes).to_string();
 
             let description_str_ptr = (*cursor).Description.as_ptr() as *const i8;
-            let bytes = CStr::from_ptr(description_str_ptr).to_bytes();
-            let description_str = from_utf8_unchecked(bytes).to_owned();
+            let description_str_bytes = CStr::from_ptr(description_str_ptr).to_bytes();
+            let description_str = String::from_utf8_lossy(description_str_bytes).to_string();
 
             all_ifaces.push(NetworkInterface {
                 name: name_str,


### PR DESCRIPTION
`GetAdaptersInfo` from IPHlpApi.h returns string data in ANSI encoding as per [docs](https://learn.microsoft.com/en-us/windows/win32/api/iptypes/ns-iptypes-ip_adapter_info#members). Which probably means `windows-1251`? I'm not sure 🤔

https://github.com/libpnet/libpnet/blob/a01aa493e2ecead4c45e7322b6c5f7ab29e8a985/pnet_datalink/src/winpcap.rs#L288-L290

And calling `str::from_utf8_unchecked` on it is undefined behavior

https://github.com/libpnet/libpnet/blob/a01aa493e2ecead4c45e7322b6c5f7ab29e8a985/pnet_datalink/src/winpcap.rs#L323

```rust
pub const unsafe fn from_utf8_unchecked(v: &[u8]) -> &str {
    // SAFETY: the caller must guarantee that the bytes `v` are valid UTF-8.
    // Also relies on `&str` and `&[u8]` having the same layout.
    unsafe { mem::transmute(v) }
}
```

Sometimes that leads to panic
<details>
  <summary>Screenshot</summary>
  
  
![chinese](https://github.com/user-attachments/assets/813f84bd-2119-44ab-b994-0df51c61f6c1)

</details>

## How to reproduce
- Install Windows 11 23H2 with Simplified Chinese language
- Install Loopback Adapter, which contains a description in Chinese [[howto]](https://learn.microsoft.com/en-us/troubleshoot/windows-server/networking/install-microsoft-loopback-adapter#method-2)

NOTE: Changing `netloop.inf` to contain the same string and manually installing the driver in the English locale doesn't trigger this
<details>
  <summary>Screenshot</summary>
  
  ![english](https://github.com/user-attachments/assets/9aee5d60-a521-4745-ba71-108a296668bd)
</details>

## Other solutions
- return `CString`, which is awkward and a breaking change
- somehow use `encoding_rs` crate or something similar
