### PR TITLE
fix: issue with elided vs explicit lifetime params

### DIFF
--- a/pnet_packet/src/ipv6.rs
+++ b/pnet_packet/src/ipv6.rs
@@ -37,7 +37,7 @@ pub struct Ipv6 {
 }
 
 impl<'p> ExtensionIterable<'p> {
-    pub fn new(buf: &[u8]) -> ExtensionIterable {
+    pub fn new(buf: &[u8]) -> ExtensionIterable<'_> {
         ExtensionIterable { buf: buf }
     }
 }

--- a/pnet_transport/src/lib.rs
+++ b/pnet_transport/src/lib.rs
@@ -331,7 +331,7 @@ macro_rules! transport_channel_iterator {
         #[doc = "Return a packet iterator with packets of type `"]
         #[doc = $tyname]
         #[doc = "` for some transport receiver."]
-        pub fn $func(tr: &mut TransportReceiver) -> $iter {
+        pub fn $func(tr: &mut TransportReceiver) -> $iter<'_> {
             $iter { tr: tr }
         }
 
@@ -339,7 +339,7 @@ macro_rules! transport_channel_iterator {
             #[doc = "Get the next (`"]
             #[doc = $tyname ]
             #[doc = "`, `IpAddr`) pair for the given channel."]
-            pub fn next(&mut self) -> io::Result<($ty, IpAddr)> {
+            pub fn next(&mut self) -> io::Result<($ty<'_>, IpAddr)> {
                 let mut caddr: pnet_sys::SockAddrStorage = unsafe { mem::zeroed() };
                 let res =
                     pnet_sys::recv_from(self.tr.socket.fd, &mut self.tr.buffer[..], &mut caddr);


### PR DESCRIPTION
Addresses lint error: "error: hiding a lifetime that's elided elsewhere is confusing".