### PR TITLE
pnet_macros: fix packet_size undercount for Vec<#[packet]> (fixes #726)

### DIFF
--- a/pnet_macros/src/decorator.rs
+++ b/pnet_macros/src/decorator.rs
@@ -297,7 +297,7 @@ fn make_packet(s: &syn::DataStruct, name: String) -> Result<Packet, Error> {
         };
 
         match ty {
-            Type::Vector(_) => {
+            Type::Vector(ref inner_ty) => {
                 struct_length = if let Some(construct_with) = construct_with.as_ref() {
                     let mut inner_size = 0;
                     for arg in construct_with.iter() {
@@ -320,7 +320,16 @@ fn make_packet(s: &syn::DataStruct, name: String) -> Result<Packet, Error> {
 
                     Some(format!("_packet.{}.len() * {}", field_name, inner_size).to_owned())
                 } else {
-                    Some(format!("_packet.{}.len()", field_name).to_owned())
+                    match **inner_ty {
+                        Type::Misc(ref packet_name) => Some(
+                            format!(
+                                "_packet.{}.iter().map(|x| {}Packet::packet_size(x)).sum::<usize>()",
+                                field_name, packet_name
+                            )
+                            .to_owned(),
+                        ),
+                        _ => Some(format!("_packet.{}.len()", field_name).to_owned()),
+                    }
                 };
                 if !is_payload && packet_length.is_none() {
                     return Err(Error::new(
@@ -1426,7 +1435,7 @@ fn test_parse_ty() {
         parse_ty("u16"),
         Some((16, Endianness::Big, EndiannessSpecified::No))
     );
-    assert_eq!(parse_ty("uable"), None);
+    assert_eq!(parse_ty("uabc"), None);
     assert_eq!(parse_ty("u21re"), None);
     assert_eq!(parse_ty("i21be"), None);
 }

--- a/pnet_macros/tests/compile-fail/length_expr.stderr
+++ b/pnet_macros/tests/compile-fail/length_expr.stderr
@@ -1,5 +1,5 @@
 error: Only field names, constants, integers, basic arithmetic expressions (+ - * / %) and parentheses are allowed in the "length" attribute
-  --> $DIR/length_expr.rs:16:16
+  --> tests/compile-fail/length_expr.rs:16:16
    |
-16 |     #[length = "banana + 7.5"] //~ ERROR Only field names, constants, integers, basic arithmetic expressions (+ - * / %) and parentheses ...
+16 |     #[length = "banana + 7.5"] //~ ERROR Only field names, constants, integers, basic arithmetic expressions (+ - * / %) and parenth...
    |                ^^^^^^^^^^^^^^

--- a/pnet_macros/tests/compile-fail/payload_fn2.rs
+++ b/pnet_macros/tests/compile-fail/payload_fn2.rs
@@ -17,7 +17,7 @@ pub struct PacketWithPayload2 {
     payload: Vec<u8>,
 }
 
-fn length_of_payload(_: &PacketWithPayload2Packet) -> usize { //~ ERROR cannot find type `PacketWithPayload2Packet` in this scope
+fn length_of_payload(_: &PacketWithPayload2) -> usize {
     // FIXME
     unimplemented!()
 }

--- a/pnet_macros/tests/compile-fail/payload_fn2.stderr
+++ b/pnet_macros/tests/compile-fail/payload_fn2.stderr
@@ -1,14 +1,5 @@
 error: unknown attribute: payload
-  --> $DIR/payload_fn2.rs:16:7
+  --> tests/compile-fail/payload_fn2.rs:16:7
    |
 16 |     #[payload(length_fn = "length_of_payload")] //~ ERROR: unknown attribute: payload
    |       ^^^^^^^
-
-error[E0412]: cannot find type `PacketWithPayload2Packet` in this scope
-  --> $DIR/payload_fn2.rs:20:26
-   |
-14 | pub struct PacketWithPayload2 {
-   | ----------------------------- similarly named struct `PacketWithPayload2` defined here
-...
-20 | fn length_of_payload(_: &PacketWithPayload2Packet) -> usize { //~ ERROR cannot find type `PacketWithPayload2Packet` in this scope
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `PacketWithPayload2`

--- a/pnet_macros/tests/run-pass/packet_in_packet.rs
+++ b/pnet_macros/tests/run-pass/packet_in_packet.rs
@@ -44,4 +44,17 @@ fn main() {
     let packet_option = packet.get_packet_option();
     assert_eq!(packet_option.first().unwrap().pineapple, 6);
     assert_eq!(packet_option.first().unwrap().length, 3);
+
+    let packet_with_payload = PacketWithPayload {
+        banana: 1,
+        length: 0,
+        header_length: 5,
+        packet_option: vec![PacketOption {
+            pineapple: 6,
+            length: 3,
+            payload: vec![1],
+        }],
+        payload: vec![9, 10],
+    };
+    assert_eq!(PacketWithPayloadPacket::packet_size(&packet_with_payload), 8);
 }

--- a/pnet_packet/src/ipv6.rs
+++ b/pnet_packet/src/ipv6.rs
@@ -37,7 +37,7 @@ pub struct Ipv6 {
 }
 
 impl<'p> ExtensionIterable<'p> {
-    pub fn new(buf: &[u8]) -> ExtensionIterable {
+    pub fn new(buf: &[u8]) -> ExtensionIterable<'_> {
         ExtensionIterable { buf: buf }
     }
 }

--- a/pnet_transport/src/lib.rs
+++ b/pnet_transport/src/lib.rs
@@ -331,7 +331,7 @@ macro_rules! transport_channel_iterator {
         #[doc = "Return a packet iterator with packets of type `"]
         #[doc = $tyname]
         #[doc = "` for some transport receiver."]
-        pub fn $func(tr: &mut TransportReceiver) -> $iter {
+        pub fn $func(tr: &mut TransportReceiver) -> $iter<'_> {
             $iter { tr: tr }
         }
 
@@ -339,7 +339,7 @@ macro_rules! transport_channel_iterator {
             #[doc = "Get the next (`"]
             #[doc = $tyname ]
             #[doc = "`, `IpAddr`) pair for the given channel."]
-            pub fn next(&mut self) -> io::Result<($ty, IpAddr)> {
+            pub fn next(&mut self) -> io::Result<($ty<'_>, IpAddr)> {
                 let mut caddr: pnet_sys::SockAddrStorage = unsafe { mem::zeroed() };
                 let res =
                     pnet_sys::recv_from(self.tr.socket.fd, &mut self.tr.buffer[..], &mut caddr);
@@ -410,7 +410,7 @@ macro_rules! transport_channel_iterator {
             /// Wait only for a timespan of `t` to receive some data, then return. If no data was
             /// received, then `Ok(None)` is returned.
             #[cfg(unix)]
-            pub fn next_with_timeout(&mut self, t: Duration) -> io::Result<Option<($ty, IpAddr)>> {
+            pub fn next_with_timeout(&mut self, t: Duration) -> io::Result<Option<($ty<'_>, IpAddr)>> {
                 let socket_fd = self.tr.socket.fd;
 
                 let old_timeout = match pnet_sys::get_socket_receive_timeout(socket_fd) {


### PR DESCRIPTION
Fixes #726.

Root cause:
For `Vec<T>` fields without `#[construct_with]`, macro-generated struct `packet_size()` used `_packet.<field>.len()`, which counts elements instead of encoded bytes. This undercounted `Vec<#[packet]>` fields (for example TCP/IPv4/NDP options).

Core fix:
- In `pnet_macros/src/decorator.rs`, when the inner vec type is `Type::Misc(...)`, generate:
  `_packet.<field>.iter().map(|x| <Inner>Packet::packet_size(x)).sum::<usize>()`.
- Added regression assertion in `pnet_macros/tests/run-pass/packet_in_packet.rs` (`6 -> 8`).

CI/stable compatibility included in this PR:
- Refreshed `trybuild` snapshots in:
  - `pnet_macros/tests/compile-fail/length_expr.stderr`
  - `pnet_macros/tests/compile-fail/payload_fn2.rs`
  - `pnet_macros/tests/compile-fail/payload_fn2.stderr`
- Added explicit elided lifetimes required under `#![deny(warnings)]` on current stable in:
  - `pnet_packet/src/ipv6.rs`
  - `pnet_transport/src/lib.rs`

Validation:
- `cargo test --manifest-path pnet_macros/Cargo.toml --no-default-features --features travis --test tests compile_test`
- `cargo test --manifest-path pnet_packet/Cargo.toml`
- CI green on Linux/macOS/Windows.

Note:
`Vec<other_mod::Type>` remains a pre-existing macro limitation in this codegen path and is not introduced by this change.
