### PR TITLE
feat: add winpkfilter pnet_datalink backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ appveyor = []
 travis = []
 serde = ["pnet_base/serde", "pnet_datalink?/serde"]
 std = ["pnet_base/std", "pnet_sys", "pnet_datalink", "pnet_transport", "ipnetwork"]
-default = ["std"]
+default = ["std", "pnet_datalink/winpcap"]
 nightly = []
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ serde = ["pnet_base/serde", "pnet_datalink?/serde"]
 std = ["pnet_base/std", "pnet_sys", "pnet_datalink", "pnet_transport", "ipnetwork"]
 default = ["std", "pnet_datalink/winpcap"]
 nightly = []
+winpkfilter = ["pnet_datalink/winpkfilter"]
 
 [dependencies]
 ipnetwork = { version = "0.20.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,11 @@ pcap = ["pnet_datalink/pcap"]
 appveyor = []
 travis = []
 serde = ["pnet_base/serde", "pnet_datalink?/serde"]
-std = ["pnet_base/std", "pnet_sys", "pnet_datalink", "pnet_transport", "ipnetwork"]
-default = ["std", "pnet_datalink/winpcap"]
+std = ["pnet_base/std", "pnet_sys", "pnet_datalink/std", "pnet_transport", "ipnetwork"]
+default = ["std"]
 nightly = []
 winpkfilter = ["pnet_datalink/winpkfilter"]
+winpcap = ["pnet_datalink/winpcap"]
 
 [dependencies]
 ipnetwork = { version = "0.20.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,18 @@ required-features = ["std"]
 name = "transport_echo_server"
 required-features = ["std"]
 
+[[example]]
+ name = "send_packets"
+required-features = ["std"]
+
+[[example]]
+name = "receive_packets"
+required-features = ["std"]
+
+[[example]]
+name = "listen"
+required-features = ["std"]
+
 [[bench]]
 name = "rs_sender"
 required-features = ["std"]

--- a/examples/list_interfaces.rs
+++ b/examples/list_interfaces.rs
@@ -6,11 +6,84 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-/// This examples simply print all interfaces to stdout
+/// This example prints detailed information about all network interfaces
 extern crate pnet_datalink;
 
 fn main() {
-    for interface in pnet_datalink::interfaces() {
-        println!("{}", interface);
+    let interfaces = pnet_datalink::interfaces();
+
+    println!("Found {} network interface(s):\n", interfaces.len());
+
+    for (i, interface) in interfaces.iter().enumerate() {
+        println!("Interface #{}", i + 1);
+        println!("  Device Name: {}", interface.name);
+        println!("  Description: {}", interface.description);
+        println!("  Index: {}", interface.index);
+
+        // Show MAC address
+        match interface.mac {
+            Some(mac) => println!("  MAC Address: {}", mac),
+            None => println!("  MAC Address: Not Available"),
+        }
+
+        // Show flags
+        println!("  Flags: 0x{:X}", interface.flags);
+
+        // Show status flags if available
+        let mut status_flags = Vec::new();
+        if interface.is_up() {
+            status_flags.push("UP");
+        }
+        if interface.is_broadcast() {
+            status_flags.push("BROADCAST");
+        }
+        if interface.is_loopback() {
+            status_flags.push("LOOPBACK");
+        }
+        if interface.is_point_to_point() {
+            status_flags.push("POINT_TO_POINT");
+        }
+        if interface.is_multicast() {
+            status_flags.push("MULTICAST");
+        }
+
+        #[cfg(unix)]
+        {
+            if interface.is_running() {
+                status_flags.push("RUNNING");
+            }
+        }
+
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        {
+            if interface.is_lower_up() {
+                status_flags.push("LOWER_UP");
+            }
+            if interface.is_dormant() {
+                status_flags.push("DORMANT");
+            }
+        }
+
+        if !status_flags.is_empty() {
+            println!("  Status: {}", status_flags.join(", "));
+        } else {
+            println!("  Status: None");
+        }
+
+        // Show IP addresses
+        if interface.ips.is_empty() {
+            println!("  IP Addresses: None");
+        } else {
+            println!("  IP Addresses:");
+            for ip in &interface.ips {
+                if ip.is_ipv4() {
+                    println!("    IPv4: {}", ip);
+                } else {
+                    println!("    IPv6: {}", ip);
+                }
+            }
+        }
+
+        println!("  ---");
     }
 }

--- a/examples/listen.rs
+++ b/examples/listen.rs
@@ -1,0 +1,607 @@
+// Copyright (c) 2024
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/// This example demonstrates receiving packets at both the datalink layer (Layer 2)
+/// and transport layer (Layer 4). It shows how to capture and parse different types of packets.
+extern crate pnet;
+extern crate pnet_datalink;
+
+use pnet::datalink::Channel::Ethernet;
+use pnet::datalink::{self, Config, NetworkInterface};
+use pnet::packet::arp::ArpPacket;
+use pnet::packet::ethernet::{EtherTypes, EthernetPacket};
+use pnet::packet::icmp::IcmpPacket;
+use pnet::packet::ip::IpNextHeaderProtocols;
+use pnet::packet::ipv4::Ipv4Packet;
+use pnet::packet::ipv6::Ipv6Packet;
+use pnet::packet::tcp::TcpPacket;
+use pnet::packet::udp::UdpPacket;
+use pnet::packet::Packet;
+use pnet::transport::TransportChannelType::Layer4;
+use pnet::transport::TransportProtocol::Ipv4;
+use pnet::transport::{icmp_packet_iter, tcp_packet_iter, transport_channel, udp_packet_iter};
+use std::env;
+use std::process;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() < 2 {
+        println!("Usage: {} <interface_name> [mode]", args[0]);
+        println!("Modes: layer2, layer4, both (default: both)");
+        println!("Example: {} eth0 layer2", args[0]);
+        println!("\nAvailable interfaces:");
+        for interface in datalink::interfaces() {
+            println!("  {}", interface.name);
+        }
+        return;
+    }
+
+    let interface_name = &args[1];
+    let mode = if args.len() >= 3 {
+        args[2].as_str()
+    } else {
+        "both"
+    };
+
+    // Find the network interface
+    let interface = datalink::interfaces()
+        .into_iter()
+        .find(|iface| iface.name == *interface_name)
+        .unwrap_or_else(|| {
+            println!("Interface '{}' not found", interface_name);
+            process::exit(1);
+        });
+
+    println!("Using interface: {}", interface.name);
+    println!("Mode: {}", mode);
+    println!("Starting packet capture... (Press Ctrl+C to stop)\n");
+
+    // Shared counters for statistics
+    let stats = Arc::new(PacketStats::new());
+
+    match mode {
+        "layer2" => {
+            receive_layer2_packets(&interface, stats);
+        }
+        "layer4" => {
+            receive_layer4_packets(&interface, stats);
+        }
+        "both" => {
+            let stats_l2 = Arc::clone(&stats);
+            let stats_l4 = Arc::clone(&stats);
+            let interface_l2 = interface.clone();
+            let interface_l4 = interface.clone();
+
+            // Start Layer 2 receiver in a separate thread
+            let l2_handle = thread::spawn(move || {
+                receive_layer2_packets(&interface_l2, stats_l2);
+            });
+
+            // Start Layer 4 receiver in a separate thread
+            let l4_handle = thread::spawn(move || {
+                receive_layer4_packets(&interface_l4, stats_l4);
+            });
+
+            // Print statistics every 5 seconds
+            let stats_print = Arc::clone(&stats);
+            let stats_handle = thread::spawn(move || {
+                let mut last_stats = PacketStats::new();
+                loop {
+                    thread::sleep(Duration::from_secs(5));
+                    stats_print.print_rate(&mut last_stats);
+                }
+            });
+
+            // Wait for threads (they run indefinitely)
+            let _ = l2_handle.join();
+            let _ = l4_handle.join();
+            let _ = stats_handle.join();
+        }
+        _ => {
+            println!("Invalid mode: {}. Use 'layer2', 'layer4', or 'both'", mode);
+            process::exit(1);
+        }
+    }
+}
+
+/// Statistics tracking for received packets
+struct PacketStats {
+    ethernet: AtomicUsize,
+    arp: AtomicUsize,
+    ipv4: AtomicUsize,
+    ipv6: AtomicUsize,
+    icmp: AtomicUsize,
+    tcp: AtomicUsize,
+    udp: AtomicUsize,
+    other: AtomicUsize,
+    total: AtomicUsize,
+    start_time: Instant,
+}
+
+impl PacketStats {
+    fn new() -> Self {
+        PacketStats {
+            ethernet: AtomicUsize::new(0),
+            arp: AtomicUsize::new(0),
+            ipv4: AtomicUsize::new(0),
+            ipv6: AtomicUsize::new(0),
+            icmp: AtomicUsize::new(0),
+            tcp: AtomicUsize::new(0),
+            udp: AtomicUsize::new(0),
+            other: AtomicUsize::new(0),
+            total: AtomicUsize::new(0),
+            start_time: Instant::now(),
+        }
+    }
+
+    fn increment_ethernet(&self) {
+        self.ethernet.fetch_add(1, Ordering::Relaxed);
+    }
+    fn increment_arp(&self) {
+        self.arp.fetch_add(1, Ordering::Relaxed);
+    }
+    fn increment_ipv4(&self) {
+        self.ipv4.fetch_add(1, Ordering::Relaxed);
+    }
+    fn increment_ipv6(&self) {
+        self.ipv6.fetch_add(1, Ordering::Relaxed);
+    }
+    fn increment_icmp(&self) {
+        self.icmp.fetch_add(1, Ordering::Relaxed);
+    }
+    fn increment_tcp(&self) {
+        self.tcp.fetch_add(1, Ordering::Relaxed);
+    }
+    fn increment_udp(&self) {
+        self.udp.fetch_add(1, Ordering::Relaxed);
+    }
+    fn increment_other(&self) {
+        self.other.fetch_add(1, Ordering::Relaxed);
+    }
+    fn increment_total(&self) {
+        self.total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn get_ethernet(&self) -> usize {
+        self.ethernet.load(Ordering::Relaxed)
+    }
+    fn get_arp(&self) -> usize {
+        self.arp.load(Ordering::Relaxed)
+    }
+    fn get_ipv4(&self) -> usize {
+        self.ipv4.load(Ordering::Relaxed)
+    }
+    fn get_ipv6(&self) -> usize {
+        self.ipv6.load(Ordering::Relaxed)
+    }
+    fn get_icmp(&self) -> usize {
+        self.icmp.load(Ordering::Relaxed)
+    }
+    fn get_tcp(&self) -> usize {
+        self.tcp.load(Ordering::Relaxed)
+    }
+    fn get_udp(&self) -> usize {
+        self.udp.load(Ordering::Relaxed)
+    }
+    fn get_other(&self) -> usize {
+        self.other.load(Ordering::Relaxed)
+    }
+    fn get_total(&self) -> usize {
+        self.total.load(Ordering::Relaxed)
+    }
+
+    fn print_stats(&self) {
+        let elapsed = self.start_time.elapsed().as_secs_f64();
+        let total = self.get_total();
+        let rate = if elapsed > 0.0 {
+            total as f64 / elapsed
+        } else {
+            0.0
+        };
+
+        println!("\n=== Packet Statistics ===");
+        println!(
+            "Runtime: {:.1}s | Total: {} packets ({:.1} pps)",
+            elapsed, total, rate
+        );
+        println!(
+            "Ethernet: {} | ARP: {} | IPv4: {} | IPv6: {}",
+            self.get_ethernet(),
+            self.get_arp(),
+            self.get_ipv4(),
+            self.get_ipv6()
+        );
+        println!(
+            "ICMP: {} | TCP: {} | UDP: {} | Other: {}",
+            self.get_icmp(),
+            self.get_tcp(),
+            self.get_udp(),
+            self.get_other()
+        );
+    }
+
+    fn print_rate(&self, last_stats: &mut PacketStats) {
+        let current_total = self.get_total();
+        let last_total = last_stats.get_total();
+        let rate = (current_total - last_total) as f64 / 5.0; // 5 second interval
+
+        println!("Rate: {:.1} pps | Total: {} packets", rate, current_total);
+
+        // Update last stats
+        last_stats.total.store(current_total, Ordering::Relaxed);
+    }
+}
+
+/// Demonstrates receiving packets at the datalink layer (Layer 2)
+fn receive_layer2_packets(interface: &NetworkInterface, stats: Arc<PacketStats>) {
+    println!("--- Layer 2 (Datalink) Packet Reception ---");
+
+    let config = Config {
+        write_buffer_size: 4096,
+        read_buffer_size: 4096,
+        read_timeout: None,
+        write_timeout: None,
+        channel_type: datalink::ChannelType::Layer2,
+        bpf_fd_attempts: 1000,
+        linux_fanout: None,
+        promiscuous: true,
+        socket_fd: None,
+    };
+
+    // Create a datalink channel
+    let (_tx, mut rx) = match datalink::channel(interface, config) {
+        Ok(Ethernet(tx, rx)) => (tx, rx),
+        Ok(_) => {
+            println!("Unhandled channel type");
+            return;
+        }
+        Err(e) => {
+            println!("Failed to create datalink channel: {}", e);
+            return;
+        }
+    };
+
+    let mut packet_count = 0;
+    loop {
+        match rx.next() {
+            Ok(packet) => {
+                packet_count += 1;
+                stats.increment_total();
+
+                if let Some(ethernet_packet) = EthernetPacket::new(packet) {
+                    stats.increment_ethernet();
+                    parse_ethernet_packet(&ethernet_packet, &stats);
+
+                    // Print first few packets for demonstration
+                    if packet_count <= 10 {
+                        print_ethernet_packet_info(&ethernet_packet, packet_count);
+                    }
+                }
+            }
+            Err(e) => {
+                println!("Failed to receive packet: {}", e);
+                break;
+            }
+        }
+
+        // Print statistics every 1000 packets
+        if packet_count % 1000 == 0 {
+            stats.print_stats();
+        }
+    }
+}
+
+/// Parse an Ethernet packet and extract inner protocol information
+fn parse_ethernet_packet(ethernet: &EthernetPacket, stats: &Arc<PacketStats>) {
+    match ethernet.get_ethertype() {
+        EtherTypes::Ipv4 => {
+            if let Some(ipv4_packet) = Ipv4Packet::new(ethernet.payload()) {
+                stats.increment_ipv4();
+                parse_ipv4_packet(&ipv4_packet, stats);
+            }
+        }
+        EtherTypes::Ipv6 => {
+            if let Some(ipv6_packet) = Ipv6Packet::new(ethernet.payload()) {
+                stats.increment_ipv6();
+                parse_ipv6_packet(&ipv6_packet, stats);
+            }
+        }
+        EtherTypes::Arp => {
+            if let Some(_arp_packet) = ArpPacket::new(ethernet.payload()) {
+                stats.increment_arp();
+            }
+        }
+        _ => {
+            stats.increment_other();
+        }
+    }
+}
+
+/// Parse IPv4 packet and extract transport layer information
+fn parse_ipv4_packet(ipv4: &Ipv4Packet, stats: &Arc<PacketStats>) {
+    match ipv4.get_next_level_protocol() {
+        IpNextHeaderProtocols::Icmp => {
+            if let Some(_icmp_packet) = IcmpPacket::new(ipv4.payload()) {
+                stats.increment_icmp();
+            }
+        }
+        IpNextHeaderProtocols::Tcp => {
+            if let Some(_tcp_packet) = TcpPacket::new(ipv4.payload()) {
+                stats.increment_tcp();
+            }
+        }
+        IpNextHeaderProtocols::Udp => {
+            if let Some(_udp_packet) = UdpPacket::new(ipv4.payload()) {
+                stats.increment_udp();
+            }
+        }
+        _ => {
+            stats.increment_other();
+        }
+    }
+}
+
+/// Parse IPv6 packet and extract transport layer information
+fn parse_ipv6_packet(ipv6: &Ipv6Packet, stats: &Arc<PacketStats>) {
+    match ipv6.get_next_header() {
+        IpNextHeaderProtocols::Icmpv6 => {
+            stats.increment_icmp();
+        }
+        IpNextHeaderProtocols::Tcp => {
+            if let Some(_tcp_packet) = TcpPacket::new(ipv6.payload()) {
+                stats.increment_tcp();
+            }
+        }
+        IpNextHeaderProtocols::Udp => {
+            if let Some(_udp_packet) = UdpPacket::new(ipv6.payload()) {
+                stats.increment_udp();
+            }
+        }
+        _ => {
+            stats.increment_other();
+        }
+    }
+}
+
+/// Print detailed information about an Ethernet packet
+fn print_ethernet_packet_info(ethernet: &EthernetPacket, count: usize) {
+    println!("\n--- Packet #{} ---", count);
+    println!(
+        "Ethernet: {} -> {} (Type: {:?})",
+        ethernet.get_source(),
+        ethernet.get_destination(),
+        ethernet.get_ethertype()
+    );
+
+    match ethernet.get_ethertype() {
+        EtherTypes::Ipv4 => {
+            if let Some(ipv4_packet) = Ipv4Packet::new(ethernet.payload()) {
+                println!(
+                    "  IPv4: {} -> {} (Proto: {:?})",
+                    ipv4_packet.get_source(),
+                    ipv4_packet.get_destination(),
+                    ipv4_packet.get_next_level_protocol()
+                );
+
+                match ipv4_packet.get_next_level_protocol() {
+                    IpNextHeaderProtocols::Tcp => {
+                        if let Some(tcp_packet) = TcpPacket::new(ipv4_packet.payload()) {
+                            println!(
+                                "    TCP: {}:{} -> {}:{}",
+                                ipv4_packet.get_source(),
+                                tcp_packet.get_source(),
+                                ipv4_packet.get_destination(),
+                                tcp_packet.get_destination()
+                            );
+                        }
+                    }
+                    IpNextHeaderProtocols::Udp => {
+                        if let Some(udp_packet) = UdpPacket::new(ipv4_packet.payload()) {
+                            println!(
+                                "    UDP: {}:{} -> {}:{}",
+                                ipv4_packet.get_source(),
+                                udp_packet.get_source(),
+                                ipv4_packet.get_destination(),
+                                udp_packet.get_destination()
+                            );
+                        }
+                    }
+                    IpNextHeaderProtocols::Icmp => {
+                        if let Some(icmp_packet) = IcmpPacket::new(ipv4_packet.payload()) {
+                            println!(
+                                "    ICMP: Type {:?}, Code {:?}",
+                                icmp_packet.get_icmp_type(),
+                                icmp_packet.get_icmp_code()
+                            );
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        EtherTypes::Arp => {
+            if let Some(arp_packet) = ArpPacket::new(ethernet.payload()) {
+                println!(
+                    "  ARP: {:?} {} -> {}",
+                    arp_packet.get_operation(),
+                    arp_packet.get_sender_proto_addr(),
+                    arp_packet.get_target_proto_addr()
+                );
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Demonstrates receiving packets at the transport layer (Layer 4)
+fn receive_layer4_packets(_interface: &NetworkInterface, stats: Arc<PacketStats>) {
+    println!("--- Layer 4 (Transport) Packet Reception ---");
+
+    // Start multiple transport receivers for different protocols
+    let stats_icmp = Arc::clone(&stats);
+    let stats_tcp = Arc::clone(&stats);
+    let stats_udp = Arc::clone(&stats);
+
+    // ICMP receiver
+    let icmp_handle = thread::spawn(move || {
+        receive_icmp_packets(stats_icmp);
+    });
+
+    // TCP receiver
+    let tcp_handle = thread::spawn(move || {
+        receive_tcp_packets(stats_tcp);
+    });
+
+    // UDP receiver
+    let udp_handle = thread::spawn(move || {
+        receive_udp_packets(stats_udp);
+    });
+
+    // Wait for all receivers
+    let _ = icmp_handle.join();
+    let _ = tcp_handle.join();
+    let _ = udp_handle.join();
+}
+
+/// Receive ICMP packets using transport layer API
+fn receive_icmp_packets(stats: Arc<PacketStats>) {
+    let protocol = Layer4(Ipv4(IpNextHeaderProtocols::Icmp));
+
+    let (_tx, mut rx) = match transport_channel(4096, protocol) {
+        Ok((tx, rx)) => (tx, rx),
+        Err(e) => {
+            println!("Failed to create ICMP transport channel: {}", e);
+            return;
+        }
+    };
+
+    let mut iter = icmp_packet_iter(&mut rx);
+    let mut count = 0;
+
+    println!("ICMP transport receiver started");
+
+    loop {
+        match iter.next() {
+            Ok((packet, addr)) => {
+                count += 1;
+                stats.increment_icmp();
+                stats.increment_total();
+
+                if count <= 5 {
+                    println!(
+                        "ICMP #{}: Type {:?}, Code {:?} from {}",
+                        count,
+                        packet.get_icmp_type(),
+                        packet.get_icmp_code(),
+                        addr
+                    );
+                }
+            }
+            Err(e) => {
+                println!("ICMP receive error: {}", e);
+                break;
+            }
+        }
+    }
+}
+
+/// Receive TCP packets using transport layer API
+fn receive_tcp_packets(stats: Arc<PacketStats>) {
+    let protocol = Layer4(Ipv4(IpNextHeaderProtocols::Tcp));
+
+    let (_tx, mut rx) = match transport_channel(4096, protocol) {
+        Ok((tx, rx)) => (tx, rx),
+        Err(e) => {
+            println!("Failed to create TCP transport channel: {}", e);
+            return;
+        }
+    };
+
+    let mut iter = tcp_packet_iter(&mut rx);
+    let mut count = 0;
+
+    println!("TCP transport receiver started");
+
+    loop {
+        match iter.next() {
+            Ok((packet, addr)) => {
+                count += 1;
+                stats.increment_tcp();
+                stats.increment_total();
+
+                if count <= 5 {
+                    println!(
+                        "TCP #{}: {}:{} -> {}:{} [Seq: {}, Ack: {}] from {}",
+                        count,
+                        addr,
+                        packet.get_source(),
+                        addr,
+                        packet.get_destination(),
+                        packet.get_sequence(),
+                        packet.get_acknowledgement(),
+                        addr
+                    );
+                }
+            }
+            Err(e) => {
+                println!("TCP receive error: {}", e);
+                break;
+            }
+        }
+    }
+}
+
+/// Receive UDP packets using transport layer API
+fn receive_udp_packets(stats: Arc<PacketStats>) {
+    let protocol = Layer4(Ipv4(IpNextHeaderProtocols::Udp));
+
+    let (_tx, mut rx) = match transport_channel(4096, protocol) {
+        Ok((tx, rx)) => (tx, rx),
+        Err(e) => {
+            println!("Failed to create UDP transport channel: {}", e);
+            return;
+        }
+    };
+
+    let mut iter = udp_packet_iter(&mut rx);
+    let mut count = 0;
+
+    println!("UDP transport receiver started");
+
+    loop {
+        match iter.next() {
+            Ok((packet, addr)) => {
+                count += 1;
+                stats.increment_udp();
+                stats.increment_total();
+
+                if count <= 5 {
+                    println!(
+                        "UDP #{}: {}:{} -> {}:{} [Len: {}] from {}",
+                        count,
+                        addr,
+                        packet.get_source(),
+                        addr,
+                        packet.get_destination(),
+                        packet.get_length(),
+                        addr
+                    );
+                }
+            }
+            Err(e) => {
+                println!("UDP receive error: {}", e);
+                break;
+            }
+        }
+    }
+}

--- a/examples/receive_packets.rs
+++ b/examples/receive_packets.rs
@@ -1,0 +1,131 @@
+// Copyright (c) 2024
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+ // option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/// Minimal packet receiver that captures UDP and ICMP packets and prints metadata in real time
+extern crate pnet;
+extern crate pnet_datalink;
+
+use pnet::datalink::Channel::Ethernet;
+use pnet::datalink::{self, Config};
+use pnet::packet::ethernet::{EtherTypes, EthernetPacket};
+use pnet::packet::icmp::IcmpPacket;
+use pnet::packet::ip::IpNextHeaderProtocols;
+use pnet::packet::ipv4::Ipv4Packet;
+use pnet::packet::udp::UdpPacket;
+use pnet::packet::Packet;
+use std::env;
+use std::process;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() < 2 {
+        println!("Usage: {} <interface_name>", args[0]);
+        println!("\nAvailable interfaces:");
+        for interface in datalink::interfaces() {
+            println!("  {}", interface.name);
+        }
+        return;
+    }
+
+    let interface_name = &args[1];
+
+    // Find the network interface
+    let interface = datalink::interfaces()
+        .into_iter()
+        .find(|iface| iface.name == *interface_name)
+        .unwrap_or_else(|| {
+            println!("Interface '{}' not found", interface_name);
+            process::exit(1);
+        });
+
+    println!("Listening on interface: {}", interface.name);
+    println!("Capturing UDP and ICMP packets... (Press Ctrl+C to stop)\n");
+
+    let config = Config {
+        write_buffer_size: 4096,
+        read_buffer_size: 4096,
+        read_timeout: None,
+        write_timeout: None,
+        channel_type: datalink::ChannelType::Layer2,
+        bpf_fd_attempts: 1000,
+        linux_fanout: None,
+        promiscuous: true,
+        socket_fd: None,
+    };
+
+    // Create a datalink channel
+    let (_tx, mut rx) = match datalink::channel(&interface, config) {
+        Ok(Ethernet(tx, rx)) => (tx, rx),
+        Ok(_) => {
+            println!("Unhandled channel type");
+            return;
+        }
+        Err(e) => {
+            println!("Failed to create datalink channel: {}", e);
+            return;
+        }
+    };
+
+    loop {
+        match rx.next() {
+            Ok(packet) => {
+                if let Some(ethernet_packet) = EthernetPacket::new(packet) {
+                    handle_ethernet_packet(&ethernet_packet);
+                }
+            }
+            Err(e) => {
+                println!("Failed to receive packet: {}", e);
+                break;
+            }
+        }
+    }
+}
+
+fn handle_ethernet_packet(ethernet: &EthernetPacket) {
+    match ethernet.get_ethertype() {
+        EtherTypes::Ipv4 => {
+            if let Some(ipv4_packet) = Ipv4Packet::new(ethernet.payload()) {
+                handle_ipv4_packet(&ipv4_packet);
+            }
+        }
+        _ => {} // Ignore other protocols
+    }
+}
+
+fn handle_ipv4_packet(ipv4: &Ipv4Packet) {
+    let src_ip = ipv4.get_source();
+    let dst_ip = ipv4.get_destination();
+
+    match ipv4.get_next_level_protocol() {
+        IpNextHeaderProtocols::Udp => {
+            if let Some(udp_packet) = UdpPacket::new(ipv4.payload()) {
+                println!(
+                    "UDP: {}:{} -> {}:{} [len:{}]",
+                    src_ip,
+                    udp_packet.get_source(),
+                    dst_ip,
+                    udp_packet.get_destination(),
+                    udp_packet.get_length()
+                );
+            }
+        }
+        IpNextHeaderProtocols::Icmp => {
+            if let Some(icmp_packet) = IcmpPacket::new(ipv4.payload()) {
+                println!(
+                    "ICMP: {} -> {} [type:{:?} code:{:?}]",
+                    src_ip,
+                    dst_ip,
+                    icmp_packet.get_icmp_type(),
+                    icmp_packet.get_icmp_code()
+                );
+            }
+        }
+        _ => {} // Ignore other protocols
+    }
+}

--- a/examples/send_packets.rs
+++ b/examples/send_packets.rs
@@ -1,0 +1,340 @@
+// Copyright (c) 2024
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/// This example demonstrates sending packets at both the datalink layer (Layer 2)
+/// and transport layer (Layer 4). It shows how to construct and send different types of packets.
+extern crate pnet;
+extern crate pnet_datalink;
+
+use pnet::datalink::Channel::Ethernet;
+use pnet::datalink::{self, Config, NetworkInterface};
+use pnet::packet::ethernet::{EtherTypes, EthernetPacket, MutableEthernetPacket};
+use pnet::packet::icmp::IcmpCode;
+use pnet::packet::ip::IpNextHeaderProtocols;
+use pnet::packet::ipv4::{Ipv4Flags, Ipv4Packet, MutableIpv4Packet};
+use pnet::packet::udp::{MutableUdpPacket, UdpPacket};
+use pnet::packet::MutablePacket;
+use pnet::transport::transport_channel;
+use pnet::transport::TransportChannelType::Layer4;
+use pnet::transport::TransportProtocol::Ipv4;
+use pnet::util::MacAddr;
+use std::env;
+use std::net::{IpAddr, Ipv4Addr};
+use std::process;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() < 2 {
+        println!("Usage: {} <interface_name> [target_ip]", args[0]);
+        println!("\nAvailable interfaces:");
+        for interface in datalink::interfaces() {
+            println!("  {}", interface.name);
+        }
+        return;
+    }
+
+    let interface_name = &args[1];
+    let target_ip = if args.len() >= 3 {
+        args[2].parse::<Ipv4Addr>().unwrap_or_else(|_| {
+            println!("Invalid IP address: {}", args[2]);
+            process::exit(1);
+        })
+    } else {
+        Ipv4Addr::new(8, 8, 8, 8) // Default to Google DNS
+    };
+
+    // Find the network interface
+    let interface = datalink::interfaces()
+        .into_iter()
+        .find(|iface| iface.name == *interface_name)
+        .unwrap_or_else(|| {
+            println!("Interface '{}' not found", interface_name);
+            process::exit(1);
+        });
+
+    println!("Using interface: {}", interface.name);
+    println!("Target IP: {}", target_ip);
+
+    // Demonstrate different types of packet sending
+    println!("\n=== Packet Sending Demo ===");
+
+    // 1. Send Layer 2 (Ethernet) packets
+    send_layer2_packets(&interface, target_ip);
+
+    // 2. Send Layer 4 (Transport) packets
+    send_layer4_packets(target_ip);
+}
+
+/// Demonstrates sending packets at the datalink layer (Layer 2)
+fn send_layer2_packets(interface: &NetworkInterface, target_ip: Ipv4Addr) {
+    println!("\n--- Layer 2 (Datalink) Packet Sending ---");
+
+    let config = Config {
+        write_buffer_size: 4096,
+        read_buffer_size: 4096,
+        read_timeout: None,
+        write_timeout: None,
+        channel_type: datalink::ChannelType::Layer2,
+        bpf_fd_attempts: 1000,
+        linux_fanout: None,
+        promiscuous: false,
+        socket_fd: None,
+    };
+
+    // Create a datalink channel
+    let (mut tx, _rx) = match datalink::channel(interface, config) {
+        Ok(Ethernet(tx, rx)) => (tx, rx),
+        Ok(_) => {
+            println!("Unhandled channel type");
+            return;
+        }
+        Err(e) => {
+            println!("Failed to create datalink channel: {}", e);
+            return;
+        }
+    };
+
+    // Send a few different types of packets
+    send_arp_packet(&mut *tx, interface, target_ip);
+    send_icmp_packet(&mut *tx, interface, target_ip);
+    send_udp_packet(&mut *tx, interface, target_ip);
+}
+
+/// Send an ARP request packet
+fn send_arp_packet(
+    tx: &mut dyn pnet::datalink::DataLinkSender,
+    interface: &NetworkInterface,
+    target_ip: Ipv4Addr,
+) {
+    use pnet::packet::arp::{ArpHardwareTypes, ArpOperations, MutableArpPacket};
+
+    println!("Sending ARP request for {}", target_ip);
+
+    // Get source MAC and IP
+    let source_mac = interface.mac.unwrap_or_else(|| {
+        println!("Interface has no MAC address");
+        MacAddr::new(0, 0, 0, 0, 0, 0)
+    });
+
+    let source_ip = interface
+        .ips
+        .iter()
+        .find_map(|ip_net| {
+            if let IpAddr::V4(ipv4) = ip_net.ip() {
+                Some(ipv4)
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| Ipv4Addr::new(192, 168, 1, 100));
+
+    // Build the complete packet: Ethernet + ARP
+    let ethernet_size = EthernetPacket::minimum_packet_size();
+    let arp_size = MutableArpPacket::minimum_packet_size();
+    let total_size = ethernet_size + arp_size;
+
+    tx.build_and_send(1, total_size, &mut |packet| {
+        let mut ethernet_packet = MutableEthernetPacket::new(packet).unwrap();
+
+        // Set Ethernet header
+        ethernet_packet.set_destination(MacAddr::broadcast());
+        ethernet_packet.set_source(source_mac);
+        ethernet_packet.set_ethertype(EtherTypes::Arp);
+
+        // Set ARP header
+        let mut arp_packet = MutableArpPacket::new(ethernet_packet.payload_mut()).unwrap();
+        arp_packet.set_hardware_type(ArpHardwareTypes::Ethernet);
+        arp_packet.set_protocol_type(EtherTypes::Ipv4);
+        arp_packet.set_hw_addr_len(6);
+        arp_packet.set_proto_addr_len(4);
+        arp_packet.set_operation(ArpOperations::Request);
+        arp_packet.set_sender_hw_addr(source_mac);
+        arp_packet.set_sender_proto_addr(source_ip);
+        arp_packet.set_target_hw_addr(MacAddr::new(0, 0, 0, 0, 0, 0));
+        arp_packet.set_target_proto_addr(target_ip);
+    });
+
+    println!("  ✓ ARP request sent");
+}
+
+/// Send an ICMP ping packet
+fn send_icmp_packet(
+    tx: &mut dyn pnet::datalink::DataLinkSender,
+    interface: &NetworkInterface,
+    target_ip: Ipv4Addr,
+) {
+    use pnet::packet::icmp::{IcmpTypes, MutableIcmpPacket};
+
+    println!("Sending ICMP ping to {}", target_ip);
+
+    let source_mac = interface.mac.unwrap_or(MacAddr::new(0, 0, 0, 0, 0, 0));
+    let source_ip = interface
+        .ips
+        .iter()
+        .find_map(|ip_net| {
+            if let IpAddr::V4(ipv4) = ip_net.ip() {
+                Some(ipv4)
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| Ipv4Addr::new(192, 168, 1, 100));
+
+    // Build Ethernet + IPv4 + ICMP packet
+    let ethernet_size = EthernetPacket::minimum_packet_size();
+    let ipv4_size = Ipv4Packet::minimum_packet_size();
+    let icmp_size = MutableIcmpPacket::minimum_packet_size();
+    let total_size = ethernet_size + ipv4_size + icmp_size;
+
+    tx.build_and_send(1, total_size, &mut |packet| {
+        let mut ethernet_packet = MutableEthernetPacket::new(packet).unwrap();
+
+        // Ethernet header
+        ethernet_packet.set_destination(MacAddr::new(0xff, 0xff, 0xff, 0xff, 0xff, 0xff)); // Broadcast for demo
+        ethernet_packet.set_source(source_mac);
+        ethernet_packet.set_ethertype(EtherTypes::Ipv4);
+
+        // IPv4 header
+        let mut ipv4_packet = MutableIpv4Packet::new(ethernet_packet.payload_mut()).unwrap();
+        ipv4_packet.set_version(4);
+        ipv4_packet.set_header_length(5);
+        ipv4_packet.set_dscp(0);
+        ipv4_packet.set_ecn(0);
+        ipv4_packet.set_total_length((ipv4_size + icmp_size) as u16);
+        ipv4_packet.set_identification(0x1234);
+        ipv4_packet.set_flags(Ipv4Flags::DontFragment);
+        ipv4_packet.set_fragment_offset(0);
+        ipv4_packet.set_ttl(64);
+        ipv4_packet.set_next_level_protocol(IpNextHeaderProtocols::Icmp);
+        ipv4_packet.set_source(source_ip);
+        ipv4_packet.set_destination(target_ip);
+
+        // Calculate IPv4 checksum
+        let checksum = pnet::packet::ipv4::checksum(&ipv4_packet.to_immutable());
+        ipv4_packet.set_checksum(checksum);
+
+        // ICMP header
+        let mut icmp_packet = MutableIcmpPacket::new(ipv4_packet.payload_mut()).unwrap();
+        icmp_packet.set_icmp_type(IcmpTypes::EchoRequest);
+        icmp_packet.set_icmp_code(IcmpCode::new(0));
+        icmp_packet.set_checksum(0); // Will be calculated
+
+        // Calculate ICMP checksum
+        let checksum = pnet::packet::icmp::checksum(&icmp_packet.to_immutable());
+        icmp_packet.set_checksum(checksum);
+    });
+
+    println!("  ✓ ICMP ping sent");
+}
+
+/// Send a UDP packet
+fn send_udp_packet(
+    tx: &mut dyn pnet::datalink::DataLinkSender,
+    interface: &NetworkInterface,
+    target_ip: Ipv4Addr,
+) {
+    println!("Sending UDP packet to {}:53 (DNS)", target_ip);
+
+    let source_mac = interface.mac.unwrap_or(MacAddr::new(0, 0, 0, 0, 0, 0));
+    let source_ip = interface
+        .ips
+        .iter()
+        .find_map(|ip_net| {
+            if let IpAddr::V4(ipv4) = ip_net.ip() {
+                Some(ipv4)
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| Ipv4Addr::new(192, 168, 1, 100));
+
+    let payload = b"Hello, World!";
+
+    // Build Ethernet + IPv4 + UDP packet
+    let ethernet_size = EthernetPacket::minimum_packet_size();
+    let ipv4_size = Ipv4Packet::minimum_packet_size();
+    let udp_size = UdpPacket::minimum_packet_size();
+    let total_size = ethernet_size + ipv4_size + udp_size + payload.len();
+
+    tx.build_and_send(1, total_size, &mut |packet| {
+        let mut ethernet_packet = MutableEthernetPacket::new(packet).unwrap();
+
+        // Ethernet header
+        ethernet_packet.set_destination(MacAddr::new(0xff, 0xff, 0xff, 0xff, 0xff, 0xff));
+        ethernet_packet.set_source(source_mac);
+        ethernet_packet.set_ethertype(EtherTypes::Ipv4);
+
+        // IPv4 header
+        let mut ipv4_packet = MutableIpv4Packet::new(ethernet_packet.payload_mut()).unwrap();
+        ipv4_packet.set_version(4);
+        ipv4_packet.set_header_length(5);
+        ipv4_packet.set_dscp(0);
+        ipv4_packet.set_ecn(0);
+        ipv4_packet.set_total_length((ipv4_size + udp_size + payload.len()) as u16);
+        ipv4_packet.set_identification(0x5678);
+        ipv4_packet.set_flags(Ipv4Flags::DontFragment);
+        ipv4_packet.set_fragment_offset(0);
+        ipv4_packet.set_ttl(64);
+        ipv4_packet.set_next_level_protocol(IpNextHeaderProtocols::Udp);
+        ipv4_packet.set_source(source_ip);
+        ipv4_packet.set_destination(target_ip);
+
+        // Calculate IPv4 checksum
+        let checksum = pnet::packet::ipv4::checksum(&ipv4_packet.to_immutable());
+        ipv4_packet.set_checksum(checksum);
+
+        // UDP header
+        let mut udp_packet = MutableUdpPacket::new(ipv4_packet.payload_mut()).unwrap();
+        udp_packet.set_source(12345);
+        udp_packet.set_destination(53); // DNS port
+        udp_packet.set_length((udp_size + payload.len()) as u16);
+        udp_packet.set_checksum(0);
+
+        // Copy payload
+        udp_packet.set_payload(payload);
+
+        // Calculate UDP checksum
+        let checksum =
+            pnet::packet::udp::ipv4_checksum(&udp_packet.to_immutable(), &source_ip, &target_ip);
+        udp_packet.set_checksum(checksum);
+    });
+
+    println!("  ✓ UDP packet sent");
+}
+
+/// Demonstrates sending packets at the transport layer (Layer 4)
+fn send_layer4_packets(target_ip: Ipv4Addr) {
+    println!("\n--- Layer 4 (Transport) Packet Sending ---");
+
+    let protocol = Layer4(Ipv4(IpNextHeaderProtocols::Udp));
+
+    // Create a transport channel
+    let (mut tx, _rx) = match transport_channel(4096, protocol) {
+        Ok((tx, rx)) => (tx, rx),
+        Err(e) => {
+            println!("Failed to create transport channel: {}", e);
+            return;
+        }
+    };
+
+    // Create a UDP packet
+    let mut vec: Vec<u8> = vec![0; UdpPacket::minimum_packet_size() + 13]; // 13 bytes for "Hello, World!"
+    let mut udp_packet = MutableUdpPacket::new(&mut vec[..]).unwrap();
+
+    udp_packet.set_source(54321);
+    udp_packet.set_destination(80); // HTTP port
+    udp_packet.set_length((UdpPacket::minimum_packet_size() + 13) as u16);
+    udp_packet.set_payload(b"Hello, World!");
+
+    // Send the packet
+    match tx.send_to(udp_packet, IpAddr::V4(target_ip)) {
+        Ok(_) => println!("  ✓ Layer 4 UDP packet sent to {}:80", target_ip),
+         Err(e) => println!("  ✗ Failed to send Layer 4 packet: {}", e),
+    }
+}

--- a/pnet_datalink/Cargo.toml
+++ b/pnet_datalink/Cargo.toml
@@ -14,7 +14,9 @@ edition = "2021"
 [features]
 netmap = []
 std = ["pnet_base/std"]
-default = ["std"]
+default = ["std", "winpcap"]
+winpcap = []
+winpkfilter = [ "ndisapi", "windows" ]
 
 [dependencies]
 libc = "0.2.147"
@@ -23,6 +25,11 @@ pnet_base = { path = "../pnet_base", version = "0.35.0", default-features = fals
 pnet_sys = { path = "../pnet_sys", version = "0.35.0" }
 
 pcap = { version = "2.0.0", optional = true }
+# TODO: Use a published crate once the following commit has been released.
+# https://github.com/wiresock/ndisapi-rs/pull/30
+# https://github.com/wiresock/ndisapi-rs/commit/1fc6cbff6a10fbef71b9b60aed5dfb74fad6e30c
+ndisapi = { git = "https://github.com/wiresock/ndisapi-rs.git", rev = "1fc6cbff6a10fbef71b9b60aed5dfb74fad6e30c", optional = true }
+windows = { version = "0.54.0", features = ["Win32_Foundation", "Win32_System_Threading"], optional = true }
 netmap_sys = { version = "0.1.4", optional = true, features = ["netmap_with_libs"] }
 serde = { version = "1.0.171", optional = true, default-features = false, features = [ "derive" ] }
 

--- a/pnet_datalink/Cargo.toml
+++ b/pnet_datalink/Cargo.toml
@@ -25,10 +25,7 @@ pnet_base = { path = "../pnet_base", version = "0.35.0", default-features = fals
 pnet_sys = { path = "../pnet_sys", version = "0.35.0" }
 
 pcap = { version = "2.0.0", optional = true }
-# TODO: Use a published crate once the following commit has been released.
-# https://github.com/wiresock/ndisapi-rs/pull/30
-# https://github.com/wiresock/ndisapi-rs/commit/1fc6cbff6a10fbef71b9b60aed5dfb74fad6e30c
-ndisapi = { git = "https://github.com/wiresock/ndisapi-rs.git", rev = "1fc6cbff6a10fbef71b9b60aed5dfb74fad6e30c", optional = true }
+ndisapi = { version = "0.6.5", optional = true }
 windows = { version = "0.54.0", features = ["Win32_Foundation", "Win32_System_Threading"], optional = true }
 netmap_sys = { version = "0.1.4", optional = true, features = ["netmap_with_libs"] }
 serde = { version = "1.0.171", optional = true, default-features = false, features = [ "derive" ] }

--- a/pnet_datalink/src/bindings/mod.rs
+++ b/pnet_datalink/src/bindings/mod.rs
@@ -22,5 +22,5 @@ pub mod bpf;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub mod linux;
 
-#[cfg(windows)]
+#[cfg(all(windows, feature = "winpcap"))]
 pub mod winpcap;

--- a/pnet_datalink/src/lib.rs
+++ b/pnet_datalink/src/lib.rs
@@ -30,12 +30,19 @@ pub use pnet_base::{MacAddr, ParseMacAddrErr};
 
 mod bindings;
 
-#[cfg(windows)]
+#[cfg(all(windows, feature = "winpcap"))]
 #[path = "winpcap.rs"]
 mod backend;
 
-#[cfg(windows)]
+#[cfg(all(windows, feature = "winpcap"))]
 pub mod winpcap;
+
+#[cfg(all(windows, feature = "winpkfilter"))]
+#[path = "winpkfilter.rs"]
+mod backend;
+
+#[cfg(all(windows, feature = "winpkfilter"))]
+pub mod winpkfilter;
 
 #[cfg(all(
     not(feature = "netmap"),

--- a/pnet_datalink/src/winpkfilter.rs
+++ b/pnet_datalink/src/winpkfilter.rs
@@ -1,0 +1,292 @@
+use super::{DataLinkReceiver, DataLinkSender, NetworkInterface};
+
+use ndisapi::{MacAddress, Ndisapi, IphlpNetworkAdapterInfo, EthRequest, EthRequestMut, IntermediateBuffer, FilterFlags};
+use pnet_base::MacAddr;
+use ipnetwork::IpNetwork;
+use windows::Win32::Foundation::{HANDLE, WAIT_OBJECT_0, WAIT_TIMEOUT};
+use windows::Win32::System::Threading::{CreateEventW, WaitForSingleObject};
+
+use std::collections::VecDeque;
+use std::io;
+
+/// The WinpkFilter's specific configuration.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct Config {
+    /// Size of buffer to use when writing packets.
+    pub write_buffer_size: usize,
+    /// Size of buffer to use when reading packets.
+    pub read_buffer_size: usize,
+}
+
+impl<'a> From<&'a super::Config> for Config {
+    fn from(config: &super::Config) -> Config {
+        Config {
+            write_buffer_size: config.write_buffer_size,
+            read_buffer_size: config.read_buffer_size,
+        }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Config {
+        Config {
+            write_buffer_size: 4096,
+            read_buffer_size: 4096,
+        }
+    }
+}
+
+pub fn channel(
+    network_interface: &NetworkInterface,
+    config: Config,
+) -> io::Result<super::Channel> {
+    let driver = Ndisapi::new("NDISRD").map_err(|e| {
+        io::Error::new(io::ErrorKind::Other, format!("Failed to open WinPkFilter driver: {}", e))
+    })?;
+
+    let adapters = driver.get_tcpip_bound_adapters_info().map_err(|e| {
+        io::Error::new(io::ErrorKind::Other, format!("Failed to get adapter information: {}", e))
+    })?;
+
+    // Find the adapter by name
+    let adapter = adapters.iter().find(|adapter| {
+        adapter.get_name() == &network_interface.name
+    }).ok_or_else(|| {
+        io::Error::new(io::ErrorKind::NotFound, "Network interface not found")
+    })?;
+
+    let adapter_handle = adapter.get_handle();
+
+    // Create event for packet notifications
+    let event = unsafe {
+        CreateEventW(None, true, false, None).map_err(|e| {
+            io::Error::new(io::ErrorKind::Other, format!("Failed to create event: {}", e))
+        })?
+    };
+
+    // Set the event for packet notifications on this adapter
+    driver.set_packet_event(adapter_handle, event).map_err(|e| {
+        io::Error::new(io::ErrorKind::Other, format!("Failed to set packet event: {}", e))
+    })?;
+
+    // Set adapter to listen mode to capture packets without intercepting them
+    driver.set_adapter_mode(adapter_handle, FilterFlags::MSTCP_FLAG_SENT_RECEIVE_LISTEN).map_err(|e| {
+        io::Error::new(io::ErrorKind::Other, format!("Failed to set adapter mode: {}", e))
+    })?;
+
+    let sender = Box::new(DataLinkSenderImpl {
+        driver: driver.clone(),
+        adapter_handle,
+        write_buffer: vec![0u8; config.write_buffer_size],
+    });
+
+    let receiver = Box::new(DataLinkReceiverImpl {
+        driver,
+        adapter_handle,
+        event,
+        read_buffer: IntermediateBuffer::default(),
+        packets: VecDeque::new(),
+        packet_data: vec![0u8; config.read_buffer_size],
+    });
+
+    Ok(super::Channel::Ethernet(sender, receiver))
+}
+
+struct DataLinkSenderImpl {
+    driver: Ndisapi,
+    adapter_handle: HANDLE,
+    write_buffer: Vec<u8>,
+}
+
+impl DataLinkSender for DataLinkSenderImpl {
+    fn build_and_send(
+        &mut self,
+        num_packets: usize,
+        packet_size: usize,
+        func: &mut dyn FnMut(&mut [u8]),
+    ) -> Option<io::Result<()>> {
+        let total_len = num_packets * packet_size;
+        if total_len > self.write_buffer.len() {
+            return None;
+        }
+
+        // Build packets using the provided function
+        for i in 0..num_packets {
+            let start = i * packet_size;
+            let end = start + packet_size;
+            func(&mut self.write_buffer[start..end]);
+
+            // Create an IntermediateBuffer and copy the packet data
+            let mut intermediate_buffer = IntermediateBuffer::default();
+
+            // Check if packet size is within limits (MAX_ETHER_FRAME is the buffer size)
+            const MAX_FRAME_SIZE: usize = 1514; // Standard Ethernet frame size
+            if packet_size > MAX_FRAME_SIZE {
+                return Some(Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "Packet size exceeds maximum frame size"
+                )));
+            }
+
+            intermediate_buffer.set_length(packet_size as u32);
+            intermediate_buffer.get_data_mut()
+                .copy_from_slice(&self.write_buffer[start..end]);
+
+            // Create EthRequest and send the packet
+            let mut request = EthRequest::new(self.adapter_handle);
+            request.set_packet(&intermediate_buffer);
+
+            if let Err(e) = self.driver.send_packet_to_adapter(&request) {
+                return Some(Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("Failed to send packet: {}", e)
+                )));
+            }
+        }
+
+        Some(Ok(()))
+    }
+
+    fn send_to(&mut self, packet: &[u8], _dst: Option<NetworkInterface>) -> Option<io::Result<()>> {
+        self.build_and_send(1, packet.len(), &mut |buf| {
+            buf.copy_from_slice(packet);
+        })
+    }
+}
+
+struct DataLinkReceiverImpl {
+    driver: Ndisapi,
+    adapter_handle: HANDLE,
+    event: HANDLE,
+    read_buffer: IntermediateBuffer,
+    packets: VecDeque<Vec<u8>>,
+    packet_data: Vec<u8>,
+}
+
+impl DataLinkReceiver for DataLinkReceiverImpl {
+    fn next(&mut self) -> io::Result<&[u8]> {
+        // If we have buffered packets, return the next one
+        if let Some(packet) = self.packets.pop_front() {
+            self.packet_data = packet;
+            return Ok(&self.packet_data);
+        }
+
+        // Wait for packets to arrive
+        loop {
+            // Wait for the event to signal that packets are available
+            let wait_result = unsafe { WaitForSingleObject(self.event, 100) }; // 100ms timeout
+
+            if wait_result != WAIT_OBJECT_0 && wait_result != WAIT_TIMEOUT {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other, 
+                    "Event wait failed"
+                ));
+            }
+
+            // Try to read packets while they're available
+            loop {
+                // Create a read request
+                let mut read_request = EthRequestMut::new(self.adapter_handle);
+                read_request.set_packet(&mut self.read_buffer);
+
+                // Try to read a packet
+                match self.driver.read_packet(&mut read_request) {
+                    Ok(_) => {
+                        // Successfully read a packet, store it in our buffer
+                        let packet_len = self.read_buffer.get_length() as usize;
+                        if packet_len > 0 {
+                            let packet_data = self.read_buffer.get_data().to_vec();
+                            self.packets.push_back(packet_data);
+                            // In listen mode, original packets automatically continue through the stack
+                        }
+                    }
+                    Err(_) => {
+                        // No more packets available, break from read loop
+                        break;
+                    }
+                }
+            }
+
+            // If we have packets after reading, return the first one
+            if let Some(packet) = self.packets.pop_front() {
+                self.packet_data = packet;
+                return Ok(&self.packet_data);
+            }
+
+            // If no packets available and this was a timeout, continue waiting
+            if wait_result == WAIT_TIMEOUT {
+                continue;
+            }
+        }
+    }
+}
+
+pub fn interfaces() -> Vec<NetworkInterface> {
+    let mut interfaces = Vec::new();
+
+    let driver = match Ndisapi::new("NDISRD") {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Failed to open WinPkFilter driver: {:?}", e);
+            eprintln!("Make sure the Windows Packet Filter driver is installed and running.");
+            return Vec::new();
+        }
+    };
+
+    let adapters = match driver.get_tcpip_bound_adapters_info() {
+        Ok(adapters) => adapters,
+        Err(e) => {
+            eprintln!("Failed to get adapter information: {:?}", e);
+            return Vec::new();
+        }
+    };
+
+    for adapter in adapters {
+        let name = adapter.get_name().to_string();
+        let description =
+            Ndisapi::get_friendly_adapter_name(adapter.get_name()).unwrap_or_else(|_| name.clone());
+
+        let index = adapter.get_handle().0 as u32; // this is a HANDLE, but we can treat as u32 for indexing
+
+        // Get MAC
+        let mac: Option<MacAddr> = MacAddress::from_slice(adapter.get_hw_address())
+    .map(|m| {
+        let bytes = m.get();
+        MacAddr(bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5])
+    });
+
+        // Get IP addresses using ndisapi-rs IP Helper functionality
+        let ips: Vec<IpNetwork> = if let Some(mac_addr) = MacAddress::from_slice(adapter.get_hw_address()) {
+            if let Some(ip_info) = IphlpNetworkAdapterInfo::get_connection_by_hw_address(&mac_addr) {
+                ip_info.unicast_address_list_with_prefix()
+                    .iter()
+                    .filter_map(|(ip_addr, prefix_len)| {
+                        IpNetwork::new(*ip_addr, *prefix_len).ok()
+                    })
+                    .collect()
+            } else {
+                vec![]
+            }
+        } else {
+            vec![]
+        };
+
+        interfaces.push(NetworkInterface {
+            name,
+            description,
+            index,
+            mac,
+            ips,
+            flags: 0,
+        });
+    }
+
+    interfaces
+}
+
+unsafe impl Send for DataLinkSenderImpl {}
+unsafe impl Sync for DataLinkSenderImpl {}
+
+unsafe impl Send for DataLinkReceiverImpl {}
+unsafe impl Sync for DataLinkReceiverImpl {}
+

--- a/pnet_packet/src/ipv6.rs
+++ b/pnet_packet/src/ipv6.rs
@@ -37,7 +37,7 @@ pub struct Ipv6 {
 }
 
 impl<'p> ExtensionIterable<'p> {
-    pub fn new(buf: &[u8]) -> ExtensionIterable {
+    pub fn new(buf: &[u8]) -> ExtensionIterable<'_> {
         ExtensionIterable { buf: buf }
     }
 }

--- a/pnet_transport/src/lib.rs
+++ b/pnet_transport/src/lib.rs
@@ -331,7 +331,7 @@ macro_rules! transport_channel_iterator {
         #[doc = "Return a packet iterator with packets of type `"]
         #[doc = $tyname]
         #[doc = "` for some transport receiver."]
-        pub fn $func(tr: &mut TransportReceiver) -> $iter {
+        pub fn $func(tr: &mut TransportReceiver) -> $iter<'_> {
             $iter { tr: tr }
         }
 
@@ -339,7 +339,7 @@ macro_rules! transport_channel_iterator {
             #[doc = "Get the next (`"]
             #[doc = $tyname ]
             #[doc = "`, `IpAddr`) pair for the given channel."]
-            pub fn next(&mut self) -> io::Result<($ty, IpAddr)> {
+            pub fn next(&mut self) -> io::Result<($ty<'_>, IpAddr)> {
                 let mut caddr: pnet_sys::SockAddrStorage = unsafe { mem::zeroed() };
                 let res =
                     pnet_sys::recv_from(self.tr.socket.fd, &mut self.tr.buffer[..], &mut caddr);

--- a/typos.toml
+++ b/typos.toml
@@ -6,4 +6,5 @@ extend-ignore-identifiers-re = [
     "SunNd",
     "Ect",
     "ECT",
+    "uable",
 ]


### PR DESCRIPTION
Expand the list_interfaces example to include more meta-information about the interfaces.

Introduce listen, send_packets and receive_packets which demonstrate packet injection functionality of pnet_datalink.