### PR TITLE
Draft vlan support

### DIFF
--- a/pnet_datalink/src/bindings/linux.rs
+++ b/pnet_datalink/src/bindings/linux.rs
@@ -37,3 +37,25 @@ pub struct packet_mreq {
     pub mr_alen: libc::c_ushort,
     pub mr_address: [libc::c_uchar; 8],
 }
+
+#[repr(C)]
+pub struct tpacket_auxdata {
+    pub tp_status: libc::c_uint,
+    pub tp_len: libc::c_uint,
+    pub tp_snaplen: libc::c_uint,
+    pub tp_mac: libc::c_ushort,
+    pub tp_net: libc::c_ushort,
+    pub tp_vlan_tci: libc::c_ushort,
+    pub tp_vlan_tpid: libc::c_ushort,
+}
+
+// struct tpacket_auxdata {
+//     __u32 tp_status;
+//     __u32 tp_len;      /* packet length */
+//     __u32 tp_snaplen;  /* captured length */
+//     __u16 tp_mac;
+//     __u16 tp_net;
+//     __u16 tp_vlan_tci;
+//     __u16 tp_vlan_tpid; /* Since Linux 3.14; earlier, these
+//                            were unused padding bytes */
+// };

--- a/pnet_datalink/src/bindings/linux.rs
+++ b/pnet_datalink/src/bindings/linux.rs
@@ -14,6 +14,7 @@ extern crate libc;
 pub const SOL_PACKET: libc::c_int = 263;
 pub const PACKET_ADD_MEMBERSHIP: libc::c_int = 1;
 pub const PACKET_MR_PROMISC: libc::c_int = 1;
+pub const PACKET_AUXDATA: libc::c_int = 8;
 pub const PACKET_FANOUT: libc::c_int = 18;
 pub const PACKET_FANOUT_HASH: libc::c_int = 0;
 pub const PACKET_FANOUT_LB: libc::c_int = 1;

--- a/pnet_datalink/src/dummy.rs
+++ b/pnet_datalink/src/dummy.rs
@@ -9,7 +9,7 @@
 //! Support for sending and receiving data link layer packets on a fake network managed
 //! by in memory FIFO queues. Useful for writing tests.
 
-use crate::{DataLinkReceiver, DataLinkSender, MacAddr, NetworkInterface};
+use crate::{DataLinkReceiver, DataLinkSender, MacAddr, NetworkInterface, TpacketAuxdata};
 
 use std::io;
 use std::sync::mpsc::{self, Receiver, Sender};
@@ -152,6 +152,11 @@ impl DataLinkReceiver for MockDataLinkReceiver {
                 }
             }
         }
+    }
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn next_msg(&mut self) -> io::Result<(&[u8], Option<TpacketAuxdata>)> {
+        let res = self.next()?;
+        return Ok((res, None));
     }
 }
 

--- a/pnet_datalink/src/lib.rs
+++ b/pnet_datalink/src/lib.rs
@@ -8,7 +8,7 @@
 
 //! Support for sending and receiving data link layer packets.
 
-// #![deny(warnings)]
+#![deny(warnings)]
 
 extern crate ipnetwork;
 extern crate libc;

--- a/pnet_datalink/src/lib.rs
+++ b/pnet_datalink/src/lib.rs
@@ -157,7 +157,10 @@ pub struct Config {
 
     pub promiscuous: bool,
 
+    ///enable auxdata
+    pub packet_auxdata: bool,
     /// Linux only: The socket's file descriptor that pnet will use
+    ///
     pub socket_fd: Option<i32>,
 }
 
@@ -173,6 +176,7 @@ impl Default for Config {
             linux_fanout: None,
             promiscuous: true,
             socket_fd: None,
+            packet_auxdata: false,
         }
     }
 }
@@ -189,14 +193,8 @@ impl Default for Config {
 /// When matching on the returned channel, make sure to include a catch-all so that code doesn't
 /// break when new channel types are added.
 #[inline]
-pub fn channel(
-    network_interface: &NetworkInterface,
-    configuration: Config,
-) -> io::Result<Channel> {
-    backend::channel(
-        network_interface,
-        (&configuration).into()
-    )
+pub fn channel(network_interface: &NetworkInterface, configuration: Config) -> io::Result<Channel> {
+    backend::channel(network_interface, (&configuration).into())
 }
 
 /// Trait to enable sending `$packet` packets.

--- a/pnet_datalink/src/lib.rs
+++ b/pnet_datalink/src/lib.rs
@@ -225,7 +225,7 @@ pub trait DataLinkSender: Send {
 pub trait DataLinkReceiver: Send {
     /// Get the next ethernet frame in the channel.
     fn next(&mut self) -> io::Result<&[u8]>;
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+
     fn next_msg(&mut self) -> io::Result<(&[u8], Option<TpacketAuxdata>)>;
 }
 

--- a/pnet_datalink/src/linux.rs
+++ b/pnet_datalink/src/linux.rs
@@ -120,11 +120,11 @@ pub fn channel(network_interface: &NetworkInterface, config: Config) -> io::Resu
         },
     };
 
-    let mut sendaddr: libc::sockaddr_storage = unsafe { mem::zeroed() };
-    let sendlen = network_addr_to_sockaddr(network_interface, &mut sendaddr, proto);
-    let send_addr = (&sendaddr as *const libc::sockaddr_storage) as *const libc::sockaddr;
+    let mut addr: libc::sockaddr_storage = unsafe { mem::zeroed() };
+    let len = network_addr_to_sockaddr(network_interface, &mut addr, proto);
+    let send_addr = (&addr as *const libc::sockaddr_storage) as *const libc::sockaddr;
     // Bind to interface
-    if unsafe { libc::bind(socket, send_addr, sendlen as libc::socklen_t) } == -1 {
+    if unsafe { libc::bind(socket, send_addr, len as libc::socklen_t) } == -1 {
         let err = io::Error::last_os_error();
         unsafe {
             pnet_sys::close(socket);
@@ -235,7 +235,7 @@ pub fn channel(network_interface: &NetworkInterface, config: Config) -> io::Resu
         write_buffer: vec![0; config.write_buffer_size],
         _channel_type: config.channel_type,
         send_addr: unsafe { *(send_addr as *const libc::sockaddr_ll) },
-        send_addr_len: sendlen,
+        send_addr_len: len,
         timeout: config
             .write_timeout
             .map(|to| pnet_sys::duration_to_timespec(to)),

--- a/pnet_packet/src/util.rs
+++ b/pnet_packet/src/util.rs
@@ -237,20 +237,20 @@ mod tests {
     }
 }
 
-// #[cfg(all(test, feature = "benchmark"))]
-// mod checksum_benchmarks {
-//     use super::checksum;
-//     use test::{black_box, Bencher};
+#[cfg(all(test, feature = "benchmark"))]
+mod checksum_benchmarks {
+    use super::checksum;
+    use test::{black_box, Bencher};
 
-//     #[bench]
-//     fn bench_checksum_small(b: &mut Bencher) {
-//         let data = vec![99u8; 20];
-//         b.iter(|| checksum(black_box(&data), 5));
-//     }
+    #[bench]
+    fn bench_checksum_small(b: &mut Bencher) {
+        let data = vec![99u8; 20];
+        b.iter(|| checksum(black_box(&data), 5));
+    }
 
-//     #[bench]
-//     fn bench_checksum_large(b: &mut Bencher) {
-//         let data = vec![123u8; 1024];
-//         b.iter(|| checksum(black_box(&data), 5));
-//     }
-// }
+    #[bench]
+    fn bench_checksum_large(b: &mut Bencher) {
+        let data = vec![123u8; 1024];
+        b.iter(|| checksum(black_box(&data), 5));
+    }
+}

--- a/pnet_packet/src/util.rs
+++ b/pnet_packet/src/util.rs
@@ -183,8 +183,8 @@ fn sum_be_words(data: &[u8], skipword: usize) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::sum_be_words;
-    use core::slice;
     use alloc::{vec, vec::Vec};
+    use core::slice;
 
     #[test]
     fn sum_be_words_different_skipwords() {
@@ -237,20 +237,20 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature = "benchmark"))]
-mod checksum_benchmarks {
-    use super::checksum;
-    use test::{black_box, Bencher};
+// #[cfg(all(test, feature = "benchmark"))]
+// mod checksum_benchmarks {
+//     use super::checksum;
+//     use test::{black_box, Bencher};
 
-    #[bench]
-    fn bench_checksum_small(b: &mut Bencher) {
-        let data = vec![99u8; 20];
-        b.iter(|| checksum(black_box(&data), 5));
-    }
+//     #[bench]
+//     fn bench_checksum_small(b: &mut Bencher) {
+//         let data = vec![99u8; 20];
+//         b.iter(|| checksum(black_box(&data), 5));
+//     }
 
-    #[bench]
-    fn bench_checksum_large(b: &mut Bencher) {
-        let data = vec![123u8; 1024];
-        b.iter(|| checksum(black_box(&data), 5));
-    }
-}
+//     #[bench]
+//     fn bench_checksum_large(b: &mut Bencher) {
+//         let data = vec![123u8; 1024];
+//         b.iter(|| checksum(black_box(&data), 5));
+//     }
+// }

--- a/pnet_sys/src/lib.rs
+++ b/pnet_sys/src/lib.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![deny(warnings)]
+//#![deny(warnings)]
 extern crate libc;
 
 use std::io;
@@ -79,6 +79,15 @@ pub fn recv_from(
         )
     });
 
+    if len < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(len as usize)
+    }
+}
+
+pub fn recv_msg(socket: CSocket, msg: *mut libc::msghdr) -> io::Result<usize> {
+    let len = imp::retry(&mut || unsafe { imp::recvmsg(socket, msg, 0) });
     if len < 0 {
         Err(io::Error::last_os_error())
     } else {
@@ -161,10 +170,10 @@ mod tests {
     use crate::get_socket_receive_timeout;
     use crate::recv_from;
     use crate::set_socket_receive_timeout;
-    use std::mem;
-    use std::time::{Duration, Instant};
     use crate::CSocket;
     use crate::SockAddrStorage;
+    use std::mem;
+    use std::time::{Duration, Instant};
 
     fn test_timeout(socket: CSocket) -> Duration {
         let mut buffer = [0u8; 1024];
@@ -182,7 +191,10 @@ mod tests {
         let d = Duration::new(1, 0);
         let res = set_socket_receive_timeout(socket, d.clone());
         match res {
-            Err(e) => panic!("set_socket_receive_timeout resulted in error: {}; are you root?", e),
+            Err(e) => panic!(
+                "set_socket_receive_timeout resulted in error: {}; are you root?",
+                e
+            ),
             _ => {}
         };
 
@@ -197,7 +209,10 @@ mod tests {
         let d = Duration::from_millis(500);
         let res = set_socket_receive_timeout(socket, d);
         match res {
-            Err(e) => panic!("set_socket_receive_timeout resulted in error: {}; are you root?", e),
+            Err(e) => panic!(
+                "set_socket_receive_timeout resulted in error: {}; are you root?",
+                e
+            ),
             _ => {}
         };
 
@@ -212,7 +227,10 @@ mod tests {
         let d = Duration::from_millis(1500);
         let res = set_socket_receive_timeout(socket, d);
         match res {
-            Err(e) => panic!("set_socket_receive_timeout resulted in error: {}; are you root?", e),
+            Err(e) => panic!(
+                "set_socket_receive_timeout resulted in error: {}; are you root?",
+                e
+            ),
             _ => {}
         };
 

--- a/pnet_sys/src/lib.rs
+++ b/pnet_sys/src/lib.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//#![deny(warnings)]
+#![deny(warnings)]
 extern crate libc;
 
 use std::io;

--- a/pnet_sys/src/unix.rs
+++ b/pnet_sys/src/unix.rs
@@ -3,8 +3,8 @@ use std::io;
 
 pub mod public {
 
-    use libc;
     use super::{htons, ntohs};
+    use libc;
     use std::io;
     use std::mem;
     use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
@@ -62,10 +62,12 @@ pub mod public {
     pub const IPV6_UNICAST_HOPS: libc::c_int = libc::IPV6_UNICAST_HOPS;
     pub const IPV6_TCLASS: libc::c_int = libc::IPV6_TCLASS;
 
-    pub use libc::{IFF_BROADCAST, IFF_LOOPBACK, IFF_RUNNING, IFF_MULTICAST, IFF_POINTOPOINT, IFF_UP};
+    pub use libc::{
+        IFF_BROADCAST, IFF_LOOPBACK, IFF_MULTICAST, IFF_POINTOPOINT, IFF_RUNNING, IFF_UP,
+    };
 
     #[cfg(any(target_os = "linux", target_os = "android"))]
-    pub use libc::{IFF_LOWER_UP, IFF_DORMANT};
+    pub use libc::{IFF_DORMANT, IFF_LOWER_UP};
 
     pub const INVALID_SOCKET: CSocket = -1;
 
@@ -253,6 +255,10 @@ pub unsafe fn recvfrom(
     libc::recvfrom(socket, buf, len, flags, addr, addrlen)
 }
 
+pub unsafe fn recvmsg(socket: CSocket, msg: *mut libc::msghdr, flags: libc::c_int) -> CouldFail {
+    libc::recvmsg(socket, msg, flags)
+}
+
 #[inline]
 pub fn retry<F>(f: &mut F) -> libc::ssize_t
 where
@@ -273,8 +279,8 @@ fn errno() -> i32 {
 #[cfg(test)]
 mod tests {
     use crate::duration_to_timespec;
-    use std::time::Duration;
     use crate::timespec_to_duration;
+    use std::time::Duration;
 
     #[test]
     fn test_duration_to_timespec() {


### PR DESCRIPTION
This is a draft for the ability to add vlan packet sniffing to raw linux sockets.  At the moment vlan tags are automatically stripped by the linux kernel and one needs some auxiliary constructs to reconstitute the vlan packet as it arrived on the wire.

Note that to demonstrate this ability I added an extra method to datalinkreceiver called next_msg, this is to demonstrate to how accessing the data construct for reconstituting vlan traffic is done, I don't want to add this method in the final version, it's for demo purposes (so you can see the differences in the existing next function like using recvmsg instead of recvfrom). In the final version we'd use the info of the returned tpacket_auxdata struct to add the vlan tag back in the bytes we return in the 'next' method.

The main gist of reconstituting vlan traffic is by enabling PACKET_AUXDATA as a socket option, when using the recv_msg syscall the kernel will then also return a control message, the struct is specified in https://man7.org/linux/man-pages/man7/packet.7.html as well as explanation of the PACKET_AUXDATA value, I also copied the specification of the struct as a comment in this draft for clarification (which I will remove from the final commit likely).

Mainly I'd like some comments on how best to approach adding the vlan traffic sniffing. I think the most straight forward way would be to enable an option in the config struct to enable reconstituting the vlan traffic as a config option (with it defaulting to false, so we don't change any end users relying on the kernel already stripping vlan tags), in which case we will enable PACKET_AUXDATA and if we detect if it is truly a VLAN packet to add the bytes back as to how they were transmitted on the wire. 

We can default to using recv_msg instead of recv_from in the next method as recv_msg is basically a more flexible variant of all the recv family of syscalls.

Please let me know your thoughts.