### PR TITLE
pnet_datalink::interfaces() better supports Windows

### DIFF
--- a/pnet_datalink/src/bindings/winpcap.rs
+++ b/pnet_datalink/src/bindings/winpcap.rs
@@ -12,11 +12,15 @@
 
 extern crate winapi;
 
+use std::ffi::c_void;
+
 use self::winapi::ctypes;
 use self::winapi::shared::{guiddef, minwindef};
 use self::winapi::um::{minwinbase, winnt};
 
+use libc::{c_char, size_t};
 use pnet_sys;
+use winapi::shared::minwindef::DWORD;
 
 #[repr(C)]
 pub struct _ADAPTER;
@@ -339,6 +343,11 @@ pub struct _IP_ADAPTER_ADDRESSES {
 
 pub type IP_ADAPTER_ADDRESSES = _IP_ADAPTER_ADDRESSES;
 pub type PIP_ADAPTER_ADDRESSES = *mut _IP_ADAPTER_ADDRESSES;
+pub type NETIO_STATUS = DWORD;
+pub type NETIOAPI_API = NETIO_STATUS;
+
+pub const AF_UNSPEC: u16 = 0;
+pub const GAA_FLAG_INCLUDE_PREFIX: ULONG = 0x10;
 
 #[link(name = "iphlpapi")]
 extern "system" {
@@ -352,6 +361,7 @@ extern "system" {
         AdapterAddresses: PIP_ADAPTER_ADDRESSES,
         SizePointer: PULONG,
     ) -> minwindef::DWORD;
+    pub fn ConvertLengthToIpv4Mask(MaskLength: ULONG, Mask: PULONG) -> NETIOAPI_API;
 }
 
 #[link(name = "Packet")]
@@ -379,4 +389,14 @@ extern "C" {
     pub fn PacketSetBuff(AdapterObject: LPADAPTER, dim: ctypes::c_int) -> winnt::BOOLEAN;
     pub fn PacketSetReadTimeout(AdapterObject: LPADAPTER, timeout: ctypes::c_int)
         -> winnt::BOOLEAN;
+}
+
+#[link(name = "Ws2_32")]
+extern "system" {
+    pub fn inet_ntop(
+        Family: i32,
+        pAddr: *const c_void,
+        pstringbuf: *mut c_char,
+        StringBufSize: size_t,
+    ) -> *mut c_char;
 }

--- a/pnet_datalink/src/winpcap.rs
+++ b/pnet_datalink/src/winpcap.rs
@@ -310,6 +310,8 @@ pub fn interfaces() -> Vec<NetworkInterface> {
         panic!("Unable to call GetAdaptersAddresses (dw_ret_val = {dw_ret_val})");
     }
 
+    unsafe { adapters.set_len(vec_size as usize); }
+
     // Create a complete list of NetworkInterfaces for the machine
     let mut cursor = adapters.as_mut_ptr();
     let mut all_ifaces = Vec::with_capacity(vec_size as usize);


### PR DESCRIPTION
It seems that pnet_datalink::interfaces() is still having limited supports on Windows platform, so I try my best to add back IPv6 supports and other details like flags for Windows. May you help me to review my code (sorry for my bad code since I am still very new in Rust)