### PR TITLE
Fix cfgs to fix build with rust 1.80

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ travis = []
 serde = ["pnet_base/serde", "pnet_datalink?/serde"]
 std = ["pnet_base/std", "pnet_sys", "pnet_datalink", "pnet_transport", "ipnetwork"]
 default = ["std"]
+nightly = []
 
 [dependencies]
 ipnetwork = { version = "0.20.0", optional = true }

--- a/pnet_packet/benches/checksum_benchmarks.rs
+++ b/pnet_packet/benches/checksum_benchmarks.rs
@@ -1,0 +1,19 @@
+#![feature(test)]
+
+mod checksum_benchmarks {
+    extern crate test;
+    use pnet_packet::util::checksum;
+    use test::{black_box, Bencher};
+
+    #[bench]
+    fn bench_checksum_small(b: &mut Bencher) {
+        let data = vec![99u8; 20];
+        b.iter(|| checksum(black_box(&data), 5));
+    }
+
+    #[bench]
+    fn bench_checksum_large(b: &mut Bencher) {
+        let data = vec![123u8; 1024];
+        b.iter(|| checksum(black_box(&data), 5));
+    }
+}

--- a/pnet_packet/src/util.rs
+++ b/pnet_packet/src/util.rs
@@ -237,7 +237,7 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature = "benchmark"))]
+#[cfg(test)]
 mod checksum_benchmarks {
     use super::checksum;
     use test::{black_box, Bencher};

--- a/pnet_packet/src/util.rs
+++ b/pnet_packet/src/util.rs
@@ -236,21 +236,3 @@ mod tests {
         }
     }
 }
-
-#[cfg(test)]
-mod checksum_benchmarks {
-    use super::checksum;
-    use test::{black_box, Bencher};
-
-    #[bench]
-    fn bench_checksum_small(b: &mut Bencher) {
-        let data = vec![99u8; 20];
-        b.iter(|| checksum(black_box(&data), 5));
-    }
-
-    #[bench]
-    fn bench_checksum_large(b: &mut Bencher) {
-        let data = vec![123u8; 1024];
-        b.iter(|| checksum(black_box(&data), 5));
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,11 +11,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "nightly", feature(custom_attribute, plugin))]
 #![cfg_attr(feature = "nightly", plugin(pnet_macros_plugin))]
-#![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "benchmark", feature(test))]
-#![cfg_attr(feature = "clippy", plugin(clippy))]
-// We can't implement Iterator since we use streaming iterators
-#![cfg_attr(feature = "clippy", allow(should_implement_trait))]
 
 //! # libpnet
 //!
@@ -150,5 +146,5 @@ pub mod util;
 
 // NOTE should probably have a cfg(pnet_test_network) here, but cargo doesn't
 //      allow custom --cfg flags
-#[cfg(all(test, std))]
+#[cfg(all(test, feature="std"))]
 mod pnettest;


### PR DESCRIPTION
* With rust 1.80, cfgs are checked to be valid. See https://blog.rust-lang.org/2024/05/06/check-cfg.html
  * Remove deprecated clippy features: https://blog.rust-lang.org/2024/02/28/Clippy-deprecating-feature-cargo-clippy.html
  * Add "nightly" feature
* The use of `#[cfg(all(test, feature = "benchmark"))]` was invalid as benchmark isn't a feature. This was causing the benchmarks to never be run. Move these to the correct directory for benchmarks to allow these to run. This was tested by running `rustup run nightly cargo bench`